### PR TITLE
fix(rawkode.academy/platform/casting-credits): remove graphql override

### DIFF
--- a/projects/rawkode.academy/platform/casting-credits/package.json
+++ b/projects/rawkode.academy/platform/casting-credits/package.json
@@ -36,8 +36,5 @@
 	},
 	"peerDependencies": {
 		"typescript": "^5.8.3"
-	},
-	"overrides": {
-		"graphql": "^16.5.0"
 	}
 }


### PR DESCRIPTION
This was a hangover from some debugging about package versions. This override shouldn't have survived.