### PR TITLE
feat: Implement chat message promotion

### DIFF
--- a/projects/rawkode.studio/CLAUDE.md
+++ b/projects/rawkode.studio/CLAUDE.md
@@ -191,10 +191,12 @@ if (!hasDirectorRole(user)) {
 ```
 
 ### 7. Real-time Features
-- **Video/Audio**: LiveKit WebRTC handles streaming
-- **Chat**: Server-sent events via Astro Actions
-- **Updates**: LiveKit webhooks for room lifecycle
-- **Layouts**: Multiple video layouts available
+- **Video/Audio**: LiveKit WebRTC handles streaming.
+- **Chat Persistence**: Chat messages are persisted via Astro Actions (`src/actions/chat.ts`) called by API endpoints (`src/pages/api/livestream/chat.ts`).
+- **Chat Real-time Display**: Basic chat messages appear in real-time leveraging LiveKit's default data channels used by `useChat()`.
+- **Promoted Message Notifications**: When a chat message is promoted by a director, a LiveKit data message is sent on the "chat:promoted" topic by the `promoteChatMessage` Astro Action. Client components (`PromotedMessagesDisplay.tsx` and `Chat.tsx`) listen on this topic to update their UIs in real-time.
+- **Other Real-time Updates**: LiveKit webhooks are used for room lifecycle events.
+- **Layouts**: Multiple video layouts available, managed via client-side state and LiveKit participant metadata.
 
 ### 8. Error Handling
 - Fix all TypeScript and linting errors properly

--- a/projects/rawkode.studio/src/actions/chat.ts
+++ b/projects/rawkode.studio/src/actions/chat.ts
@@ -1,8 +1,14 @@
 import { ActionError, defineAction } from "astro:actions";
 import { z } from "astro:schema";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { database } from "@/lib/database";
 import { chatMessagesTable } from "@/schema";
+import {
+  hasDirectorRole,
+  type OidcStandardClaimsWithRoles,
+} from "@/lib/security";
+import { roomClientService } from "@/lib/livekit";
+import { DataPacket_Kind } from "livekit-server-sdk";
 
 export type ChatMessage = {
   id: number;
@@ -10,6 +16,7 @@ export type ChatMessage = {
   participantIdentity: string;
   participantName: string;
   message: string;
+  isPromoted: boolean;
   createdAt: Date;
 };
 
@@ -45,6 +52,7 @@ export const chat = {
             participantIdentity: chatMessagesTable.participantIdentity,
             participantName: chatMessagesTable.participantName,
             message: chatMessagesTable.message,
+            isPromoted: chatMessagesTable.isPromoted,
             createdAt: chatMessagesTable.createdAt,
           })
           .from(chatMessagesTable)
@@ -56,6 +64,101 @@ export const chat = {
         throw new ActionError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to fetch chat messages.",
+        });
+      }
+    },
+  }),
+
+  promoteChatMessage: defineAction({
+    input: z.object({
+      messageId: z.number(),
+    }),
+    handler: async (input, context) => {
+      // @ts-expect-error - locals is not typed correctly by Astro
+      const user = context.locals?.user as OidcStandardClaimsWithRoles | undefined;
+
+      if (!user || !hasDirectorRole(user)) {
+        throw new ActionError({
+          code: "UNAUTHORIZED",
+          message: "You are not authorized to promote messages.",
+        });
+      }
+
+      try {
+        const [updatedMessage] = await database
+          .update(chatMessagesTable)
+          .set({ isPromoted: true })
+          .where(eq(chatMessagesTable.id, input.messageId))
+          .returning();
+
+        if (!updatedMessage) {
+          throw new ActionError({
+            code: "NOT_FOUND",
+            message: "Message not found.",
+          });
+        }
+
+        // Notify clients via LiveKit data message
+        const topic = "chat:promoted"; // Define a topic for promoted messages
+        const payload = {
+          type: "message_promoted",
+          message: updatedMessage,
+        };
+        const data = new TextEncoder().encode(JSON.stringify(payload));
+
+        await roomClientService.sendData(
+          updatedMessage.roomId, // Send to the room where the message originated
+          data,
+          DataPacket_Kind.RELIABLE,
+          { topic }, // Send on a specific topic
+        );
+
+        return { success: true, message: updatedMessage };
+      } catch (error) {
+        console.error("Failed to promote chat message:", error);
+        if (error instanceof ActionError) {
+          throw error;
+        }
+        throw new ActionError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to promote chat message.",
+        });
+      }
+    },
+  }),
+
+  getPromotedChatMessages: defineAction({
+    input: z.object({
+      roomId: z.string(),
+    }),
+    handler: async (input) => {
+      try {
+        const messages = await database
+          .select({
+            id: chatMessagesTable.id,
+            roomId: chatMessagesTable.roomId,
+            participantIdentity: chatMessagesTable.participantIdentity,
+            participantName: chatMessagesTable.participantName,
+            message: chatMessagesTable.message,
+            isPromoted: chatMessagesTable.isPromoted,
+            createdAt: chatMessagesTable.createdAt,
+          })
+          .from(chatMessagesTable)
+          .where(
+            and(
+              eq(chatMessagesTable.roomId, input.roomId),
+              eq(chatMessagesTable.isPromoted, true),
+            ),
+          )
+          .orderBy(chatMessagesTable.createdAt) // Fetches oldest promoted first
+          .all();
+
+        return messages as ChatMessage[];
+      } catch (_error) {
+        console.error("Failed to fetch promoted chat messages:", _error);
+        throw new ActionError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to fetch promoted chat messages.",
         });
       }
     },

--- a/projects/rawkode.studio/src/components/livestreams/room/PromotedMessagesDisplay.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/PromotedMessagesDisplay.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { useDataChannel, useRoomContext } from "@livekit/components-react";
+import { actions } from "astro:actions";
+import type { ChatMessage as APIChatMessage } from "@/actions/chat";
+import { ShieldCheck } from "lucide-react"; // Using a different icon for promoted message
+
+interface PromotedMessagesDisplayProps {
+  // Potentially add props for styling or behavior customization later
+}
+
+export function PromotedMessagesDisplay({}: PromotedMessagesDisplayProps) {
+  const [promotedMessage, setPromotedMessage] = useState<APIChatMessage | null>(
+    null,
+  );
+  const [isVisible, setIsVisible] = useState(false);
+  const room = useRoomContext();
+
+  // Fetch initial promoted messages
+  useEffect(() => {
+    const fetchInitialPromoted = async () => {
+      if (!room.name) return;
+      try {
+        const result = await actions.chat.getPromotedChatMessages({
+          roomId: room.name,
+        });
+        if (result.error) {
+          console.error(
+            "Failed to fetch initial promoted messages:",
+            result.error.message,
+          );
+          return;
+        }
+        if (result.data && result.data.length > 0) {
+          // Display the latest promoted message by createdAt timestamp
+          const latestMessage = result.data.sort(
+            (a, b) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+          )[0];
+          setPromotedMessage(latestMessage);
+          setIsVisible(true);
+        }
+      } catch (e) {
+        console.error("Error calling getPromotedChatMessages:", e);
+      }
+    };
+
+    fetchInitialPromoted();
+  }, [room.name]);
+
+  // Listen for LiveKit data messages for real-time updates
+  useDataChannel("chat:promoted", (message) => {
+    try {
+      const decoder = new TextDecoder();
+      const receivedData = JSON.parse(decoder.decode(message.payload));
+
+      if (receivedData.type === "message_promoted" && receivedData.message) {
+        setPromotedMessage(receivedData.message as APIChatMessage);
+        setIsVisible(true);
+
+        // Optional: Auto-hide message after a few seconds
+        // setTimeout(() => setIsVisible(false), 10000); // Hide after 10 seconds
+      }
+      // Could handle "message_demoted" or other types here in the future
+    } catch (e) {
+      console.error("Error processing data channel message:", e);
+    }
+  });
+
+  useEffect(() => {
+    if (promotedMessage) {
+      setIsVisible(true);
+      // Optional: Auto-hide message after a few seconds
+      const timer = setTimeout(() => setIsVisible(false), 10000); // Hide after 10 seconds
+      return () => clearTimeout(timer);
+    }
+  }, [promotedMessage]);
+
+  if (!isVisible || !promotedMessage) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute bottom-4 left-1/2 -translate-x-1/2 w-full max-w-md p-4 bg-background/80 backdrop-blur-md border border-primary/50 rounded-lg shadow-xl text-foreground transition-all duration-500 ease-in-out animate-slideInUp"
+      style={{
+        animationName: isVisible ? "slideInUp" : "slideOutDown",
+        animationDuration: "0.5s",
+        animationFillMode: "forwards",
+      }}
+    >
+      <div className="flex items-center mb-2">
+        <ShieldCheck className="h-6 w-6 text-primary mr-2 flex-shrink-0" />
+        <p className="text-sm font-semibold text-primary truncate">
+          {promotedMessage.participantName}
+        </p>
+      </div>
+      <p className="text-base break-words">{promotedMessage.message}</p>
+      <style>{`
+        @keyframes slideInUp {
+          from {
+            transform: translate(-50%, 100%);
+            opacity: 0;
+          }
+          to {
+            transform: translate(-50%, 0);
+            opacity: 1;
+          }
+        }
+        @keyframes slideOutDown {
+          from {
+            transform: translate(-50%, 0);
+            opacity: 1;
+          }
+          to {
+            transform: translate(-50%, 100%);
+            opacity: 0;
+          }
+        }
+        .animate-slideInUp {
+          animation-name: slideInUp;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/core/LiveKitRoom.tsx
@@ -17,6 +17,7 @@ import {
   X,
 } from "lucide-react";
 import { useContext, useEffect, useState } from "react";
+import { PromotedMessagesDisplay } from "@/components/livestreams/room/PromotedMessagesDisplay"; // Added import
 import { Chat } from "@/components/livestreams/room/chat/Chat";
 import {
   RaiseHandContext,
@@ -384,6 +385,7 @@ function RoomContent({
       {/* Main video grid area */}
       <div className="flex-1 h-full overflow-hidden relative bg-gray-100 dark:bg-background">
         <VideoGrid />
+        <PromotedMessagesDisplay /> {/* Added PromotedMessagesDisplay component */}
 
         {/* Mobile menu button - shown on sm and md breakpoints */}
         <div className="xl:hidden absolute top-2 right-2 z-10">

--- a/projects/rawkode.studio/src/schema.ts
+++ b/projects/rawkode.studio/src/schema.ts
@@ -38,6 +38,9 @@ export const chatMessagesTable = sqliteTable("chat_messages", {
   participantIdentity: text("participant_identity").notNull(),
   participantName: text("participant_name").notNull(),
   message: text("message").notNull(),
+  isPromoted: integer("is_promoted", { mode: "boolean" })
+    .notNull()
+    .default(false),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),


### PR DESCRIPTION
- Add `isPromoted` field to chat messages schema.
- Create `promoteChatMessage` Astro Action to mark messages as promoted and send a LiveKit data message on topic "chat:promoted".
- Create `getPromotedChatMessages` Astro Action to fetch promoted messages.
- Update `Chat.tsx` component:
  - Display "Promote" button for directors on persisted messages.
  - Button calls `promoteChatMessage` action.
  - Chat list updates `isPromoted` status based on LiveKit data messages.
- Create `PromotedMessagesDisplay.tsx` component:
  - Fetches initial promoted messages.
  - Listens for LiveKit data messages on "chat:promoted" topic.
  - Displays the latest promoted message as an overlay, auto-hides.
- Integrate `PromotedMessagesDisplay` into `LiveKitRoom.tsx`.
- Update `CLAUDE.md` to clarify real-time chat mechanisms.