### PR TITLE
feat(rawkode.studio): remove rejoin logic and debug console logs

### DIFF
--- a/projects/rawkode.studio/src/actions/rooms.ts
+++ b/projects/rawkode.studio/src/actions/rooms.ts
@@ -384,8 +384,6 @@ export const rooms = {
         });
       }
 
-      console.log(JSON.stringify(createRoomOptions));
-
       const room = await roomClientService.createRoom(createRoomOptions);
 
       // Insert into database with 'created' status

--- a/projects/rawkode.studio/src/components/livestreams/room/RoomWrapper.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/RoomWrapper.tsx
@@ -1,7 +1,7 @@
 import { PrejoinScreen } from "@/components/livestreams/prejoin/PrejoinScreen";
 import LiveKitRoom from "@/components/livestreams/room/core/LiveKitRoom";
 import type { LocalUserChoices } from "@livekit/components-core";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface RoomWrapperProps {
   serverUrl: string;
@@ -25,60 +25,14 @@ export function RoomWrapper({
   const [showPrejoin, setShowPrejoin] = useState(true);
   const [displayName, setDisplayName] = useState<string | undefined>(username);
 
-  // Check if user has already completed prejoin
-  useEffect(() => {
-    const prejoinCompleted = sessionStorage.getItem("prejoin-completed");
-    const lastRoom = sessionStorage.getItem("last-room-display-name");
-
-    if (prejoinCompleted === "true" && roomDisplayName === lastRoom) {
-      // User already went through prejoin, skip it
-      // Display name is now handled through LiveKit participant attributes
-      setShowPrejoin(false);
-    } else {
-      // Clear old prejoin data if switching rooms
-      sessionStorage.removeItem("prejoin-completed");
-      sessionStorage.removeItem("prejoin-audio-enabled");
-      sessionStorage.removeItem("prejoin-video-enabled");
-      sessionStorage.removeItem("prejoin-audio-device");
-      sessionStorage.removeItem("prejoin-video-device");
-    }
-
-    // Store current room display name
-    sessionStorage.setItem("last-room-display-name", roomDisplayName);
-  }, [roomDisplayName]);
-
   const handleJoin = (choices: LocalUserChoices) => {
-    // Store prejoin choices in session storage
-    sessionStorage.setItem("prejoin-completed", "true");
-    // Display name is passed to LiveKit token, no need to store separately
-    sessionStorage.setItem(
-      "prejoin-audio-enabled",
-      choices.audioEnabled.toString(),
-    );
-    sessionStorage.setItem(
-      "prejoin-video-enabled",
-      choices.videoEnabled.toString(),
-    );
-
-    if (choices.audioDeviceId) {
-      sessionStorage.setItem("prejoin-audio-device", choices.audioDeviceId);
-    }
-    if (choices.videoDeviceId) {
-      sessionStorage.setItem("prejoin-video-device", choices.videoDeviceId);
-    }
-
     // Update state to show room
     setDisplayName(choices.username);
     setShowPrejoin(false);
   };
 
   const handleLeaveRoom = () => {
-    // Clear prejoin flag and reload to show prejoin again
-    sessionStorage.removeItem("prejoin-completed");
-    sessionStorage.removeItem("prejoin-audio-enabled");
-    sessionStorage.removeItem("prejoin-video-enabled");
-    sessionStorage.removeItem("prejoin-audio-device");
-    sessionStorage.removeItem("prejoin-video-device");
+    // Reload to show prejoin again
     window.location.reload();
   };
 

--- a/projects/rawkode.studio/src/lib/zitadel.ts
+++ b/projects/rawkode.studio/src/lib/zitadel.ts
@@ -77,7 +77,6 @@ export class Zitadel {
         // Verify the audience includes our client ID
         audience: this.clientId,
       });
-      console.log(JSON.stringify(payload));
 
       // Extract roles from the verified payload
       if ("urn:zitadel:iam:org:project:roles" in payload) {


### PR DESCRIPTION
- Remove session storage-based rejoin logic that allowed users to skip the prejoin screen when returning to a room
- Remove debug console.log statements from room creation and JWT verification
- Ensures users always go through the prejoin flow for a consistent experience

🤖 Generated with [Claude Code](https://claude.ai/code)