### PR TITLE
chore(web): make local development easier

### DIFF
--- a/projects/rawkode-academy/web/.dev.vars.tpl
+++ b/projects/rawkode-academy/web/.dev.vars.tpl
@@ -1,5 +1,0 @@
-REDIRECT_URL="http://localhost:4321/auth/callback"
-
-WORKOS_CLIENT_ID="{{ op://sa.rawkode.academy/workos-staging/username }}"
-WORKOS_API_KEY="{{ op://sa.rawkode.academy/workos-staging/password }}"
-WORKOS_COOKIE_PASSWORD="{{ op://sa.rawkode.academy/workos-staging/cookiePassword }}"

--- a/projects/rawkode-academy/web/.envrc
+++ b/projects/rawkode-academy/web/.envrc
@@ -1,1 +1,6 @@
+export ASTRO_ADAPTER="local"
 export CLOUDFLARE_API_TOKEN="op://sa.rawkode.academy/cloudflare/password"
+export REDIRECT_URL="http://localhost:4321/auth/callback"
+export WORKOS_CLIENT_ID="op://sa.rawkode.academy/workos-staging/username"
+export WORKOS_API_KEY="op://sa.rawkode.academy/workos-staging/password"
+export WORKOS_COOKIE_PASSWORD="op://sa.rawkode.academy/workos-staging/cookiePassword"

--- a/projects/rawkode-academy/web/astro.config.mjs
+++ b/projects/rawkode-academy/web/astro.config.mjs
@@ -3,10 +3,9 @@ import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import tailwind from "@astrojs/tailwind";
 import vue from "@astrojs/vue";
-import rehypeExternalLinks from 'rehype-external-links';
+import { defineConfig, envField } from "astro/config";
+import rehypeExternalLinks from "rehype-external-links";
 
-import { defineConfig } from "astro/config";
-// https://astro.build/config
 export default defineConfig({
 	output: "hybrid",
 	integrations: [tailwind(), vue(), react(), mdx()],
@@ -15,15 +14,41 @@ export default defineConfig({
 	}),
 	experimental: {
 		serverIslands: true,
+		env: {
+			validateSecrets: true,
+			schema: {
+				REDIRECT_URL: envField.string({
+					context: "client",
+					access: "public",
+					optional: true,
+					default: "http://localhost:4321/auth/callback",
+				}),
+				WORKOS_CLIENT_ID: envField.string({
+					context: "server",
+					access: "secret",
+					optional: false,
+				}),
+				WORKOS_API_KEY: envField.string({
+					context: "server",
+					access: "secret",
+					optional: false,
+				}),
+				WORKOS_COOKIE_PASSWORD: envField.string({
+					context: "server",
+					access: "secret",
+					optional: false,
+				}),
+			},
+		},
 	},
 	markdown: {
 		rehypePlugins: [
 			[
 				rehypeExternalLinks,
 				{
-					"target": '_blank'
-				}
-			]
-		]
-	}
+					target: "_blank",
+				},
+			],
+		],
+	},
 });

--- a/projects/rawkode-academy/web/package.json
+++ b/projects/rawkode-academy/web/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "0.8.1",
     "@astrojs/cloudflare": "11.0.1",
     "@astrojs/mdx": "3.1.2",
+		"@astrojs/node": "^8.3.2",
     "@astrojs/react": "3.6.0",
     "@astrojs/tailwind": "5.1.0",
     "@astrojs/vue": "4.5.0",

--- a/projects/rawkode-academy/web/src/env.d.ts
+++ b/projects/rawkode-academy/web/src/env.d.ts
@@ -1,13 +1,15 @@
+/// <reference path="../.astro/env.d.ts" />
 /// <reference types="astro/client" />
 /// <reference path="../.astro/types.d.ts" />
 import type { User } from "@workos-inc/node";
-
-type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 
 declare global {
 	namespace App {
 		interface Locals extends Runtime {
 			user: User;
+			WORKOS_CLIENT_ID: string;
+			WORKOS_API_KEY: string;
+			WORKOS_COOKIE_PASSWORD: string;
 		}
 	}
 }

--- a/projects/rawkode-academy/web/src/pages/auth/callback.ts
+++ b/projects/rawkode-academy/web/src/pages/auth/callback.ts
@@ -1,17 +1,16 @@
 import { WorkOS } from '@workos-inc/node';
 import type { APIRoute } from 'astro';
+import { getSecret } from "astro:env/server";
 import { sealData } from 'iron-session';
 
 export const prerender = false;
 
 export const GET: APIRoute = async ({
-	locals,
   request,
   redirect,
   cookies,
 }) => {
-	const env = locals.runtime.env;
-	const workos = new WorkOS(env.WORKOS_API_KEY)
+	const workos = new WorkOS(getSecret("WORKOS_API_KEY"));
 
   const code = String(
     new URL(request.url).searchParams.get('code')
@@ -19,11 +18,11 @@ export const GET: APIRoute = async ({
   const session =
     await workos.userManagement.authenticateWithCode({
       code,
-      clientId: env.WORKOS_CLIENT_ID,
+			clientId: getSecret("WORKOS_CLIENT_ID") || "",
     })
 
   const encryptedSession = await sealData(session, {
-    password: env.WORKOS_COOKIE_PASSWORD,
+    password: getSecret("WORKOS_COOKIE_PASSWORD") || "",
   })
 
   cookies.set('wos-session', encryptedSession, {

--- a/projects/rawkode-academy/web/src/pages/auth/login.ts
+++ b/projects/rawkode-academy/web/src/pages/auth/login.ts
@@ -1,17 +1,17 @@
 import { WorkOS } from "@workos-inc/node";
 import type { APIRoute } from 'astro';
+import { REDIRECT_URL } from "astro:env/client";
+import { getSecret } from "astro:env/server";
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ locals, redirect }) => {
-	const env = locals.runtime.env;
-
-	const workos = new WorkOS(env.WORKOS_API_KEY);
-	const clientId = env.WORKOS_CLIENT_ID || "";
+export const GET: APIRoute = async ({ redirect }) => {
+	const workos = new WorkOS(getSecret("WORKOS_API_KEY"));
+	const clientId = getSecret("WORKOS_CLIENT_ID") || "";
 
 	const authorizationUrl = workos.userManagement.getAuthorizationUrl({
 		provider: 'authkit',
-		redirectUri: locals.runtime.env.REDIRECT_URL,
+		redirectUri: REDIRECT_URL,
 		clientId,
 	});
 


### PR DESCRIPTION
Cloudflare consumes environment variables differently from everything else; Astro's new env (experimental) feature provides a common API; that also means we don't need to use wrangler's terrible .dev.vars format