### PR TITLE
feat(direnv): remove nix support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,11 +1,3 @@
 export CLOUDFLARE_ACCOUNT_ID="0aeb879de8e3cdde5fb3d413025222ce"
 export TERRAFORM_BACKEND_URL="https://terraform-state-backend.rawkode-academy.workers.dev"
 export TERRAFORM_BACKEND_BUCKET_NAME="rawkode-cloud-tfstate"
-
-if has nix &>/dev/null; then
-  if nix flake show &>/dev/null; then
-    watch_file flake.nix
-    use flake
-  fi
-fi
-


### PR DESCRIPTION
We are no longer supporting Nix and will be relying on Dagger to provide all commands, scripts, and CI/CD.