### PR TITLE
Add show data to video collection entries

### DIFF
--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -27,58 +27,93 @@ let video: (typeof videos)[0] | undefined = videos.find(
 if (!video) {
 	const graphQLClient = new GraphQLClient(GRAPHQL_ENDPOINT);
 
-	const query = gql`
-		query GetVideoBySlug($slug: String!) {
-			getVideoBySlug(slug: $slug) {
-				id
-				slug
-				title
-				subtitle
-				description
-				publishedAt
-				streamUrl
-				thumbnailUrl
-				duration
-				technologies {
-					id
-					name
-					logo
-				}
-			}
-		}
-	`;
+        const query = gql`
+                query GetVideoBySlug($slug: String!) {
+                        getVideoBySlug(slug: $slug) {
+                                id
+                                slug
+                                title
+                                subtitle
+                                description
+                                publishedAt
+                                streamUrl
+                                thumbnailUrl
+                                duration
+                                technologies {
+                                        id
+                                        name
+                                        logo
+                                }
+                                episode {
+                                        show {
+                                                id
+                                                name
+                                                hosts {
+                                                        forename
+                                                        surname
+                                                }
+                                        }
+                                }
+                        }
+                }
+        `;
 
 	try {
-		const response = await graphQLClient.request<{
-			getVideoBySlug: {
-				id: string;
-				slug: string;
-				title: string;
-				subtitle?: string;
-				description: string;
-				publishedAt: string;
-				streamUrl: string;
-				thumbnailUrl: string;
-				duration: number;
-				technologies: Array<{
-					id: string;
-					name: string;
-					logo: string;
-				}>;
-			} | null;
-		}>(query, { slug });
+                const response = await graphQLClient.request<{
+                        getVideoBySlug: {
+                                id: string;
+                                slug: string;
+                                title: string;
+                                subtitle?: string;
+                                description: string;
+                                publishedAt: string;
+                                streamUrl: string;
+                                thumbnailUrl: string;
+                                duration: number;
+                                technologies: Array<{
+                                        id: string;
+                                        name: string;
+                                        logo: string;
+                                }>;
+                                episode?: {
+                                        show?: {
+                                                id: string;
+                                                name: string;
+                                                hosts?: Array<{
+                                                        forename: string;
+                                                        surname: string;
+                                                }> | null;
+                                        } | null;
+                                } | null;
+                        } | null;
+                }>(query, { slug });
 
-		if (response.getVideoBySlug) {
-			// Transform the GraphQL response to match the collection format
-			video = {
-				id: response.getVideoBySlug.slug,
-				collection: "videos",
-				data: response.getVideoBySlug,
-			} as (typeof videos)[0];
-		}
-	} catch (error) {
-		console.error("Error fetching video from GraphQL:", error);
-	}
+                if (response.getVideoBySlug) {
+                        // Transform the GraphQL response to match the collection format
+                        const { episode, ...rawVideo } = response.getVideoBySlug;
+                        const show = episode?.show
+                                ? {
+                                          id: episode.show.id,
+                                          name: episode.show.name,
+                                          hosts:
+                                                  episode.show.hosts?.map((host) => ({
+                                                          forename: host.forename,
+                                                          surname: host.surname,
+                                                  })) ?? [],
+                                  }
+                                : undefined;
+                        video = {
+                                id: rawVideo.slug,
+                                collection: "videos",
+                                data: {
+                                        ...rawVideo,
+                                        show,
+                                },
+                        } as (typeof videos)[0];
+                }
+        } catch (error) {
+                console.error("Error fetching video from GraphQL:", error);
+        }
 }
 
 // Handle 404 case if still not found

--- a/projects/rawkode.academy/website/src/types/video.ts
+++ b/projects/rawkode.academy/website/src/types/video.ts
@@ -1,23 +1,35 @@
 import type { Author, BaseEntity, Technology } from "./common";
 
 export interface Video extends BaseEntity {
-	title: string;
-	slug: string;
-	description: string;
-	duration: number; // in seconds
-	publishedAt: Date;
-	thumbnailUrl: string;
-	videoUrl: string;
-	manifestUrl?: string;
-	captionsUrl?: string;
-	author?: Author;
-	technologies?: Technology[];
-	tags?: string[];
-	viewCount?: number;
-	likeCount?: number;
-	commentCount?: number;
-	series?: VideoSeries;
-	chapters?: VideoChapter[];
+        title: string;
+        slug: string;
+        description: string;
+        duration: number; // in seconds
+        publishedAt: Date;
+        thumbnailUrl: string;
+        videoUrl: string;
+        manifestUrl?: string;
+        captionsUrl?: string;
+        author?: Author;
+        technologies?: Technology[];
+        tags?: string[];
+        viewCount?: number;
+        likeCount?: number;
+        commentCount?: number;
+        series?: VideoSeries;
+        chapters?: VideoChapter[];
+        show?: VideoShow;
+}
+
+export interface VideoShowHost {
+        forename: string;
+        surname: string;
+}
+
+export interface VideoShow {
+        id: string;
+        name: string;
+        hosts: VideoShowHost[];
 }
 
 export interface VideoSeries {


### PR DESCRIPTION
## Summary
- extend the video GraphQL queries to request show metadata for each episode
- normalize the show payload into the videos content collection and video type definitions
- preserve show data when falling back to live GraphQL lookups on the watch page

## Testing
- pnpm test *(fails: vitest not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d801638938833187563f4bfea1326e