### PR TITLE
fix(rawkode.studio): enable dynamic layout updates in recording templ…

### DIFF
--- a/projects/rawkode.studio/src/components/recording-templates/RecordingTemplateWrapper.tsx
+++ b/projects/rawkode.studio/src/components/recording-templates/RecordingTemplateWrapper.tsx
@@ -224,18 +224,17 @@ function RoomContent({ layout, error }: RoomContentProps) {
 
 export function RecordingTemplateWrapper() {
   const [error, setError] = useState<Error>();
+  const [layout, setLayout] = useState(EgressHelper.getLayout() || "grid");
 
   // Get parameters from URL using the official SDK
   const url = EgressHelper.getLiveKitURL();
   const token = EgressHelper.getAccessToken();
-  const layout = EgressHelper.getLayout() || "grid";
 
   // Listen for layout changes
   useEffect(() => {
     EgressHelper.onLayoutChanged((newLayout: string) => {
       console.log(`Layout changed to: ${newLayout}`);
-      // In this implementation, we handle layout changes through re-renders
-      // The layout is fetched fresh from EgressHelper on each render
+      setLayout(newLayout);
     });
   }, []);
 


### PR DESCRIPTION
…ates

Previously, the recording template layout was stored as a const value that never updated when EgressHelper.onLayoutChanged fired. This prevented layout changes from taking effect during active recordings.

Changes:
- Convert layout from const to React state using useState
- Update onLayoutChanged callback to call setLayout with new layout value
- Component now properly re-renders when layout changes are triggered

This fix ensures that layout switching (e.g., from grid to speaker view) works correctly during live egress recordings without requiring a restart.

🤖 Generated with [Claude Code](https://claude.ai/code)