### PR TITLE
fix(rawkode.studio): resolve getMeetingSession TypeError and add miss…

### DIFF
--- a/projects/rawkode.studio/src/components/app/pages/MeetingRoom.tsx
+++ b/projects/rawkode.studio/src/components/app/pages/MeetingRoom.tsx
@@ -33,34 +33,32 @@ export function MeetingRoom() {
 			return;
 		}
 
-		getMeetingSession(id)
-			.then((data) => {
-				if (data) {
-					// Validate session data
-					const validation = validateSessionData(data, id, user?.sub);
-					if (validation.isValid) {
-						setSessionData(data);
-						logSessionEvent("session_accessed", id, user?.sub, {
-							sessionId: data.sessionId,
-						});
-					} else {
-						console.warn("Invalid session data:", validation.reason);
-						logSessionEvent("session_invalid", id, user?.sub, {
-							reason: validation.reason,
-						});
-						// Clear invalid session data
-						clearMeetingSession(id);
-					}
+		try {
+			const data = getMeetingSession(id);
+			if (data) {
+				// Validate session data
+				const validation = validateSessionData(data, id, user?.sub);
+				if (validation.isValid) {
+					setSessionData(data);
+					logSessionEvent("session_accessed", id, user?.sub, {
+						sessionId: data.sessionId,
+					});
+				} else {
+					console.warn("Invalid session data:", validation.reason);
+					logSessionEvent("session_invalid", id, user?.sub, {
+						reason: validation.reason,
+					});
+					// Clear invalid session data
+					clearMeetingSession(id);
 				}
-				setIsLoadingSession(false);
-			})
-			.catch((error) => {
-				console.warn("Failed to load session data:", error);
-				logSessionEvent("session_invalid", id, user?.sub, {
-					error: error instanceof Error ? error.message : "Session load error",
-				});
-				setIsLoadingSession(false);
+			}
+		} catch (error) {
+			console.warn("Failed to load session data:", error);
+			logSessionEvent("session_invalid", id, user?.sub, {
+				error: error instanceof Error ? error.message : "Session load error",
 			});
+		}
+		setIsLoadingSession(false);
 	}, [id, user]);
 
 	// Clean up session data when component unmounts or meeting is accessed

--- a/projects/rawkode.studio/src/lib/meeting-session.ts
+++ b/projects/rawkode.studio/src/lib/meeting-session.ts
@@ -8,6 +8,7 @@ export interface MeetingSessionData {
 	participantName: string;
 	preset: "livestream_viewer" | "livestream_host";
 	sessionId: string;
+	timestamp: number;
 }
 
 const STORAGE_KEY_PREFIX = "rws_meeting_";
@@ -53,6 +54,7 @@ export function storeMeetingSession(
 		participantName: data.participantName,
 		preset: data.preset,
 		sessionId: generateSessionId(),
+		timestamp: Date.now(),
 	};
 
 	try {


### PR DESCRIPTION
…ing timestamp field

- Fix getMeetingSession() being used as Promise when it's synchronous
- Add timestamp field to MeetingSessionData interface to match validation
- Update storeMeetingSession() to include timestamp when creating session data
- Replace Promise-based .then()/.catch() with synchronous try/catch in MeetingRoom

Resolves session validation failures and "getMeetingSession(...).then is not a function" errors.

🤖 Generated with [Claude Code](https://claude.ai/code)