### PR TITLE
feat(rawkode.studio): use displayName attribute from LiveKit token fo…

### DIFF
--- a/projects/rawkode.studio/src/actions/chat.ts
+++ b/projects/rawkode.studio/src/actions/chat.ts
@@ -18,17 +18,15 @@ export const chat = {
     input: z.object({
       roomId: z.string(),
       participantIdentity: z.string(),
+      participantName: z.string(),
       message: z.string(),
     }),
 
     handler: async (input) => {
-      // Use the identity as the participant name - this prevents spoofing
-      const participantName = input.participantIdentity;
-
       await database.insert(chatMessagesTable).values({
         roomId: input.roomId,
         participantIdentity: input.participantIdentity,
-        participantName: participantName,
+        participantName: input.participantName,
         message: input.message,
       });
     },

--- a/projects/rawkode.studio/src/components/livestreams/room/RoomWrapper.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/RoomWrapper.tsx
@@ -23,9 +23,7 @@ export function RoomWrapper({
   isAuthenticated,
 }: RoomWrapperProps) {
   const [showPrejoin, setShowPrejoin] = useState(true);
-  const [participantName, setParticipantName] = useState<string | undefined>(
-    username,
-  );
+  const [displayName, setDisplayName] = useState<string | undefined>(username);
 
   // Check if user has already completed prejoin
   useEffect(() => {
@@ -34,15 +32,11 @@ export function RoomWrapper({
 
     if (prejoinCompleted === "true" && roomDisplayName === lastRoom) {
       // User already went through prejoin, skip it
-      const savedName = sessionStorage.getItem("participant-name");
-      if (savedName) {
-        setParticipantName(savedName);
-      }
+      // Display name is now handled through LiveKit participant attributes
       setShowPrejoin(false);
     } else {
       // Clear old prejoin data if switching rooms
       sessionStorage.removeItem("prejoin-completed");
-      sessionStorage.removeItem("participant-name");
       sessionStorage.removeItem("prejoin-audio-enabled");
       sessionStorage.removeItem("prejoin-video-enabled");
       sessionStorage.removeItem("prejoin-audio-device");
@@ -56,7 +50,7 @@ export function RoomWrapper({
   const handleJoin = (choices: LocalUserChoices) => {
     // Store prejoin choices in session storage
     sessionStorage.setItem("prejoin-completed", "true");
-    sessionStorage.setItem("participant-name", choices.username);
+    // Display name is passed to LiveKit token, no need to store separately
     sessionStorage.setItem(
       "prejoin-audio-enabled",
       choices.audioEnabled.toString(),
@@ -74,14 +68,13 @@ export function RoomWrapper({
     }
 
     // Update state to show room
-    setParticipantName(choices.username);
+    setDisplayName(choices.username);
     setShowPrejoin(false);
   };
 
   const handleLeaveRoom = () => {
     // Clear prejoin flag and reload to show prejoin again
     sessionStorage.removeItem("prejoin-completed");
-    sessionStorage.removeItem("participant-name");
     sessionStorage.removeItem("prejoin-audio-enabled");
     sessionStorage.removeItem("prejoin-video-enabled");
     sessionStorage.removeItem("prejoin-audio-device");
@@ -107,7 +100,7 @@ export function RoomWrapper({
       serverUrl={serverUrl}
       roomName={roomName}
       roomDisplayName={roomDisplayName}
-      participantName={participantName}
+      displayName={displayName}
       onLeaveRoom={handleLeaveRoom}
     />
   );

--- a/projects/rawkode.studio/src/components/livestreams/room/chat/Chat.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/chat/Chat.tsx
@@ -124,12 +124,6 @@ export function Chat({ token, onNewMessage }: ChatProps) {
             },
             body: JSON.stringify({
               roomName: room.name,
-              participantName:
-                room.localParticipant?.name ||
-                room.localParticipant?.identity ||
-                "Anonymous",
-              participantIdentity:
-                room.localParticipant?.identity || "anonymous",
               message: processedMessage,
             }),
           });
@@ -271,7 +265,10 @@ export function Chat({ token, onNewMessage }: ChatProps) {
         allMessages.push({
           id: msg.id,
           message: msg.message,
-          participantName: msg.from?.name || msg.from?.identity || "Anonymous",
+          participantName:
+            msg.from?.attributes?.displayName ||
+            msg.from?.identity ||
+            "Anonymous",
           participantIdentity: msg.from?.identity || "anonymous",
           timestamp: msg.timestamp || Date.now(),
         });

--- a/projects/rawkode.studio/src/components/livestreams/room/controls/PresenterSelector.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/controls/PresenterSelector.tsx
@@ -89,7 +89,10 @@ export function PresenterSelector() {
         const participant = participants.find(
           (p) => p.identity === participantIdentity,
         );
-        const name = participant?.name || participant?.identity || "Unknown";
+        const name =
+          participant?.attributes?.displayName ||
+          participant?.identity ||
+          "Unknown";
         toast.success(`${name} is now the presenter`);
       } catch (error) {
         console.error("Failed to update presenter:", error);
@@ -147,7 +150,7 @@ export function PresenterSelector() {
             <>
               <div className="px-2 py-1.5 text-sm text-muted-foreground">
                 Current:{" "}
-                {currentPresenterParticipant.name ||
+                {currentPresenterParticipant.attributes?.displayName ||
                   currentPresenterParticipant.identity}
               </div>
               <DropdownMenuSeparator />
@@ -180,7 +183,8 @@ export function PresenterSelector() {
                         isCurrentPresenter ? "text-primary" : ""
                       }`}
                     >
-                      {participant.name || participant.identity}
+                      {participant.attributes?.displayName ||
+                        participant.identity}
                       {isYou && " (You)"}
                     </div>
                     <div className="text-xs text-muted-foreground">

--- a/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
@@ -41,7 +41,7 @@ export interface LiveKitRoomProps {
   serverUrl: string;
   roomName: string;
   roomDisplayName: string;
-  participantName?: string;
+  displayName?: string;
   onLeaveRoom?: (roomName: string) => void;
   className?: string;
 }
@@ -50,13 +50,12 @@ export default function LiveKitRoom({
   serverUrl,
   roomName,
   roomDisplayName,
-  participantName: propParticipantName,
+  displayName,
   onLeaveRoom,
   className,
 }: LiveKitRoomProps) {
   // Custom hooks
-  const { participantName, initialMediaSettings } =
-    useParticipantInfo(propParticipantName);
+  const { initialMediaSettings } = useParticipantInfo();
   const {
     connectionState,
     error,
@@ -73,7 +72,7 @@ export default function LiveKitRoom({
     error: tokenError,
   } = useLivestreamToken({
     roomName,
-    participantName,
+    displayName,
   });
 
   // Handle token error

--- a/projects/rawkode.studio/src/components/livestreams/room/layouts/ParticipantNameplate.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/layouts/ParticipantNameplate.tsx
@@ -10,7 +10,9 @@ export function ParticipantNameplate({
   size = "default",
 }: ParticipantNameplateProps) {
   const name =
-    trackRef.participant?.name || trackRef.participant?.identity || "Unknown";
+    trackRef.participant?.attributes?.displayName ||
+    trackRef.participant?.identity ||
+    "Unknown";
 
   const isSmall = size === "small";
 

--- a/projects/rawkode.studio/src/components/livestreams/room/participants/ParticipantsList.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/participants/ParticipantsList.tsx
@@ -150,7 +150,7 @@ export function ParticipantsList({ token }: ParticipantsListProps) {
       >
         <div className="flex-1 min-w-0 flex items-center gap-2">
           <p className="text-sm font-medium text-foreground truncate">
-            {participant.name || participant.identity}
+            {participant.attributes?.displayName || participant.identity}
           </p>
 
           <div className="flex items-center gap-2 ml-auto">

--- a/projects/rawkode.studio/src/components/livestreams/room/participants/RaisedHandsList.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/participants/RaisedHandsList.tsx
@@ -91,7 +91,7 @@ export function RaisedHandsList({ onPromote, token }: RaisedHandsListProps) {
               className="flex items-center gap-2 p-2 bg-orange-500/10 dark:bg-orange-500/10 border border-orange-500/30 dark:border-orange-500/20 rounded-xl"
             >
               <span className="flex-1 text-sm font-medium text-foreground truncate">
-                {participant.name || participant.identity}
+                {participant.attributes?.displayName || participant.identity}
               </span>
 
               <div className="flex items-center gap-1">

--- a/projects/rawkode.studio/src/hooks/useLivestreamToken.ts
+++ b/projects/rawkode.studio/src/hooks/useLivestreamToken.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 interface UseTokenOptions {
   roomName?: string;
-  participantName?: string;
+  displayName?: string;
 }
 
 interface TokenResult {
@@ -13,7 +13,7 @@ interface TokenResult {
 
 export function useLivestreamToken({
   roomName,
-  participantName,
+  displayName,
 }: UseTokenOptions): TokenResult {
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -62,7 +62,7 @@ export function useLivestreamToken({
           },
           body: JSON.stringify({
             roomName,
-            ...(participantName && { participantName }),
+            ...(displayName && { displayName }),
           }),
         });
         const data = await response.json();
@@ -81,7 +81,7 @@ export function useLivestreamToken({
     };
 
     fetchToken();
-  }, [roomName, participantName]);
+  }, [roomName, displayName]);
 
   // Set up polling for token refresh
   useEffect(() => {

--- a/projects/rawkode.studio/src/hooks/useParticipantInfo.ts
+++ b/projects/rawkode.studio/src/hooks/useParticipantInfo.ts
@@ -7,16 +7,7 @@ interface MediaSettings {
   videoDeviceId?: string;
 }
 
-export function useParticipantInfo(propParticipantName?: string) {
-  // Get participant name from props or sessionStorage
-  const getInitialParticipantName = () => {
-    if (propParticipantName) return propParticipantName;
-    if (typeof window !== "undefined") {
-      return sessionStorage.getItem("participant-name") || undefined;
-    }
-    return undefined;
-  };
-
+export function useParticipantInfo() {
   // Get initial media settings from prejoin preferences
   const getInitialMediaSettings = (): MediaSettings => {
     if (typeof window !== "undefined") {
@@ -39,15 +30,11 @@ export function useParticipantInfo(propParticipantName?: string) {
     };
   };
 
-  const [participantName] = useState<string | undefined>(
-    getInitialParticipantName,
-  );
   const [initialMediaSettings] = useState<MediaSettings>(
     getInitialMediaSettings,
   );
 
   return {
-    participantName,
     initialMediaSettings,
   };
 }

--- a/projects/rawkode.studio/src/lib/guest.ts
+++ b/projects/rawkode.studio/src/lib/guest.ts
@@ -1,0 +1,12 @@
+export const generateGuestName = () => {
+  // Use crypto API for better randomness
+  const array = new Uint8Array(5);
+  crypto.getRandomValues(array);
+
+  // Convert to digits (0-9)
+  const randomNumbers = Array.from(array)
+    .map((byte) => byte % 10)
+    .join("");
+
+  return `guest-${randomNumbers}`;
+};

--- a/projects/rawkode.studio/src/lib/security.ts
+++ b/projects/rawkode.studio/src/lib/security.ts
@@ -6,6 +6,7 @@ export type Roles = (typeof roles)[number];
 
 export interface OidcStandardClaimsWithRoles extends OidcStandardClaims {
   roles: Roles[];
+  name?: string;
 }
 
 /**
@@ -23,6 +24,7 @@ export interface LiveKitAuth {
   token: string;
   identity: string;
   room?: string;
+  displayName?: string;
 }
 
 /**
@@ -45,10 +47,13 @@ export async function extractLiveKitAuth(
     if (!identity) {
       return null;
     }
+    // Extract displayName from attributes if available
+    const displayName = decoded.attributes?.displayName;
     return {
       token,
       identity,
       room: decoded.video?.room,
+      displayName,
     };
   } catch (error) {
     return null;

--- a/projects/rawkode.studio/src/lib/zitadel.ts
+++ b/projects/rawkode.studio/src/lib/zitadel.ts
@@ -77,6 +77,7 @@ export class Zitadel {
         // Verify the audience includes our client ID
         audience: this.clientId,
       });
+      console.log(JSON.stringify(payload));
 
       // Extract roles from the verified payload
       if ("urn:zitadel:iam:org:project:roles" in payload) {
@@ -87,12 +88,14 @@ export class Zitadel {
         return {
           ...payload,
           roles: Object.keys(roles).map((role) => role as Roles),
+          name: payload.name as string | undefined,
         } as OidcStandardClaimsWithRoles;
       }
 
       return {
         ...payload,
         roles: [],
+        name: payload.name as string | undefined,
       } as OidcStandardClaimsWithRoles;
     } catch (e) {
       console.error("JWT verification failed:", e);

--- a/projects/rawkode.studio/src/pages/api/livestream/chat.ts
+++ b/projects/rawkode.studio/src/pages/api/livestream/chat.ts
@@ -84,6 +84,7 @@ export const POST: APIRoute = async ({ request, callAction, locals }) => {
     roomId: roomName, // roomName is our custom ID
     message,
     participantIdentity: auth.identity,
+    participantName: auth.displayName || auth.identity, // Use displayName from token if available
   });
 
   if (result.error) {

--- a/projects/rawkode.studio/src/pages/api/webhooks/livekit.ts
+++ b/projects/rawkode.studio/src/pages/api/webhooks/livekit.ts
@@ -57,7 +57,7 @@ export const POST: APIRoute = async ({ request }) => {
         .values({
           roomId: room.name, // room.name is our custom ID
           identity: participant.identity,
-          name: participant.name || participant.identity,
+          name: participant.attributes?.displayName || participant.identity,
         })
         .onConflictDoNothing();
       break;

--- a/projects/rawkode.studio/src/pages/watch/[roomName].astro
+++ b/projects/rawkode.studio/src/pages/watch/[roomName].astro
@@ -48,7 +48,7 @@ try {
 // Check if user is authenticated and has director role
 const user = Astro.locals.user;
 const isDirector = user?.roles?.includes("director") || false;
-const username = user?.preferred_username || user?.name;
+const username = user?.name;
 const isAuthenticated = !!user;
 ---
 


### PR DESCRIPTION
…r participant names

- Update webhook handler to extract displayName from participant attributes
- Replace all participant.name references with participant.attributes?.displayName
- Ensure consistent naming across chat, presenter selector, and participant lists
- Add displayName attribute when generating LiveKit tokens
- Improve guest user display name handling in prejoin screen

This ensures that the display name set during token generation is properly used throughout the application instead of relying on the deprecated participant.name field.

🤖 Generated with [Claude Code](https://claude.ai/code)