### PR TITLE
fix(rawkode.studio): improve chat and participants layout balance

### DIFF
--- a/projects/rawkode.studio/src/components/livestreams/room/chat/Chat.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/chat/Chat.tsx
@@ -280,10 +280,10 @@ export function Chat({ token, onNewMessage }: ChatProps) {
   })();
 
   return (
-    <div className="flex flex-col h-full min-h-0 p-2">
+    <div className="flex flex-col h-full min-h-0">
       <div
         ref={messagesContainerRef}
-        className="flex-1 overflow-y-auto pr-2 mb-3 min-h-0 custom-scrollbar"
+        className="flex-1 overflow-y-auto px-2 mb-3 min-h-0 custom-scrollbar"
       >
         <div>
           {isLoadingHistory ? (

--- a/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
@@ -303,22 +303,27 @@ const SidebarContentComponent: React.FC<SidebarContentProps> = ({
             </Button>
           </div>
 
-          {/* Desktop: Participants always visible, mobile: conditional */}
-          <div className="hidden xl:block mb-3">
-            <ScrollArea className="h-[200px] pr-3">
-              <ParticipantsList token={token} />
-            </ScrollArea>
-          </div>
+          {/* Desktop: Split view for participants and chat */}
+          <div className="hidden xl:flex flex-col flex-1 gap-3">
+            {/* Participants section - 50% height */}
+            <div className="flex-1 flex flex-col min-h-0">
+              <ScrollArea className="h-full">
+                <ParticipantsList token={token} />
+              </ScrollArea>
+            </div>
 
-          {/* Desktop: Chat always visible, mobile: conditional */}
-          <div className="flex-1 hidden xl:flex">
-            <Chat token={token} />
+            <Separator />
+
+            {/* Chat section - 50% height */}
+            <div className="flex-1 flex min-h-0">
+              <Chat token={token} />
+            </div>
           </div>
 
           {/* Mobile: Show active tab content */}
           <div className="flex-1 xl:hidden overflow-hidden">
             {activeTab === "participants" ? (
-              <ScrollArea className="h-full pr-3">
+              <ScrollArea className="h-full">
                 <ParticipantsList token={token} />
               </ScrollArea>
             ) : (


### PR DESCRIPTION
- Remove outer padding from chat container for better spacing
- Add symmetric horizontal padding to chat messages area
- Split participants and chat sections equally on desktop (50/50)
- Add separator between participants and chat for visual clarity
- Remove fixed height constraint from participants section
- Ensure proper overflow handling with min-h-0 on flex containers

🤖 Generated with [Claude Code](https://claude.ai/code)