### PR TITLE
add an aria-label to the link in the navbar

### DIFF
--- a/projects/rawkode-academy/web/src/layouts/app.astro
+++ b/projects/rawkode-academy/web/src/layouts/app.astro
@@ -98,7 +98,7 @@ const menuItemsOrgs = [
 					</svg>
 					<span class="sr-only">Toggle sidebar</span>
 				</button>
-				<a href="/" class="flex mr-4 w-32">
+				<a href="/" aria-label="return to the home page" class="flex mr-4 w-32">
 					<svg
 						class="fill-black dark:fill-white h-8"
 						id="Layer_1"


### PR DESCRIPTION
currently, the link back to `/` doesn't have a name that a screenreader can pick up, so this commit adds in a label for a11y.