### PR TITLE
add viewbox to centre the svg logo

### DIFF
--- a/projects/rawkode-academy/web/src/components/partner/logos/ngrok.svg
+++ b/projects/rawkode-academy/web/src/components/partner/logos/ngrok.svg
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="Layer_1"
+    viewBox="0 0 195 90"
+    height="90"
+    width="195"
 	xmlns="http://www.w3.org/2000/svg"
 	xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
 	<g>


### PR DESCRIPTION
not perfect, since the other logos stretch to the entire parent element, but at least it's not on the far left side anymore.