### PR TITLE
fix(rawkode.academy/website): fix GitHub avatar URLs site-wide

### DIFF
--- a/projects/rawkode.academy/website/src/components/articles/ArticleCard.vue
+++ b/projects/rawkode.academy/website/src/components/articles/ArticleCard.vue
@@ -70,7 +70,7 @@ defineProps<Props>();
                 >
                   <img
                     class="w-10 h-10 rounded-full object-cover border-2 border-purple-500 p-0.5 bg-white"
-                    :src="`https://github.com/${author.handle}.png`"
+                    :src="`https://avatars.githubusercontent.com/${author.handle}`"
                     :alt="`Profile picture of ${author.name}`"
                     loading="lazy"
                   />

--- a/projects/rawkode.academy/website/src/components/articles/featured/Featured.astro
+++ b/projects/rawkode.academy/website/src/components/articles/featured/Featured.astro
@@ -75,7 +75,7 @@ const otherArticles = allArticles.slice(1);
 													<div class="relative" style={`z-index: ${10 - index}`}>
 														<img
 															class="w-12 h-12 rounded-full object-cover border-2 border-purple-500 p-0.5 bg-white"
-															src={`https://github.com/${author.data.handle}.png`}
+															src={`https://avatars.githubusercontent.com/${author.data.handle}`}
 															alt={`Profile picture of ${author.data.name}`}
 														/>
 														{index === 0 && (

--- a/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.vue
+++ b/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.vue
@@ -9,7 +9,7 @@
       >
         <img
           class="w-10 h-10 rounded-full object-cover border-2 border-purple-500 p-0.5 bg-white"
-          :src="`https://github.com/${author.data.handle}.png`"
+          :src="`https://avatars.githubusercontent.com/${author.data.handle}`"
           :alt="`Profile picture of ${author.data.name}`"
           loading="lazy"
         />

--- a/projects/rawkode.academy/website/src/pages/adrs/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/adrs/[...slug].astro
@@ -70,7 +70,7 @@ const adrNumber = adr.id.match(/^(\d{4})-/)?.[1] || "0000";
                       <div class="relative" style={`z-index: ${10 - index}`}>
                         <img
                           class="w-16 h-16 min-w-16 rounded-full object-cover border-2 border-purple-500 bg-white"
-                          src={`https://github.com/${author.data.handle}.png`}
+                          src={`https://avatars.githubusercontent.com/${author.data.handle}`}
                           alt={`Profile picture of ${author.data.name}`}
                         />
                         {index === 0 && (

--- a/projects/rawkode.academy/website/src/pages/adrs/index.astro
+++ b/projects/rawkode.academy/website/src/pages/adrs/index.astro
@@ -92,7 +92,7 @@ const getAdrNumber = (id: string): string => {
                           <div class="relative" style={`z-index: ${10 - index}`}>
                             <img
                               class="w-8 h-8 rounded-full object-cover border-2 border-purple-500 p-0.5 bg-white"
-                              src={`https://github.com/${author.data.handle}.png`}
+                              src={`https://avatars.githubusercontent.com/${author.data.handle}`}
                               alt={`Profile picture of ${author.data.name}`}
                               title={author.data.name}
                             />

--- a/projects/rawkode.academy/website/src/pages/changelog/index.astro
+++ b/projects/rawkode.academy/website/src/pages/changelog/index.astro
@@ -32,7 +32,7 @@ async function fetchGitHubUser(username: string) {
 	// Fallback values
 	return {
 		name: username,
-		avatar_url: `https://github.com/${username}.png`,
+		avatar_url: `https://avatars.githubusercontent.com/${username}`,
 	};
 }
 

--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -126,7 +126,7 @@ const badgeConfig = getTypeBadgeConfig(articleType);
 								{authors.slice(0, 3).map((author, index) => (
 									<img
 										class="w-10 h-10 rounded-full object-cover border-2 border-white dark:border-gray-900 shadow-sm"
-										src={`https://github.com/${author.data.handle}.png`}
+										src={`https://avatars.githubusercontent.com/${author.data.handle}`}
 										alt={`Profile picture of ${author.data.name}`}
 										style={`z-index: ${3 - index}`}
 									/>


### PR DESCRIPTION
- Fix COEP blocking error by using correct avatars.githubusercontent.com domain
- Update all GitHub avatar URLs from github.com to avatars.githubusercontent.com
- Affects ArticleCard, Featured article component, AuthorAvatarGroup, ADR pages, changelog, and read pages
- Resolves ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep errors
- Ensures consistent avatar loading across all components

🤖 Generated with [Claude Code](https://claude.ai/code)