### PR TITLE
fix(rawkode.studio): handle insert conflicts when creating rooms

### DIFF
--- a/projects/rawkode.studio/src/actions/index.ts
+++ b/projects/rawkode.studio/src/actions/index.ts
@@ -227,11 +227,14 @@ export const server = {
 			});
 
 			// Insert into database with 'created' status
-			await database.insert(livestreamsTable).values({
-				sid: room.sid,
-				name: room.name,
-				status: "created",
-			});
+			await database
+				.insert(livestreamsTable)
+				.values({
+					sid: room.sid,
+					name: room.name,
+					status: "created",
+				})
+				.onConflictDoNothing();
 
 			return {
 				id: room.sid,


### PR DESCRIPTION
Add onConflictDoNothing() to the room creation insert statement to gracefully handle cases where a room with the same SID or name already exists in the database.