### PR TITLE
fix(rawkode.studio): preserve displayName in room metadata updates

### DIFF
--- a/projects/rawkode.studio/src/components/livestreams/room/controls/LayoutSelector.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/controls/LayoutSelector.tsx
@@ -79,8 +79,8 @@ export function LayoutSelector({ token }: LayoutSelectorProps) {
     if (!roomInfo?.metadata) return;
 
     const metadata = parseRoomMetadata(roomInfo.metadata);
-    if (metadata?.activeLayout && metadata.activeLayout !== currentLayout) {
-      setCurrentLayout(metadata.activeLayout);
+    if (metadata?.layout && metadata.layout !== currentLayout) {
+      setCurrentLayout(metadata.layout as LayoutType);
     }
   }, [roomInfo?.metadata, currentLayout, setCurrentLayout]);
 
@@ -96,11 +96,11 @@ export function LayoutSelector({ token }: LayoutSelectorProps) {
       setIsUpdating(true);
 
       try {
-        // Preserve existing metadata like presenter
+        // Preserve existing metadata like presenter and displayName
         const existingMetadata = parseRoomMetadata(roomInfo?.metadata) || {};
         const metadata: RoomLayoutMetadata = {
           ...existingMetadata,
-          activeLayout: newLayout,
+          layout: newLayout,
         };
 
         // Update room metadata via API endpoint with LiveKit token auth

--- a/projects/rawkode.studio/src/components/livestreams/room/controls/PresenterSelector.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/controls/PresenterSelector.tsx
@@ -70,7 +70,7 @@ export function PresenterSelector() {
 
       try {
         const existingMetadata = parseRoomMetadata(roomInfo.metadata) || {
-          activeLayout: LayoutType.GRID,
+          layout: LayoutType.GRID,
         };
 
         const metadata = {

--- a/projects/rawkode.studio/src/components/livestreams/room/layouts/permissions.ts
+++ b/projects/rawkode.studio/src/components/livestreams/room/layouts/permissions.ts
@@ -61,8 +61,10 @@ export const LAYOUT_CONFIGS: Record<LayoutType, LayoutConfig> = {
 };
 
 export interface RoomLayoutMetadata {
-  activeLayout: LayoutType;
+  layout?: string; // Layout type
   presenter?: string; // Identity of the current presenter
+  displayName?: string; // Display name of the room
+  [key: string]: unknown; // Allow other fields to be preserved
 }
 
 export function parseRoomMetadata(
@@ -72,12 +74,15 @@ export function parseRoomMetadata(
 
   try {
     const parsed = JSON.parse(metadata);
-    if (
-      parsed.activeLayout &&
-      Object.values(LayoutType).includes(parsed.activeLayout)
-    ) {
-      return parsed as RoomLayoutMetadata;
-    }
+
+    // Ensure layout field exists with a valid value
+    return {
+      ...parsed,
+      layout:
+        parsed.layout && Object.values(LayoutType).includes(parsed.layout)
+          ? parsed.layout
+          : LayoutType.GRID,
+    };
   } catch (e) {
     console.error("Failed to parse room metadata:", e);
   }

--- a/projects/rawkode.studio/src/components/livestreams/room/media/VideoGrid.tsx
+++ b/projects/rawkode.studio/src/components/livestreams/room/media/VideoGrid.tsx
@@ -80,8 +80,8 @@ export function VideoGrid() {
   // Update layout based on room metadata
   useEffect(() => {
     const metadata = parseRoomMetadata(roomInfo?.metadata);
-    if (metadata?.activeLayout) {
-      setCurrentLayout(metadata.activeLayout);
+    if (metadata?.layout) {
+      setCurrentLayout(metadata.layout as LayoutType);
     } else {
       // Use default layout based on room state
       setCurrentLayout(

--- a/projects/rawkode.studio/src/pages/api/livestream/token.ts
+++ b/projects/rawkode.studio/src/pages/api/livestream/token.ts
@@ -67,7 +67,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       if (!currentMetadata?.presenter) {
         try {
           const metadata = {
-            activeLayout: currentMetadata?.activeLayout || LayoutType.GRID,
+            ...currentMetadata,
+            layout: currentMetadata?.layout || LayoutType.GRID,
             presenter: identity,
           };
 


### PR DESCRIPTION
- Updated RoomLayoutMetadata interface to include displayName and use index signature
- Changed from activeLayout to layout field for consistency with createRoom
- Modified parseRoomMetadata to preserve all fields while normalizing layout
- Updated all components to use layout instead of activeLayout
- Fixed metadata updates in LayoutSelector and PresenterSelector to preserve all fields

This ensures that displayName and other metadata fields are preserved when updating room layout or presenter, preventing data loss during metadata updates.

🤖 Generated with [Claude Code](https://claude.ai/code)