### PR TITLE
fix(rawkode.academy/website): correct new issue link URL

### DIFF
--- a/projects/rawkode.academy/website/src/layouts/app.astro
+++ b/projects/rawkode.academy/website/src/layouts/app.astro
@@ -151,7 +151,7 @@ import Footer from "@/components/footer/Footer.astro";
 						<div class="flex items-center space-x-2">
 							<a
 								target="_blank"
-								href="https://github.com/RawkodeAcademy/RawkodeAcademy/-/issues/new"
+								href="https://github.com/RawkodeAcademy/RawkodeAcademy/issues/new"
 								class="bg-white/15 hover:bg-white/25 text-white text-xs font-medium px-3 py-1 rounded-md transition-colors duration-200"
 							>
 								Create an Issue
@@ -188,7 +188,7 @@ import Footer from "@/components/footer/Footer.astro";
 						<div class="flex items-center space-x-2">
 							<a
 								target="_blank"
-								href="https://github.com/RawkodeAcademy/RawkodeAcademy/-/issues/new"
+								href="https://github.com/RawkodeAcademy/RawkodeAcademy/issues/new"
 								class="bg-white/15 hover:bg-white/25 text-white text-xs font-medium px-3 py-1 rounded-md transition-colors duration-200"
 							>
 								Create an Issue


### PR DESCRIPTION
Fixes #583

This PR removes the extra `/-/` from the GitHub issue creation URL in the website layout.

The incorrect URL `https://github.com/RawkodeAcademy/RawkodeAcademy/-/issues/new` has been corrected to `https://github.com/RawkodeAcademy/RawkodeAcademy/issues/new`.

Generated with [Claude Code](https://claude.ai/code)