### PR TITLE
fix(rawkode.studio): remove user authentication check and add room va…

### DIFF
--- a/projects/rawkode.studio/src/actions/chat.ts
+++ b/projects/rawkode.studio/src/actions/chat.ts
@@ -38,11 +38,7 @@ export const chat = {
     input: z.object({
       roomId: z.string(),
     }),
-    handler: async (input, context) => {
-      if (!context.locals.user) {
-        throw new ActionError({ code: "UNAUTHORIZED" });
-      }
-
+    handler: async (input) => {
       try {
         const messages = await database
           .select({

--- a/projects/rawkode.studio/src/pages/api/livestream/chat.ts
+++ b/projects/rawkode.studio/src/pages/api/livestream/chat.ts
@@ -19,9 +19,12 @@ export const GET: APIRoute = async ({ request, url, callAction }) => {
     });
   }
 
-  // Note: We already have the participant's identity from the token
-  // The token itself proves they have access to the room since it was
-  // generated specifically for this room
+  // Verify the participant has access to this room
+  if (auth.room !== roomName) {
+    return new Response("Unauthorized access to room", {
+      status: 403,
+    });
+  }
 
   try {
     const result = await callAction(actions.chat.getPastRoomChatMessages, {
@@ -67,6 +70,13 @@ export const POST: APIRoute = async ({ request, callAction, locals }) => {
   if (!roomName || !message) {
     return new Response("Room name and message are required", {
       status: 400,
+    });
+  }
+
+  // Verify the participant has access to this room
+  if (auth.room !== roomName) {
+    return new Response("Unauthorized access to room", {
+      status: 403,
     });
   }
 


### PR DESCRIPTION
…lidation

- Remove the context.locals.user check from getPastRoomChatMessages to allow chat history retrieval with just LiveKit token authentication
- Add room validation to chat endpoints to ensure the LiveKit token's room claim matches the requested room, preventing unauthorized cross-room access
- Verify auth.room === roomName for both GET and POST chat endpoints

This ensures the chat history endpoint works properly when called from the client with a valid LiveKit token while maintaining proper room-level security.

🤖 Generated with [Claude Code](https://claude.ai/code)