### PR TITLE
Handle paragraph text in dark mode on about page

### DIFF
--- a/projects/rawkode-academy/web/src/components/partner/logos.astro
+++ b/projects/rawkode-academy/web/src/components/partner/logos.astro
@@ -65,7 +65,7 @@ const partners: Partners = [
 				<a
 					href="/organizations/lets-chat"
 					title=""
-					class="inline-flex items-center text-base font-medium text-primary-600 hover:underline dark:text-primary-500"
+					class="inline-flex items-center text-base font-medium text-primary-600 hover:underline dark:text-white"
 				>
 					Become a Partner
 					<svg

--- a/projects/rawkode-academy/web/src/pages/about/index.astro
+++ b/projects/rawkode-academy/web/src/pages/about/index.astro
@@ -5,7 +5,7 @@ import Page from "../../wrappers/page.astro";
 <Page title="About">
 	<h1>About the Rawkode Academy</h1>
 
-	<p class="mb-4 font-semibold">
+	<p class="mb-4 font-semibold dark:text-white">
 		The Rawkode Academy was founded in 2019 by David Flanagan, née McKay; a
 		developer and operator with over 20 years experience in the industry.
 	</p>
@@ -55,7 +55,7 @@ import Page from "../../wrappers/page.astro";
 	<h2>The History Lesson</h2>
 
 	<h3>The Early Years</h3>
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		Starting his career, back in 2003, David joined a small local development
 		company that specialised in ticketing systems for horse racing tracks across
 		the UK. His favourite thing about working at a smaller shop was the ability
@@ -65,14 +65,14 @@ import Page from "../../wrappers/page.astro";
 		development today; have you ever tried a Windows CE 4 device? 😅
 	</p>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		Given that this was a small team, David was also responsible for the
 		infrastructure that ran the company's products; primarily due to his
 		extensive Linux knowledge having ran Linux on the desktop since his first
 		Coral Linux install in 2000. Is it they year of the Linux desktop yet? 🤔
 	</p>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		Working with all these technologies from early on in his career, David
 		become a bit of a technology magpie; continually exploring and experimenting
 		with new technologies to better understand the problems they solved and the
@@ -85,7 +85,7 @@ import Page from "../../wrappers/page.astro";
 
 	<h3>First Real Scaling Challenge</h3>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		David was an early adopter of cloud, containers, and cloud-native
 		technologies. During his time as the Director of Development for a rock and
 		metal media organization called TeamRock (now LouderSound), David was
@@ -99,7 +99,7 @@ import Page from "../../wrappers/page.astro";
 
 	<h3>The Educator</h3>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		As much as David enjoys writing software, scaling infrastructure, and
 		leading teams; he quickly realised that his passion was helping others learn
 		and be successful. David started presenting at local user groups in 2016,
@@ -107,7 +107,7 @@ import Page from "../../wrappers/page.astro";
 		Developer Advocacy position at InfluxData
 	</p>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		During his time at Influx, David was a driving force to help make it easier
 		for people operating Kubernetes adopt InfluxDB and Telegraf as their stack
 		of choice for metric collection and storage. This didn't just involve being
@@ -142,7 +142,7 @@ import Page from "../../wrappers/page.astro";
 		</div>
 	</div>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		It was during this time that the Rawkode Academy released it's first video
 		... "Last Week in Kubernetes".
 	</p>
@@ -157,7 +157,7 @@ import Page from "../../wrappers/page.astro";
 			allowfullscreen></iframe>
 	</div>
 
-	<p class="mb-4">Let's not forget the first live-stream too ... 😅</p>
+	<p class="mb-4 dark:text-white">Let's not forget the first live-stream too ... 😅</p>
 	<div class="mb-4 flex justify-center">
 		<iframe
 			width="560"
@@ -195,7 +195,7 @@ import Page from "../../wrappers/page.astro";
 		</div>
 	</div>
 
-	<p class="mb-4 font-medium">
+	<p class="mb-4 font-medium dark:text-white">
 		After moving on from InfluxData, David joined Equinix Metal where he
 		continued to work-on and grow the Rawkode Academy by helping developers and
 		operators learn how to run and use Kubernetes, and other Cloud Native
@@ -203,7 +203,7 @@ import Page from "../../wrappers/page.astro";
 		that are not present when running on a cloud provider.
 	</p>
 
-	<p class="mb-4 font-medium">
+	<p class="mb-4 font-medium dark:text-white">
 		Throughout his time working with Kubernetes, David was a fan and keen
 		watcher of TGIK, a weekly live stream hosted by Joe Beda, one of the
 		creators of Kubernetes. On TGIK, Joe live streamed himself exploring new
@@ -244,7 +244,7 @@ import Page from "../../wrappers/page.astro";
 		</div>
 	</div>
 
-	<p class="mb-4 font-medium">
+	<p class="mb-4 font-medium dark:text-white">
 		Fast-forward to 2021, and David had the worst idea of his career; but
 		through hubris and in the name of edutainment, David hosted the first
 		episode of Klustered, along with his guest, Walid Shaari.

--- a/projects/rawkode-academy/web/src/pages/organizations/lets-chat.astro
+++ b/projects/rawkode-academy/web/src/pages/organizations/lets-chat.astro
@@ -18,7 +18,7 @@ import Page from "../../wrappers/page.astro";
 <Page title="Let's Chat">
 	<h1>Let's Chat</h1>
 
-	<p class="mb-4">
+	<p class="mb-4 dark:text-white">
 		Whether you want to discuss sponsorships, collaborations, content, consulting, training, Kubernetes, or anything in-between; let's find some time and work it out together.
 	</p>
 

--- a/projects/rawkode-academy/web/src/pages/organizations/lets-chat.astro
+++ b/projects/rawkode-academy/web/src/pages/organizations/lets-chat.astro
@@ -18,7 +18,7 @@ import Page from "../../wrappers/page.astro";
 <Page title="Let's Chat">
 	<h1>Let's Chat</h1>
 
-	<p class="mb-4 dark:text-white">
+	<p class="mb-4 dark:text-gray-400">
 		Whether you want to discuss sponsorships, collaborations, content, consulting, training, Kubernetes, or anything in-between; let's find some time and work it out together.
 	</p>
 


### PR DESCRIPTION
Currently on the about page, when looking at it in dark mode, the text is black and hard to see. This change makes the text white when the web page is displaying in dark mode.