### PR TITLE
feat(rawkode.academy/website): implement WebVTT transcript display functionality

### DIFF
--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -522,20 +522,12 @@ const formatDate = (dateString: string) => {
 			
 			console.log('Loading transcript for video ID:', videoId, 'slug:', videoSlug);
 			
-			// Try fetching with video ID first
-			let transcriptUrl = `https://content.rawkode.academy/videos/${videoId}/captions/en.vtt`;
+			// Use the videoId directly as provided in the example URL pattern
+			const transcriptUrl = `https://content.rawkode.academy/videos/${videoId}/captions/en.vtt`;
 			console.log('Fetching transcript from:', transcriptUrl);
 			
-			let response = await fetch(transcriptUrl);
-			console.log('Transcript fetch response (ID):', response.status, response.statusText);
-			
-			// If that fails, try with slug
-			if (!response.ok && videoSlug !== videoId) {
-				transcriptUrl = `https://content.rawkode.academy/videos/${videoSlug}/captions/en.vtt`;
-				console.log('Retrying with slug:', transcriptUrl);
-				response = await fetch(transcriptUrl);
-				console.log('Transcript fetch response (slug):', response.status, response.statusText);
-			}
+			const response = await fetch(transcriptUrl);
+			console.log('Transcript fetch response:', response.status, response.statusText);
 			
 			if (!response.ok) {
 				throw new Error(`Failed to fetch transcript: ${response.status} ${response.statusText} from ${transcriptUrl}`);

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -453,7 +453,7 @@ const formatDate = (dateString: string) => {
 	});
 </script>
 
-<script define:vars={{videoId: video.data.id}}>
+<script define:vars={{videoId: video.data.id, videoSlug: video.data.slug}}>
 	// Transcript functionality
 	let transcriptLoaded = false;
 	
@@ -520,10 +520,25 @@ const formatDate = (dateString: string) => {
 			errorEl?.classList.add('hidden');
 			contentEl?.classList.add('hidden');
 			
-			const response = await fetch(`https://content.rawkode.academy/videos/${videoId}/captions/en.vtt`);
+			console.log('Loading transcript for video ID:', videoId, 'slug:', videoSlug);
+			
+			// Try fetching with video ID first
+			let transcriptUrl = `https://content.rawkode.academy/videos/${videoId}/captions/en.vtt`;
+			console.log('Fetching transcript from:', transcriptUrl);
+			
+			let response = await fetch(transcriptUrl);
+			console.log('Transcript fetch response (ID):', response.status, response.statusText);
+			
+			// If that fails, try with slug
+			if (!response.ok && videoSlug !== videoId) {
+				transcriptUrl = `https://content.rawkode.academy/videos/${videoSlug}/captions/en.vtt`;
+				console.log('Retrying with slug:', transcriptUrl);
+				response = await fetch(transcriptUrl);
+				console.log('Transcript fetch response (slug):', response.status, response.statusText);
+			}
 			
 			if (!response.ok) {
-				throw new Error(`Failed to fetch transcript: ${response.status}`);
+				throw new Error(`Failed to fetch transcript: ${response.status} ${response.statusText} from ${transcriptUrl}`);
 			}
 			
 			const vttText = await response.text();
@@ -533,17 +548,26 @@ const formatDate = (dateString: string) => {
 				throw new Error('No transcript content found');
 			}
 			
-			// Create transcript HTML
-			const transcriptHTML = cues.map(cue => {
-				return `
-					<div class="transcript-entry group hover:bg-gray-50 dark:hover:bg-gray-800 p-3 rounded-lg cursor-pointer transition-colors">
-						<div class="text-sm text-blue-600 dark:text-blue-400 font-mono mb-1">${cue.start}</div>
-						<div class="text-gray-900 dark:text-gray-100 leading-relaxed">${cue.text}</div>
-					</div>
-				`;
-			}).join('');
-			
-			contentEl.innerHTML = transcriptHTML;
+			// Create transcript content safely to prevent XSS
+			contentEl.innerHTML = ''; // Clear existing content
+			cues.forEach((cue, index) => {
+				const entryButton = document.createElement('button');
+				entryButton.className = 'transcript-entry group hover:bg-gray-50 dark:hover:bg-gray-800 p-3 rounded-lg transition-colors w-full text-left';
+				entryButton.setAttribute('aria-label', `Jump to ${cue.start}`);
+				entryButton.setAttribute('tabindex', '0');
+				
+				const startDiv = document.createElement('div');
+				startDiv.className = 'text-sm text-blue-600 dark:text-blue-400 font-mono mb-1';
+				startDiv.textContent = cue.start;
+				
+				const textDiv = document.createElement('div');
+				textDiv.className = 'text-gray-900 dark:text-gray-100 leading-relaxed';
+				textDiv.textContent = cue.text;
+				
+				entryButton.appendChild(startDiv);
+				entryButton.appendChild(textDiv);
+				contentEl.appendChild(entryButton);
+			});
 			
 			loadingEl?.classList.add('hidden');
 			contentEl.classList.remove('hidden');
@@ -553,6 +577,17 @@ const formatDate = (dateString: string) => {
 			console.error('Failed to load transcript:', error);
 			loadingEl?.classList.add('hidden');
 			errorEl?.classList.remove('hidden');
+			
+			// Show more specific error messages for debugging in dev
+			if (errorEl) {
+				const isDev = window.location.hostname === 'localhost' || window.location.hostname.includes('workers.dev');
+				if (isDev && error instanceof Error) {
+					const errorP = errorEl.querySelector('p');
+					if (errorP) {
+						errorP.textContent = `Failed to load transcript: ${error.message}`;
+					}
+				}
+			}
 		}
 	}
 	

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -457,11 +457,17 @@ const formatDate = (dateString: string) => {
 	// Transcript functionality
 	let transcriptLoaded = false;
 	
+	interface TranscriptCue {
+		start: string;
+		end: string;
+		text: string;
+	}
+	
 	// Function to parse WebVTT format
-	function parseWebVTT(vttText: string) {
+	function parseWebVTT(vttText: string): TranscriptCue[] {
 		const lines = vttText.split('\n');
-		const cues = [];
-		let currentCue = null;
+		const cues: TranscriptCue[] = [];
+		let currentCue: TranscriptCue | null = null;
 		
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i].trim();
@@ -509,6 +515,11 @@ const formatDate = (dateString: string) => {
 		const errorEl = document.getElementById('transcript-error');
 		const contentEl = document.getElementById('transcript-content');
 		
+		if (!contentEl) {
+			console.error('Transcript content element not found');
+			return;
+		}
+		
 		try {
 			loadingEl?.classList.remove('hidden');
 			errorEl?.classList.add('hidden');
@@ -537,12 +548,10 @@ const formatDate = (dateString: string) => {
 				`;
 			}).join('');
 			
-			if (contentEl) {
-				contentEl.innerHTML = transcriptHTML;
-			}
+			contentEl.innerHTML = transcriptHTML;
 			
 			loadingEl?.classList.add('hidden');
-			contentEl?.classList.remove('hidden');
+			contentEl.classList.remove('hidden');
 			
 			transcriptLoaded = true;
 		} catch (error) {

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -453,13 +453,12 @@ const formatDate = (dateString: string) => {
 	});
 </script>
 
-<script>
+<script define:vars={{videoId: video.data.id}}>
 	// Transcript functionality
 	let transcriptLoaded = false;
-	const videoId = `${video.data.id}`;
 	
 	// Function to parse WebVTT format
-	function parseWebVTT(vttText) {
+	function parseWebVTT(vttText: string) {
 		const lines = vttText.split('\n');
 		const cues = [];
 		let currentCue = null;
@@ -538,7 +537,9 @@ const formatDate = (dateString: string) => {
 				`;
 			}).join('');
 			
-			contentEl.innerHTML = transcriptHTML;
+			if (contentEl) {
+				contentEl.innerHTML = transcriptHTML;
+			}
 			
 			loadingEl?.classList.add('hidden');
 			contentEl?.classList.remove('hidden');

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -457,17 +457,12 @@ const formatDate = (dateString: string) => {
 	// Transcript functionality
 	let transcriptLoaded = false;
 	
-	interface TranscriptCue {
-		start: string;
-		end: string;
-		text: string;
-	}
 	
 	// Function to parse WebVTT format
-	function parseWebVTT(vttText: string): TranscriptCue[] {
+	function parseWebVTT(vttText) {
 		const lines = vttText.split('\n');
-		const cues: TranscriptCue[] = [];
-		let currentCue: TranscriptCue | null = null;
+		const cues = [];
+		let currentCue = null;
 		
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i].trim();

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -254,20 +254,16 @@ const formatDate = (dateString: string) => {
 						{/* Transcript Panel */}
 						<div id="panel-transcript" data-panel="transcript" class="tab-panel hidden" role="tabpanel" aria-labelledby="tab-transcript">
 							<div class="prose prose-lg dark:prose-invert max-w-none">
-								<p class="text-gray-600 dark:text-gray-400">
-									Loading transcript...
-									<div id="transcript-loading" class="hidden text-center py-8">
-										<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-										<p class="text-gray-600 dark:text-gray-400">Loading transcript...</p>
-									</div>
-									<div id="transcript-error" class="hidden text-center py-8">
-										<p class="text-red-600 dark:text-red-400">Failed to load transcript. Please try again later.</p>
-									</div>
-									<div id="transcript-content" class="hidden space-y-3">
-										<!-- Transcript content will be loaded here -->
-									</div>
-									<p style="display: none;"
-								</p>
+								<div id="transcript-loading" class="hidden text-center py-8" aria-live="polite">
+									<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
+									<p class="text-gray-600 dark:text-gray-400">Loading transcript...</p>
+								</div>
+								<div id="transcript-error" class="hidden text-center py-8">
+									<p class="text-red-600 dark:text-red-400">Failed to load transcript. Please try again later.</p>
+								</div>
+								<div id="transcript-content" class="hidden space-y-3" aria-live="polite">
+									<!-- Transcript content will be loaded here -->
+								</div>
 							</div>
 						</div>
 						
@@ -556,9 +552,10 @@ const formatDate = (dateString: string) => {
 	}
 	
 	// Load transcript when transcript tab is clicked
-	document.addEventListener('click', (e) => {
-		if (e.target.closest('[data-tab="transcript"]')) {
+	const transcriptTab = document.querySelector('[data-tab="transcript"]');
+	if (transcriptTab) {
+		transcriptTab.addEventListener('click', () => {
 			loadTranscript();
-		}
-	});
+		});
+	}
 </script>

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -255,7 +255,18 @@ const formatDate = (dateString: string) => {
 						<div id="panel-transcript" data-panel="transcript" class="tab-panel hidden" role="tabpanel" aria-labelledby="tab-transcript">
 							<div class="prose prose-lg dark:prose-invert max-w-none">
 								<p class="text-gray-600 dark:text-gray-400">
-									Transcript feature coming soon. This will display the full transcript of the video with timestamps.
+									Loading transcript...
+									<div id="transcript-loading" class="hidden text-center py-8">
+										<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
+										<p class="text-gray-600 dark:text-gray-400">Loading transcript...</p>
+									</div>
+									<div id="transcript-error" class="hidden text-center py-8">
+										<p class="text-red-600 dark:text-red-400">Failed to load transcript. Please try again later.</p>
+									</div>
+									<div id="transcript-content" class="hidden space-y-3">
+										<!-- Transcript content will be loaded here -->
+									</div>
+									<p style="display: none;"
 								</p>
 							</div>
 						</div>
@@ -443,5 +454,111 @@ const formatDate = (dateString: string) => {
 				}, 3000);
 			});
 		});
+	});
+</script>
+
+<script>
+	// Transcript functionality
+	let transcriptLoaded = false;
+	const videoId = `${video.data.id}`;
+	
+	// Function to parse WebVTT format
+	function parseWebVTT(vttText) {
+		const lines = vttText.split('\n');
+		const cues = [];
+		let currentCue = null;
+		
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i].trim();
+			
+			// Skip empty lines and WEBVTT header
+			if (!line || line === 'WEBVTT') continue;
+			
+			// Check if line contains timestamp (format: 00:00:00.000 --> 00:00:00.000)
+			const timestampMatch = line.match(/^(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})/);
+			
+			if (timestampMatch) {
+				// If we have a previous cue, add it to the array
+				if (currentCue && currentCue.text.trim()) {
+					cues.push(currentCue);
+				}
+				
+				// Start a new cue
+				currentCue = {
+					start: timestampMatch[1],
+					end: timestampMatch[2],
+					text: ''
+				};
+			} else if (currentCue && line && !line.startsWith('NOTE')) {
+				// Add text to current cue (skip NOTE lines)
+				if (currentCue.text) {
+					currentCue.text += ' ';
+				}
+				currentCue.text += line;
+			}
+		}
+		
+		// Add the last cue
+		if (currentCue && currentCue.text.trim()) {
+			cues.push(currentCue);
+		}
+		
+		return cues;
+	}
+	
+	// Function to load and display transcript
+	async function loadTranscript() {
+		if (transcriptLoaded) return;
+		
+		const loadingEl = document.getElementById('transcript-loading');
+		const errorEl = document.getElementById('transcript-error');
+		const contentEl = document.getElementById('transcript-content');
+		
+		try {
+			loadingEl?.classList.remove('hidden');
+			errorEl?.classList.add('hidden');
+			contentEl?.classList.add('hidden');
+			
+			const response = await fetch(`https://content.rawkode.academy/videos/${videoId}/captions/en.vtt`);
+			
+			if (!response.ok) {
+				throw new Error(`Failed to fetch transcript: ${response.status}`);
+			}
+			
+			const vttText = await response.text();
+			const cues = parseWebVTT(vttText);
+			
+			if (cues.length === 0) {
+				throw new Error('No transcript content found');
+			}
+			
+			// Create transcript HTML
+			const transcriptHTML = cues.map(cue => {
+				return `
+					<div class="transcript-entry group hover:bg-gray-50 dark:hover:bg-gray-800 p-3 rounded-lg cursor-pointer transition-colors">
+						<div class="text-sm text-blue-600 dark:text-blue-400 font-mono mb-1">${cue.start}</div>
+						<div class="text-gray-900 dark:text-gray-100 leading-relaxed">${cue.text}</div>
+					</div>
+				`;
+			}).join('');
+			
+			contentEl.innerHTML = transcriptHTML;
+			
+			loadingEl?.classList.add('hidden');
+			contentEl?.classList.remove('hidden');
+			
+			transcriptLoaded = true;
+		} catch (error) {
+			console.error('Failed to load transcript:', error);
+			loadingEl?.classList.add('hidden');
+			errorEl?.classList.remove('hidden');
+		}
+	}
+	
+	// Load transcript when transcript tab is clicked
+	document.addEventListener('click', (e) => {
+		if (e.target.closest('[data-tab="transcript"]')) {
+			loadTranscript();
+		}
 	});
 </script>


### PR DESCRIPTION
Implement WebVTT transcript display functionality for the rawkode.academy video player.

## Changes
- Add WebVTT parsing function to extract timestamps and text
- Implement transcript loading with proper loading states
- Add event listener to fetch transcript when tab is clicked
- Display transcript entries with timestamps and hover effects
- Handle error states for failed transcript loading

The transcript tab now loads WebVTT files from content.rawkode.academy and displays them in a readable format with timestamps.

Resolves #593

Generated with [Claude Code](https://claude.ai/code)