### PR TITLE
chore(people): switch to graphql-yoga

### DIFF
--- a/projects/rawkode.academy/people-service/deno.jsonc
+++ b/projects/rawkode.academy/people-service/deno.jsonc
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "@apollo/server": "npm:@apollo/server@^4.11.0",
     "@libsql/client": "npm:@libsql/client@^0.14.0",
     "@restatedev/restate-sdk": "npm:@restatedev/restate-sdk@0.0.0-SNAPSHOT-20240926122157",
     "@std/assert": "jsr:@std/assert@1",
@@ -8,6 +7,7 @@
     "drizzle-orm": "npm:drizzle-orm@^0.33.0",
     "drizzle-zod": "npm:drizzle-zod@^0.5.1",
     "graphql": "npm:graphql@^16.9.0",
+    "graphql-yoga": "npm:graphql-yoga@^5.7.0",
     "zod": "npm:zod@^3.23.8"
   },
   "compilerOptions": {

--- a/projects/rawkode.academy/people-service/deno.lock
+++ b/projects/rawkode.academy/people-service/deno.lock
@@ -4,13 +4,13 @@
     "specifiers": {
       "jsr:@std/assert@1": "jsr:@std/assert@1.0.6",
       "jsr:@std/internal@^1.0.4": "jsr:@std/internal@1.0.4",
-      "npm:@apollo/server@^4.11.0": "npm:@apollo/server@4.11.0_graphql@16.9.0",
       "npm:@libsql/client@^0.14.0": "npm:@libsql/client@0.14.0",
       "npm:@restatedev/restate-sdk@0.0.0-SNAPSHOT-20240926122157": "npm:@restatedev/restate-sdk@0.0.0-SNAPSHOT-20240926122157",
-      "npm:@sindresorhus/slugify@^2.2.1": "npm:@sindresorhus/slugify@2.2.1",
+      "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:drizzle-graphql@^0.8.5": "npm:drizzle-graphql@0.8.5_drizzle-orm@0.33.0__@libsql+client@0.14.0_graphql@16.9.0_@libsql+client@0.14.0",
       "npm:drizzle-orm@^0.33.0": "npm:drizzle-orm@0.33.0_@libsql+client@0.14.0",
       "npm:drizzle-zod@^0.5.1": "npm:drizzle-zod@0.5.1_drizzle-orm@0.33.0__@libsql+client@0.14.0_zod@3.23.8_@libsql+client@0.14.0",
+      "npm:graphql-yoga@^5.7.0": "npm:graphql-yoga@5.7.0_graphql@16.9.0",
       "npm:graphql@^16.9.0": "npm:graphql@16.9.0",
       "npm:zod@^3.23.8": "npm:zod@3.23.8"
     },
@@ -26,174 +26,58 @@
       }
     },
     "npm": {
-      "@apollo/cache-control-types@1.0.3_graphql@16.9.0": {
-        "integrity": "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/protobufjs@1.2.7": {
-        "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
-        "dependencies": {
-          "@protobufjs/aspromise": "@protobufjs/aspromise@1.1.2",
-          "@protobufjs/base64": "@protobufjs/base64@1.1.2",
-          "@protobufjs/codegen": "@protobufjs/codegen@2.0.4",
-          "@protobufjs/eventemitter": "@protobufjs/eventemitter@1.1.0",
-          "@protobufjs/fetch": "@protobufjs/fetch@1.1.0",
-          "@protobufjs/float": "@protobufjs/float@1.0.2",
-          "@protobufjs/inquire": "@protobufjs/inquire@1.1.0",
-          "@protobufjs/path": "@protobufjs/path@1.1.2",
-          "@protobufjs/pool": "@protobufjs/pool@1.1.0",
-          "@protobufjs/utf8": "@protobufjs/utf8@1.1.0",
-          "@types/long": "@types/long@4.0.2",
-          "long": "long@4.0.0"
-        }
-      },
-      "@apollo/server-gateway-interface@1.1.1_graphql@16.9.0": {
-        "integrity": "sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==",
-        "dependencies": {
-          "@apollo/usage-reporting-protobuf": "@apollo/usage-reporting-protobuf@4.1.1",
-          "@apollo/utils.fetcher": "@apollo/utils.fetcher@2.0.1",
-          "@apollo/utils.keyvaluecache": "@apollo/utils.keyvaluecache@2.1.1",
-          "@apollo/utils.logger": "@apollo/utils.logger@2.0.1",
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/server@4.11.0_graphql@16.9.0": {
-        "integrity": "sha512-SWDvbbs0wl2zYhKG6aGLxwTJ72xpqp0awb2lotNpfezd9VcAvzaUizzKQqocephin2uMoaA8MguoyBmgtPzNWw==",
-        "dependencies": {
-          "@apollo/cache-control-types": "@apollo/cache-control-types@1.0.3_graphql@16.9.0",
-          "@apollo/server-gateway-interface": "@apollo/server-gateway-interface@1.1.1_graphql@16.9.0",
-          "@apollo/usage-reporting-protobuf": "@apollo/usage-reporting-protobuf@4.1.1",
-          "@apollo/utils.createhash": "@apollo/utils.createhash@2.0.1",
-          "@apollo/utils.fetcher": "@apollo/utils.fetcher@2.0.1",
-          "@apollo/utils.isnodelike": "@apollo/utils.isnodelike@2.0.1",
-          "@apollo/utils.keyvaluecache": "@apollo/utils.keyvaluecache@2.1.1",
-          "@apollo/utils.logger": "@apollo/utils.logger@2.0.1",
-          "@apollo/utils.usagereporting": "@apollo/utils.usagereporting@2.1.0_graphql@16.9.0",
-          "@apollo/utils.withrequired": "@apollo/utils.withrequired@2.0.1",
-          "@graphql-tools/schema": "@graphql-tools/schema@9.0.19_graphql@16.9.0",
-          "@types/express": "@types/express@4.17.21",
-          "@types/express-serve-static-core": "@types/express-serve-static-core@4.19.6",
-          "@types/node-fetch": "@types/node-fetch@2.6.11",
-          "async-retry": "async-retry@1.3.3",
-          "cors": "cors@2.8.5",
-          "express": "express@4.21.0",
-          "graphql": "graphql@16.9.0",
-          "loglevel": "loglevel@1.9.2",
-          "lru-cache": "lru-cache@7.18.3",
-          "negotiator": "negotiator@0.6.3",
-          "node-abort-controller": "node-abort-controller@3.1.1",
-          "node-fetch": "node-fetch@2.7.0",
-          "uuid": "uuid@9.0.1",
-          "whatwg-mimetype": "whatwg-mimetype@3.0.0"
-        }
-      },
-      "@apollo/usage-reporting-protobuf@4.1.1": {
-        "integrity": "sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==",
-        "dependencies": {
-          "@apollo/protobufjs": "@apollo/protobufjs@1.2.7"
-        }
-      },
-      "@apollo/utils.createhash@2.0.1": {
-        "integrity": "sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==",
-        "dependencies": {
-          "@apollo/utils.isnodelike": "@apollo/utils.isnodelike@2.0.1",
-          "sha.js": "sha.js@2.4.11"
-        }
-      },
-      "@apollo/utils.dropunuseddefinitions@2.0.1_graphql@16.9.0": {
-        "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/utils.fetcher@2.0.1": {
-        "integrity": "sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==",
-        "dependencies": {}
-      },
-      "@apollo/utils.isnodelike@2.0.1": {
-        "integrity": "sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==",
-        "dependencies": {}
-      },
-      "@apollo/utils.keyvaluecache@2.1.1": {
-        "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
-        "dependencies": {
-          "@apollo/utils.logger": "@apollo/utils.logger@2.0.1",
-          "lru-cache": "lru-cache@7.18.3"
-        }
-      },
-      "@apollo/utils.logger@2.0.1": {
-        "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-        "dependencies": {}
-      },
-      "@apollo/utils.printwithreducedwhitespace@2.0.1_graphql@16.9.0": {
-        "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/utils.removealiases@2.0.1_graphql@16.9.0": {
-        "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/utils.sortast@2.0.1_graphql@16.9.0": {
-        "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0",
-          "lodash.sortby": "lodash.sortby@4.7.0"
-        }
-      },
-      "@apollo/utils.stripsensitiveliterals@2.0.1_graphql@16.9.0": {
-        "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
-        "dependencies": {
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/utils.usagereporting@2.1.0_graphql@16.9.0": {
-        "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
-        "dependencies": {
-          "@apollo/usage-reporting-protobuf": "@apollo/usage-reporting-protobuf@4.1.1",
-          "@apollo/utils.dropunuseddefinitions": "@apollo/utils.dropunuseddefinitions@2.0.1_graphql@16.9.0",
-          "@apollo/utils.printwithreducedwhitespace": "@apollo/utils.printwithreducedwhitespace@2.0.1_graphql@16.9.0",
-          "@apollo/utils.removealiases": "@apollo/utils.removealiases@2.0.1_graphql@16.9.0",
-          "@apollo/utils.sortast": "@apollo/utils.sortast@2.0.1_graphql@16.9.0",
-          "@apollo/utils.stripsensitiveliterals": "@apollo/utils.stripsensitiveliterals@2.0.1_graphql@16.9.0",
-          "graphql": "graphql@16.9.0"
-        }
-      },
-      "@apollo/utils.withrequired@2.0.1": {
-        "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
-        "dependencies": {}
-      },
       "@bufbuild/protobuf@1.10.0": {
         "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
         "dependencies": {}
       },
-      "@graphql-tools/merge@8.4.2_graphql@16.9.0": {
-        "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "@envelop/core@5.0.2": {
+        "integrity": "sha512-tVL6OrMe6UjqLosiE+EH9uxh2TQC0469GwF4tE014ugRaDDKKVWwFwZe0TBMlcyHKh5MD4ZxktWo/1hqUxIuhw==",
         "dependencies": {
-          "@graphql-tools/utils": "@graphql-tools/utils@9.2.1_graphql@16.9.0",
-          "graphql": "graphql@16.9.0",
+          "@envelop/types": "@envelop/types@5.0.0",
           "tslib": "tslib@2.7.0"
         }
       },
-      "@graphql-tools/schema@9.0.19_graphql@16.9.0": {
-        "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "@envelop/types@5.0.0": {
+        "integrity": "sha512-IPjmgSc4KpQRlO4qbEDnBEixvtb06WDmjKfi/7fkZaryh5HuOmTtixe1EupQI5XfXO8joc3d27uUZ0QdC++euA==",
         "dependencies": {
-          "@graphql-tools/merge": "@graphql-tools/merge@8.4.2_graphql@16.9.0",
-          "@graphql-tools/utils": "@graphql-tools/utils@9.2.1_graphql@16.9.0",
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "@graphql-tools/executor@1.3.1_graphql@16.9.0": {
+        "integrity": "sha512-tgJDdGf9SCAm64ofEMZdv925u6/J+eTmv36TGNLxgP2DpCJsZ6gnJ4A+0D28EazDXqJIvMiPd+3d+o3cCRCAnQ==",
+        "dependencies": {
+          "@graphql-tools/utils": "@graphql-tools/utils@10.5.4_graphql@16.9.0",
+          "@graphql-typed-document-node/core": "@graphql-typed-document-node/core@3.2.0_graphql@16.9.0",
+          "@repeaterjs/repeater": "@repeaterjs/repeater@3.0.6",
           "graphql": "graphql@16.9.0",
           "tslib": "tslib@2.7.0",
           "value-or-promise": "value-or-promise@1.0.12"
         }
       },
-      "@graphql-tools/utils@9.2.1_graphql@16.9.0": {
-        "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "@graphql-tools/merge@9.0.7_graphql@16.9.0": {
+        "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
+        "dependencies": {
+          "@graphql-tools/utils": "@graphql-tools/utils@10.5.4_graphql@16.9.0",
+          "graphql": "graphql@16.9.0",
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "@graphql-tools/schema@10.0.6_graphql@16.9.0": {
+        "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+        "dependencies": {
+          "@graphql-tools/merge": "@graphql-tools/merge@9.0.7_graphql@16.9.0",
+          "@graphql-tools/utils": "@graphql-tools/utils@10.5.4_graphql@16.9.0",
+          "graphql": "graphql@16.9.0",
+          "tslib": "tslib@2.7.0",
+          "value-or-promise": "value-or-promise@1.0.12"
+        }
+      },
+      "@graphql-tools/utils@10.5.4_graphql@16.9.0": {
+        "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
         "dependencies": {
           "@graphql-typed-document-node/core": "@graphql-typed-document-node/core@3.2.0_graphql@16.9.0",
+          "cross-inspect": "cross-inspect@1.0.1",
+          "dset": "dset@3.1.4",
           "graphql": "graphql@16.9.0",
           "tslib": "tslib@2.7.0"
         }
@@ -203,6 +87,32 @@
         "dependencies": {
           "graphql": "graphql@16.9.0"
         }
+      },
+      "@graphql-yoga/logger@2.0.0": {
+        "integrity": "sha512-Mg8psdkAp+YTG1OGmvU+xa6xpsAmSir0hhr3yFYPyLNwzUj95DdIwsMpKadDj9xDpYgJcH3Hp/4JMal9DhQimA==",
+        "dependencies": {
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "@graphql-yoga/subscription@5.0.1": {
+        "integrity": "sha512-1wCB1DfAnaLzS+IdoOzELGGnx1ODEg9nzQXFh4u2j02vAnne6d+v4A7HIH9EqzVdPLoAaMKXCZUUdKs+j3z1fg==",
+        "dependencies": {
+          "@graphql-yoga/typed-event-target": "@graphql-yoga/typed-event-target@3.0.0",
+          "@repeaterjs/repeater": "@repeaterjs/repeater@3.0.6",
+          "@whatwg-node/events": "@whatwg-node/events@0.1.2",
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "@graphql-yoga/typed-event-target@3.0.0": {
+        "integrity": "sha512-w+liuBySifrstuHbFrHoHAEyVnDFVib+073q8AeAJ/qqJfvFvAwUPLLtNohR/WDVRgSasfXtl3dcNuVJWN+rjg==",
+        "dependencies": {
+          "@repeaterjs/repeater": "@repeaterjs/repeater@3.0.6",
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "@kamilkisiela/fast-url-parser@1.1.4": {
+        "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+        "dependencies": {}
       },
       "@libsql/client@0.14.0": {
         "integrity": "sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==",
@@ -272,47 +182,8 @@
         "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
         "dependencies": {}
       },
-      "@protobufjs/aspromise@1.1.2": {
-        "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-        "dependencies": {}
-      },
-      "@protobufjs/base64@1.1.2": {
-        "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-        "dependencies": {}
-      },
-      "@protobufjs/codegen@2.0.4": {
-        "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-        "dependencies": {}
-      },
-      "@protobufjs/eventemitter@1.1.0": {
-        "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-        "dependencies": {}
-      },
-      "@protobufjs/fetch@1.1.0": {
-        "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-        "dependencies": {
-          "@protobufjs/aspromise": "@protobufjs/aspromise@1.1.2",
-          "@protobufjs/inquire": "@protobufjs/inquire@1.1.0"
-        }
-      },
-      "@protobufjs/float@1.0.2": {
-        "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-        "dependencies": {}
-      },
-      "@protobufjs/inquire@1.1.0": {
-        "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-        "dependencies": {}
-      },
-      "@protobufjs/path@1.1.2": {
-        "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-        "dependencies": {}
-      },
-      "@protobufjs/pool@1.1.0": {
-        "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-        "dependencies": {}
-      },
-      "@protobufjs/utf8@1.1.0": {
-        "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "@repeaterjs/repeater@3.0.6": {
+        "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
         "dependencies": {}
       },
       "@restatedev/restate-sdk-core@0.0.0-SNAPSHOT-20240926122157": {
@@ -326,95 +197,9 @@
           "@restatedev/restate-sdk-core": "@restatedev/restate-sdk-core@0.0.0-SNAPSHOT-20240926122157"
         }
       },
-      "@sindresorhus/slugify@2.2.1": {
-        "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
-        "dependencies": {
-          "@sindresorhus/transliterate": "@sindresorhus/transliterate@1.6.0",
-          "escape-string-regexp": "escape-string-regexp@5.0.0"
-        }
-      },
-      "@sindresorhus/transliterate@1.6.0": {
-        "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
-        "dependencies": {
-          "escape-string-regexp": "escape-string-regexp@5.0.0"
-        }
-      },
-      "@types/body-parser@1.19.5": {
-        "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-        "dependencies": {
-          "@types/connect": "@types/connect@3.4.38",
-          "@types/node": "@types/node@18.16.19"
-        }
-      },
-      "@types/connect@3.4.38": {
-        "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-        "dependencies": {
-          "@types/node": "@types/node@18.16.19"
-        }
-      },
-      "@types/express-serve-static-core@4.19.6": {
-        "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-        "dependencies": {
-          "@types/node": "@types/node@18.16.19",
-          "@types/qs": "@types/qs@6.9.16",
-          "@types/range-parser": "@types/range-parser@1.2.7",
-          "@types/send": "@types/send@0.17.4"
-        }
-      },
-      "@types/express@4.17.21": {
-        "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-        "dependencies": {
-          "@types/body-parser": "@types/body-parser@1.19.5",
-          "@types/express-serve-static-core": "@types/express-serve-static-core@4.19.6",
-          "@types/qs": "@types/qs@6.9.16",
-          "@types/serve-static": "@types/serve-static@1.15.7"
-        }
-      },
-      "@types/http-errors@2.0.4": {
-        "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-        "dependencies": {}
-      },
-      "@types/long@4.0.2": {
-        "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-        "dependencies": {}
-      },
-      "@types/mime@1.3.5": {
-        "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-        "dependencies": {}
-      },
-      "@types/node-fetch@2.6.11": {
-        "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-        "dependencies": {
-          "@types/node": "@types/node@18.16.19",
-          "form-data": "form-data@4.0.0"
-        }
-      },
       "@types/node@18.16.19": {
         "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
         "dependencies": {}
-      },
-      "@types/qs@6.9.16": {
-        "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
-        "dependencies": {}
-      },
-      "@types/range-parser@1.2.7": {
-        "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-        "dependencies": {}
-      },
-      "@types/send@0.17.4": {
-        "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-        "dependencies": {
-          "@types/mime": "@types/mime@1.3.5",
-          "@types/node": "@types/node@18.16.19"
-        }
-      },
-      "@types/serve-static@1.15.7": {
-        "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-        "dependencies": {
-          "@types/http-errors": "@types/http-errors@2.0.4",
-          "@types/node": "@types/node@18.16.19",
-          "@types/send": "@types/send@0.17.4"
-        }
       },
       "@types/ws@8.5.12": {
         "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
@@ -422,124 +207,56 @@
           "@types/node": "@types/node@18.16.19"
         }
       },
-      "accepts@1.3.8": {
-        "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "@whatwg-node/events@0.1.2": {
+        "integrity": "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==",
         "dependencies": {
-          "mime-types": "mime-types@2.1.35",
-          "negotiator": "negotiator@0.6.3"
+          "tslib": "tslib@2.7.0"
         }
       },
-      "array-flatten@1.1.1": {
-        "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-        "dependencies": {}
-      },
-      "async-retry@1.3.3": {
-        "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "@whatwg-node/fetch@0.9.21": {
+        "integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
         "dependencies": {
-          "retry": "retry@0.13.1"
+          "@whatwg-node/node-fetch": "@whatwg-node/node-fetch@0.5.26",
+          "urlpattern-polyfill": "urlpattern-polyfill@10.0.0"
         }
       },
-      "asynckit@0.4.0": {
-        "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-        "dependencies": {}
-      },
-      "body-parser@1.20.3": {
-        "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "@whatwg-node/node-fetch@0.5.26": {
+        "integrity": "sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g==",
         "dependencies": {
-          "bytes": "bytes@3.1.2",
-          "content-type": "content-type@1.0.5",
-          "debug": "debug@2.6.9",
-          "depd": "depd@2.0.0",
-          "destroy": "destroy@1.2.0",
-          "http-errors": "http-errors@2.0.0",
-          "iconv-lite": "iconv-lite@0.4.24",
-          "on-finished": "on-finished@2.4.1",
-          "qs": "qs@6.13.0",
-          "raw-body": "raw-body@2.5.2",
-          "type-is": "type-is@1.6.18",
-          "unpipe": "unpipe@1.0.0"
+          "@kamilkisiela/fast-url-parser": "@kamilkisiela/fast-url-parser@1.1.4",
+          "busboy": "busboy@1.6.0",
+          "fast-querystring": "fast-querystring@1.1.2",
+          "tslib": "tslib@2.7.0"
         }
       },
-      "bytes@3.1.2": {
-        "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-        "dependencies": {}
-      },
-      "call-bind@1.0.7": {
-        "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "@whatwg-node/server@0.9.49": {
+        "integrity": "sha512-3KzLXw80gWnTsQ746G/LFdCThTPfDodjQs4PnmoNuPa6XUOl4HWq8TlJpxtmnEEB+y+UYLal+3VQ68dtYlbUDQ==",
         "dependencies": {
-          "es-define-property": "es-define-property@1.0.0",
-          "es-errors": "es-errors@1.3.0",
-          "function-bind": "function-bind@1.1.2",
-          "get-intrinsic": "get-intrinsic@1.2.4",
-          "set-function-length": "set-function-length@1.2.2"
+          "@whatwg-node/fetch": "@whatwg-node/fetch@0.9.21",
+          "tslib": "tslib@2.7.0"
         }
       },
-      "combined-stream@1.0.8": {
-        "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "busboy@1.6.0": {
+        "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
         "dependencies": {
-          "delayed-stream": "delayed-stream@1.0.0"
+          "streamsearch": "streamsearch@1.1.0"
         }
       },
-      "content-disposition@0.5.4": {
-        "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "cross-inspect@1.0.1": {
+        "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
         "dependencies": {
-          "safe-buffer": "safe-buffer@5.2.1"
-        }
-      },
-      "content-type@1.0.5": {
-        "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-        "dependencies": {}
-      },
-      "cookie-signature@1.0.6": {
-        "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-        "dependencies": {}
-      },
-      "cookie@0.6.0": {
-        "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-        "dependencies": {}
-      },
-      "cors@2.8.5": {
-        "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-        "dependencies": {
-          "object-assign": "object-assign@4.1.1",
-          "vary": "vary@1.1.2"
+          "tslib": "tslib@2.7.0"
         }
       },
       "data-uri-to-buffer@4.0.1": {
         "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
         "dependencies": {}
       },
-      "debug@2.6.9": {
-        "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-        "dependencies": {
-          "ms": "ms@2.0.0"
-        }
-      },
       "debug@4.3.7": {
         "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
         "dependencies": {
           "ms": "ms@2.1.3"
         }
-      },
-      "define-data-property@1.1.4": {
-        "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-        "dependencies": {
-          "es-define-property": "es-define-property@1.0.0",
-          "es-errors": "es-errors@1.3.0",
-          "gopd": "gopd@1.0.1"
-        }
-      },
-      "delayed-stream@1.0.0": {
-        "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-        "dependencies": {}
-      },
-      "depd@2.0.0": {
-        "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-        "dependencies": {}
-      },
-      "destroy@1.2.0": {
-        "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-        "dependencies": {}
       },
       "detect-libc@2.0.2": {
         "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
@@ -566,74 +283,18 @@
           "zod": "zod@3.23.8"
         }
       },
-      "ee-first@1.1.1": {
-        "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dset@3.1.4": {
+        "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
         "dependencies": {}
       },
-      "encodeurl@1.0.2": {
-        "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "fast-decode-uri-component@1.0.1": {
+        "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
         "dependencies": {}
       },
-      "encodeurl@2.0.0": {
-        "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-        "dependencies": {}
-      },
-      "es-define-property@1.0.0": {
-        "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "fast-querystring@1.1.2": {
+        "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
         "dependencies": {
-          "get-intrinsic": "get-intrinsic@1.2.4"
-        }
-      },
-      "es-errors@1.3.0": {
-        "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-        "dependencies": {}
-      },
-      "escape-html@1.0.3": {
-        "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-        "dependencies": {}
-      },
-      "escape-string-regexp@5.0.0": {
-        "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-        "dependencies": {}
-      },
-      "etag@1.8.1": {
-        "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-        "dependencies": {}
-      },
-      "express@4.21.0": {
-        "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
-        "dependencies": {
-          "accepts": "accepts@1.3.8",
-          "array-flatten": "array-flatten@1.1.1",
-          "body-parser": "body-parser@1.20.3",
-          "content-disposition": "content-disposition@0.5.4",
-          "content-type": "content-type@1.0.5",
-          "cookie": "cookie@0.6.0",
-          "cookie-signature": "cookie-signature@1.0.6",
-          "debug": "debug@2.6.9",
-          "depd": "depd@2.0.0",
-          "encodeurl": "encodeurl@2.0.0",
-          "escape-html": "escape-html@1.0.3",
-          "etag": "etag@1.8.1",
-          "finalhandler": "finalhandler@1.3.1",
-          "fresh": "fresh@0.5.2",
-          "http-errors": "http-errors@2.0.0",
-          "merge-descriptors": "merge-descriptors@1.0.3",
-          "methods": "methods@1.1.2",
-          "on-finished": "on-finished@2.4.1",
-          "parseurl": "parseurl@1.3.3",
-          "path-to-regexp": "path-to-regexp@0.1.10",
-          "proxy-addr": "proxy-addr@2.0.7",
-          "qs": "qs@6.13.0",
-          "range-parser": "range-parser@1.2.1",
-          "safe-buffer": "safe-buffer@5.2.1",
-          "send": "send@0.19.0",
-          "serve-static": "serve-static@1.16.2",
-          "setprototypeof": "setprototypeof@1.2.0",
-          "statuses": "statuses@2.0.1",
-          "type-is": "type-is@1.6.18",
-          "utils-merge": "utils-merge@1.0.1",
-          "vary": "vary@1.1.2"
+          "fast-decode-uri-component": "fast-decode-uri-component@1.0.1"
         }
       },
       "fetch-blob@3.2.0": {
@@ -643,58 +304,10 @@
           "web-streams-polyfill": "web-streams-polyfill@3.3.3"
         }
       },
-      "finalhandler@1.3.1": {
-        "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-        "dependencies": {
-          "debug": "debug@2.6.9",
-          "encodeurl": "encodeurl@2.0.0",
-          "escape-html": "escape-html@1.0.3",
-          "on-finished": "on-finished@2.4.1",
-          "parseurl": "parseurl@1.3.3",
-          "statuses": "statuses@2.0.1",
-          "unpipe": "unpipe@1.0.0"
-        }
-      },
-      "form-data@4.0.0": {
-        "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-        "dependencies": {
-          "asynckit": "asynckit@0.4.0",
-          "combined-stream": "combined-stream@1.0.8",
-          "mime-types": "mime-types@2.1.35"
-        }
-      },
       "formdata-polyfill@4.0.10": {
         "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
         "dependencies": {
           "fetch-blob": "fetch-blob@3.2.0"
-        }
-      },
-      "forwarded@0.2.0": {
-        "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-        "dependencies": {}
-      },
-      "fresh@0.5.2": {
-        "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-        "dependencies": {}
-      },
-      "function-bind@1.1.2": {
-        "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-        "dependencies": {}
-      },
-      "get-intrinsic@1.2.4": {
-        "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-        "dependencies": {
-          "es-errors": "es-errors@1.3.0",
-          "function-bind": "function-bind@1.1.2",
-          "has-proto": "has-proto@1.0.3",
-          "has-symbols": "has-symbols@1.0.3",
-          "hasown": "hasown@2.0.2"
-        }
-      },
-      "gopd@1.0.1": {
-        "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-        "dependencies": {
-          "get-intrinsic": "get-intrinsic@1.2.4"
         }
       },
       "graphql-parse-resolve-info@4.13.0_graphql@16.9.0": {
@@ -705,52 +318,25 @@
           "tslib": "tslib@2.7.0"
         }
       },
+      "graphql-yoga@5.7.0_graphql@16.9.0": {
+        "integrity": "sha512-QyGVvFAvGhMrzjJvhjsxsyoE+e4lNrj5f5qOsRYJuWIjyw7tHfbBvybZIwzNOGY0aB5sgA8BlVvu5hxjdKJ5tQ==",
+        "dependencies": {
+          "@envelop/core": "@envelop/core@5.0.2",
+          "@graphql-tools/executor": "@graphql-tools/executor@1.3.1_graphql@16.9.0",
+          "@graphql-tools/schema": "@graphql-tools/schema@10.0.6_graphql@16.9.0",
+          "@graphql-tools/utils": "@graphql-tools/utils@10.5.4_graphql@16.9.0",
+          "@graphql-yoga/logger": "@graphql-yoga/logger@2.0.0",
+          "@graphql-yoga/subscription": "@graphql-yoga/subscription@5.0.1",
+          "@whatwg-node/fetch": "@whatwg-node/fetch@0.9.21",
+          "@whatwg-node/server": "@whatwg-node/server@0.9.49",
+          "dset": "dset@3.1.4",
+          "graphql": "graphql@16.9.0",
+          "lru-cache": "lru-cache@10.4.3",
+          "tslib": "tslib@2.7.0"
+        }
+      },
       "graphql@16.9.0": {
         "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
-        "dependencies": {}
-      },
-      "has-property-descriptors@1.0.2": {
-        "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-        "dependencies": {
-          "es-define-property": "es-define-property@1.0.0"
-        }
-      },
-      "has-proto@1.0.3": {
-        "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-        "dependencies": {}
-      },
-      "has-symbols@1.0.3": {
-        "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-        "dependencies": {}
-      },
-      "hasown@2.0.2": {
-        "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-        "dependencies": {
-          "function-bind": "function-bind@1.1.2"
-        }
-      },
-      "http-errors@2.0.0": {
-        "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-        "dependencies": {
-          "depd": "depd@2.0.0",
-          "inherits": "inherits@2.0.4",
-          "setprototypeof": "setprototypeof@1.2.0",
-          "statuses": "statuses@2.0.1",
-          "toidentifier": "toidentifier@1.0.1"
-        }
-      },
-      "iconv-lite@0.4.24": {
-        "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-        "dependencies": {
-          "safer-buffer": "safer-buffer@2.1.2"
-        }
-      },
-      "inherits@2.0.4": {
-        "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-        "dependencies": {}
-      },
-      "ipaddr.js@1.9.1": {
-        "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
         "dependencies": {}
       },
       "js-base64@3.7.7": {
@@ -771,73 +357,17 @@
           "detect-libc": "detect-libc@2.0.2"
         }
       },
-      "lodash.sortby@4.7.0": {
-        "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-        "dependencies": {}
-      },
-      "loglevel@1.9.2": {
-        "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-        "dependencies": {}
-      },
-      "long@4.0.0": {
-        "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-        "dependencies": {}
-      },
-      "lru-cache@7.18.3": {
-        "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-        "dependencies": {}
-      },
-      "media-typer@0.3.0": {
-        "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-        "dependencies": {}
-      },
-      "merge-descriptors@1.0.3": {
-        "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-        "dependencies": {}
-      },
-      "methods@1.1.2": {
-        "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-        "dependencies": {}
-      },
-      "mime-db@1.52.0": {
-        "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-        "dependencies": {}
-      },
-      "mime-types@2.1.35": {
-        "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-        "dependencies": {
-          "mime-db": "mime-db@1.52.0"
-        }
-      },
-      "mime@1.6.0": {
-        "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-        "dependencies": {}
-      },
-      "ms@2.0.0": {
-        "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "lru-cache@10.4.3": {
+        "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
         "dependencies": {}
       },
       "ms@2.1.3": {
         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
         "dependencies": {}
       },
-      "negotiator@0.6.3": {
-        "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-        "dependencies": {}
-      },
-      "node-abort-controller@3.1.1": {
-        "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-        "dependencies": {}
-      },
       "node-domexception@1.0.0": {
         "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
         "dependencies": {}
-      },
-      "node-fetch@2.7.0": {
-        "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-        "dependencies": {
-          "whatwg-url": "whatwg-url@5.0.0"
-        }
       },
       "node-fetch@3.3.2": {
         "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
@@ -847,189 +377,29 @@
           "formdata-polyfill": "formdata-polyfill@4.0.10"
         }
       },
-      "object-assign@4.1.1": {
-        "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-        "dependencies": {}
-      },
-      "object-inspect@1.13.2": {
-        "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-        "dependencies": {}
-      },
-      "on-finished@2.4.1": {
-        "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-        "dependencies": {
-          "ee-first": "ee-first@1.1.1"
-        }
-      },
-      "parseurl@1.3.3": {
-        "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-        "dependencies": {}
-      },
-      "path-to-regexp@0.1.10": {
-        "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-        "dependencies": {}
-      },
       "promise-limit@2.7.0": {
         "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
         "dependencies": {}
       },
-      "proxy-addr@2.0.7": {
-        "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-        "dependencies": {
-          "forwarded": "forwarded@0.2.0",
-          "ipaddr.js": "ipaddr.js@1.9.1"
-        }
-      },
-      "qs@6.13.0": {
-        "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-        "dependencies": {
-          "side-channel": "side-channel@1.0.6"
-        }
-      },
-      "range-parser@1.2.1": {
-        "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-        "dependencies": {}
-      },
-      "raw-body@2.5.2": {
-        "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-        "dependencies": {
-          "bytes": "bytes@3.1.2",
-          "http-errors": "http-errors@2.0.0",
-          "iconv-lite": "iconv-lite@0.4.24",
-          "unpipe": "unpipe@1.0.0"
-        }
-      },
-      "retry@0.13.1": {
-        "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-        "dependencies": {}
-      },
-      "safe-buffer@5.2.1": {
-        "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-        "dependencies": {}
-      },
-      "safer-buffer@2.1.2": {
-        "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-        "dependencies": {}
-      },
-      "send@0.19.0": {
-        "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-        "dependencies": {
-          "debug": "debug@2.6.9",
-          "depd": "depd@2.0.0",
-          "destroy": "destroy@1.2.0",
-          "encodeurl": "encodeurl@1.0.2",
-          "escape-html": "escape-html@1.0.3",
-          "etag": "etag@1.8.1",
-          "fresh": "fresh@0.5.2",
-          "http-errors": "http-errors@2.0.0",
-          "mime": "mime@1.6.0",
-          "ms": "ms@2.1.3",
-          "on-finished": "on-finished@2.4.1",
-          "range-parser": "range-parser@1.2.1",
-          "statuses": "statuses@2.0.1"
-        }
-      },
-      "serve-static@1.16.2": {
-        "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-        "dependencies": {
-          "encodeurl": "encodeurl@2.0.0",
-          "escape-html": "escape-html@1.0.3",
-          "parseurl": "parseurl@1.3.3",
-          "send": "send@0.19.0"
-        }
-      },
-      "set-function-length@1.2.2": {
-        "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-        "dependencies": {
-          "define-data-property": "define-data-property@1.1.4",
-          "es-errors": "es-errors@1.3.0",
-          "function-bind": "function-bind@1.1.2",
-          "get-intrinsic": "get-intrinsic@1.2.4",
-          "gopd": "gopd@1.0.1",
-          "has-property-descriptors": "has-property-descriptors@1.0.2"
-        }
-      },
-      "setprototypeof@1.2.0": {
-        "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-        "dependencies": {}
-      },
-      "sha.js@2.4.11": {
-        "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-        "dependencies": {
-          "inherits": "inherits@2.0.4",
-          "safe-buffer": "safe-buffer@5.2.1"
-        }
-      },
-      "side-channel@1.0.6": {
-        "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-        "dependencies": {
-          "call-bind": "call-bind@1.0.7",
-          "es-errors": "es-errors@1.3.0",
-          "get-intrinsic": "get-intrinsic@1.2.4",
-          "object-inspect": "object-inspect@1.13.2"
-        }
-      },
-      "statuses@2.0.1": {
-        "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-        "dependencies": {}
-      },
-      "toidentifier@1.0.1": {
-        "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-        "dependencies": {}
-      },
-      "tr46@0.0.3": {
-        "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "streamsearch@1.1.0": {
+        "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
         "dependencies": {}
       },
       "tslib@2.7.0": {
         "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
         "dependencies": {}
       },
-      "type-is@1.6.18": {
-        "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-        "dependencies": {
-          "media-typer": "media-typer@0.3.0",
-          "mime-types": "mime-types@2.1.35"
-        }
-      },
-      "unpipe@1.0.0": {
-        "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-        "dependencies": {}
-      },
-      "utils-merge@1.0.1": {
-        "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-        "dependencies": {}
-      },
-      "uuid@9.0.1": {
-        "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "urlpattern-polyfill@10.0.0": {
+        "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
         "dependencies": {}
       },
       "value-or-promise@1.0.12": {
         "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
         "dependencies": {}
       },
-      "vary@1.1.2": {
-        "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-        "dependencies": {}
-      },
       "web-streams-polyfill@3.3.3": {
         "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
         "dependencies": {}
-      },
-      "webidl-conversions@3.0.1": {
-        "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-        "dependencies": {}
-      },
-      "whatwg-mimetype@3.0.0": {
-        "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-        "dependencies": {}
-      },
-      "whatwg-url@5.0.0": {
-        "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-        "dependencies": {
-          "tr46": "tr46@0.0.3",
-          "webidl-conversions": "webidl-conversions@3.0.1"
-        }
       },
       "ws@8.18.0": {
         "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
@@ -1041,17 +411,27 @@
       }
     }
   },
-  "remote": {},
+  "remote": {
+    "https://deno.land/std@0.157.0/async/abortable.ts": "87aa7230be8360c24ad437212311c9e8d4328854baec27b4c7abb26e85515c06",
+    "https://deno.land/std@0.157.0/async/deadline.ts": "48ac998d7564969f3e6ec6b6f9bf0217ebd00239b1b2292feba61272d5dd58d0",
+    "https://deno.land/std@0.157.0/async/debounce.ts": "de5433bff08a2bb61416fc53b3bd2d5867090c8a815465e5b4a10a77495b1051",
+    "https://deno.land/std@0.157.0/async/deferred.ts": "c01de44b9192359cebd3fe93273fcebf9e95110bf3360023917da9a2d1489fae",
+    "https://deno.land/std@0.157.0/async/delay.ts": "0419dfc993752849692d1f9647edf13407c7facc3509b099381be99ffbc9d699",
+    "https://deno.land/std@0.157.0/async/mod.ts": "dd0a8ed4f3984ffabe2fcca7c9f466b7932d57b1864ffee148a5d5388316db6b",
+    "https://deno.land/std@0.157.0/async/mux_async_iterator.ts": "3447b28a2a582224a3d4d3596bccbba6e85040da3b97ed64012f7decce98d093",
+    "https://deno.land/std@0.157.0/async/pool.ts": "ef9eb97b388543acbf0ac32647121e4dbe629236899586c4d4311a8770fbb239",
+    "https://deno.land/std@0.157.0/async/tee.ts": "d27680d911816fcb3d231e16d690e7588079e66a9b2e5ce8cc354db94fdce95f",
+    "https://deno.land/std@0.157.0/http/server.ts": "c1bce1cbf4060055f622d5c3f0e406fd553e5dca111ca836d28c6268f170ebeb"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "npm:@apollo/server@^4.11.0",
       "npm:@libsql/client@^0.14.0",
       "npm:@restatedev/restate-sdk@0.0.0-SNAPSHOT-20240926122157",
-      "npm:@sindresorhus/slugify@^2.2.1",
       "npm:drizzle-graphql@^0.8.5",
       "npm:drizzle-orm@^0.33.0",
       "npm:drizzle-zod@^0.5.1",
+      "npm:graphql-yoga@^5.7.0",
       "npm:graphql@^16.9.0",
       "npm:zod@^3.23.8"
     ]

--- a/projects/rawkode.academy/people-service/read-model/index.ts
+++ b/projects/rawkode.academy/people-service/read-model/index.ts
@@ -1,22 +1,21 @@
-import { ApolloServer } from "@apollo/server";
-import { startStandaloneServer } from "@apollo/server/standalone";
 import { createClient } from "@libsql/client";
 import { buildSchema } from "drizzle-graphql";
 import { drizzle } from "drizzle-orm/libsql";
 import { GraphQLObjectType, GraphQLSchema } from "graphql";
+import { createYoga } from "graphql-yoga";
 import * as dataSchema from "../data-model/schema.ts";
 
 if (!Deno.env.has("LIBSQL_URL")) {
-  Deno.env.set("LIBSQL_URL", "http://localhost:2000");
+	Deno.env.set("LIBSQL_URL", "http://localhost:2000");
 }
 
 if (!Deno.env.has("LIBSQL_TOKEN")) {
-  Deno.env.set("LIBSQL_TOKEN", "");
+	Deno.env.set("LIBSQL_TOKEN", "");
 }
 
 const client = createClient({
-  url: Deno.env.get("LIBSQL_URL") || "",
-  authToken: Deno.env.get("LIBSQL_TOKEN"),
+	url: Deno.env.get("LIBSQL_URL") || "",
+	authToken: Deno.env.get("LIBSQL_TOKEN"),
 });
 
 const db = drizzle(client, { schema: dataSchema });
@@ -24,22 +23,18 @@ const db = drizzle(client, { schema: dataSchema });
 const { entities } = buildSchema(db);
 
 const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
-    name: "Query",
-    fields: {
-      person: entities.queries.peopleTableSingle,
-      people: entities.queries.peopleTable,
-    },
-  }),
+	query: new GraphQLObjectType({
+		name: "Query",
+		fields: {
+			person: entities.queries.peopleTableSingle,
+			people: entities.queries.peopleTable,
+		},
+	}),
 });
 
-const server = new ApolloServer({
-  schema,
-  introspection: true,
-});
+const yoga = createYoga({ schema });
 
-const { url } = await startStandaloneServer(server, {
-  listen: { port: 4000 },
-});
-
-console.log(`🚀  Server ready at: ${url}`);
+Deno.serve({
+	hostname: "0.0.0.0",
+	port: 3000,
+}, yoga);


### PR DESCRIPTION
This is a **maybe**.

Reasoning?

I can't host my own Apollo GraphOS Router without being on the "Enterprise" plan, which means we can't use `https://api.rawkode.academy".

Apollo is also Elastic Licensed.

GraphQL Yoga and Hive are true open-source and the pricing for Hive, their GraphOS competitor, is very reasonable.

https://the-guild.dev/graphql/hive