### PR TITLE
add a very basic robots.txt

### DIFF
--- a/projects/rawkode-academy/web/public/robots.txt
+++ b/projects/rawkode-academy/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
Currently, when hitting https://rawkode.academy/robots.txt, it renders the index document instead of a 404 page, so crawlers are probably getting confused since that's not a format they're expecting.

In theory, the AI crawlers don't respect these anyway, but we might as well make it easier for the indexers.