### PR TITLE
feat(website): add shows catalogue page

### DIFF
--- a/projects/rawkode.academy/website/src/components/footer/Footer.astro
+++ b/projects/rawkode.academy/website/src/components/footer/Footer.astro
@@ -18,13 +18,14 @@ const currentYear = new Date().getFullYear();
 
 // Define all sections of links
 const learningSections = {
-	title: "Learning",
-	links: [
-		{ name: "Articles", href: "/read", icon: NewspaperIcon },
-		{ name: "Videos", href: "/watch", icon: VideoCameraIcon },
-		{ name: "Courses", href: "/courses", icon: AcademicCapIcon },
-		{ name: "Technologies", href: "/technology", icon: CubeIcon },
-	],
+        title: "Learning",
+        links: [
+                { name: "Articles", href: "/read", icon: NewspaperIcon },
+                { name: "Videos", href: "/watch", icon: VideoCameraIcon },
+                { name: "Shows", href: "/shows", icon: VideoCameraIcon },
+                { name: "Courses", href: "/courses", icon: AcademicCapIcon },
+                { name: "Technologies", href: "/technology", icon: CubeIcon },
+        ],
 };
 
 const organizationSection = {

--- a/projects/rawkode.academy/website/src/components/show/ShowCard.astro
+++ b/projects/rawkode.academy/website/src/components/show/ShowCard.astro
@@ -1,17 +1,8 @@
 ---
-interface Host {
-        forename?: string | null;
-        surname?: string | null;
-}
-
-interface Show {
-        id: string;
-        name: string;
-        hosts?: Host[] | null;
-}
+import type { ShowSummary } from "@/types/show";
 
 interface Props {
-        show: Show;
+        show: ShowSummary;
 }
 
 const { show } = Astro.props as Props;

--- a/projects/rawkode.academy/website/src/components/show/ShowCard.astro
+++ b/projects/rawkode.academy/website/src/components/show/ShowCard.astro
@@ -1,0 +1,54 @@
+---
+interface Host {
+        forename?: string | null;
+        surname?: string | null;
+}
+
+interface Show {
+        id: string;
+        name: string;
+        hosts?: Host[] | null;
+}
+
+interface Props {
+        show: Show;
+}
+
+const { show } = Astro.props as Props;
+
+const hostNames = (show.hosts ?? [])
+        .map((host) => [host.forename, host.surname].filter(Boolean).join(" "))
+        .filter(Boolean);
+---
+
+<a
+        href={`/shows/${show.id}`}
+        class="flex h-full flex-col justify-between rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary/40 dark:border-gray-800 dark:bg-gray-900"
+>
+        <div class="space-y-3">
+                <h3 class="line-clamp-2 text-xl font-semibold text-gray-900 dark:text-white">
+                        {show.name}
+                </h3>
+                <p class="line-clamp-3 text-sm text-gray-500 dark:text-gray-400">
+                        {hostNames.length > 0 ? hostNames.join(", ") : "Hosts to be announced"}
+                </p>
+        </div>
+        <div class="mt-6 flex items-center text-sm font-medium text-primary dark:text-primary-300">
+                <span>View episodes</span>
+                <svg
+                        class="ml-2 h-4 w-4"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                >
+                        <path
+                                d="M7.5 5L12.5 10L7.5 15"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                        />
+                </svg>
+        </div>
+</a>

--- a/projects/rawkode.academy/website/src/components/sidebar/index.vue
+++ b/projects/rawkode.academy/website/src/components/sidebar/index.vue
@@ -52,10 +52,11 @@ const toggleSection = (section: keyof typeof sectionsExpanded.value) => {
 
 // Main navigation - core learning content
 const baseMenuItemsMain = [
-	{ name: "Articles", href: "/read", icon: NewspaperIcon },
-	{ name: "Videos", href: "/watch", icon: VideoCameraIcon },
-	{ name: "Courses", href: "/courses", icon: AcademicCapIcon },
-	{ name: "Technologies", href: "/technology", icon: CubeIcon },
+        { name: "Articles", href: "/read", icon: NewspaperIcon },
+        { name: "Videos", href: "/watch", icon: VideoCameraIcon },
+        { name: "Shows", href: "/shows", icon: VideoCameraIcon },
+        { name: "Courses", href: "/courses", icon: AcademicCapIcon },
+        { name: "Technologies", href: "/technology", icon: CubeIcon },
 ];
 
 // Community items

--- a/projects/rawkode.academy/website/src/pages/api/sitemap-pages.json.ts
+++ b/projects/rawkode.academy/website/src/pages/api/sitemap-pages.json.ts
@@ -71,17 +71,23 @@ async function generateNavigationItems(
 			category: "About",
 			description: "About Rawkode Academy",
 		},
-		{
-			href: "/watch",
-			title: "All Videos",
-			category: "Videos",
-			description: "Browse all videos",
-		},
-		{
-			href: "/read",
-			title: "All Articles",
-			category: "Articles",
-			description: "Browse all articles",
+                {
+                        href: "/watch",
+                        title: "All Videos",
+                        category: "Videos",
+                        description: "Browse all videos",
+                },
+                {
+                        href: "/shows",
+                        title: "All Shows",
+                        category: "Videos",
+                        description: "Discover Rawkode Academy shows",
+                },
+                {
+                        href: "/read",
+                        title: "All Articles",
+                        category: "Articles",
+                        description: "Browse all articles",
 		},
 		{
 			href: "/series",

--- a/projects/rawkode.academy/website/src/pages/shows/index.astro
+++ b/projects/rawkode.academy/website/src/pages/shows/index.astro
@@ -11,6 +11,12 @@ interface AllShowsResponse {
         allShows?: (ShowSummary | null)[] | null;
 }
 
+type ShowsState =
+        | { kind: "loading" }
+        | { kind: "success"; shows: ShowSummary[] }
+        | { kind: "empty" }
+        | { kind: "error"; message: string };
+
 const showsQuery = /* GraphQL */ `
         query AllShows {
                 allShows {
@@ -32,27 +38,37 @@ Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
 Astro.response.headers.set("Cache-Tag", "shows-page, shows-list");
 Astro.response.headers.set("X-Build-Time", new Date().toISOString());
 
-let shows: ShowSummary[] = [];
-let status: "loading" | "success" | "empty" | "error" = "loading";
-let errorMessage = "";
+let state: ShowsState = { kind: "loading" };
 
-try {
-        const data = await request<AllShowsResponse>(GRAPHQL_ENDPOINT, showsQuery);
-        shows = (data.allShows ?? []).filter((show): show is ShowSummary => Boolean(show?.id && show?.name));
-        status = shows.length > 0 ? "success" : "empty";
-} catch (error) {
-        console.error("Failed to fetch shows for /shows:", error);
-        if (error instanceof ClientError && error.response.errors?.[0]?.message) {
-                errorMessage = error.response.errors[0].message;
-        } else if (error instanceof Error) {
-                errorMessage = error.message;
-        } else if (typeof error === "string") {
-                errorMessage = error;
-        } else {
-                errorMessage = "Unable to load shows.";
+if (!GRAPHQL_ENDPOINT) {
+        state = {
+                kind: "error",
+                message: "GraphQL endpoint is not configured.",
+        };
+} else {
+        try {
+                const data = await request<AllShowsResponse>(GRAPHQL_ENDPOINT, showsQuery);
+                const shows = (data.allShows ?? []).filter((show): show is ShowSummary => Boolean(show?.id && show?.name));
+                state = shows.length > 0 ? { kind: "success", shows } : { kind: "empty" };
+        } catch (error) {
+                console.error("Failed to fetch shows for /shows:", error);
+
+                let message = "Unable to load shows.";
+
+                if (error instanceof ClientError && error.response.errors?.[0]?.message) {
+                        message = error.response.errors[0].message;
+                } else if (error instanceof Error) {
+                        message = error.message;
+                } else if (typeof error === "string") {
+                        message = error;
+                }
+
+                state = { kind: "error", message };
         }
-        status = "error";
 }
+
+const shows = state.kind === "success" ? state.shows : [];
+const placeholderTiles = Array.from({ length: 6 }, (_, index) => index);
 ---
 
 <Page title="Shows">
@@ -68,11 +84,11 @@ try {
                         </div>
 
                         <div class="mt-12">
-                                {status === "loading" && (
+                                {state.kind === "loading" && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                                                {Array.from({ length: 6 }).map((_, index) => (
+                                                {placeholderTiles.map((placeholder) => (
                                                         <div
-                                                                key={`shows-loading-${index}`}
+                                                                data-placeholder-index={placeholder}
                                                                 class="h-36 animate-pulse rounded-xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-gray-800"
                                                                 aria-hidden="true"
                                                         />
@@ -80,18 +96,18 @@ try {
                                         </div>
                                 )}
 
-                                {status === "error" && (
+                                {state.kind === "error" && (
                                         <div class="rounded-xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/60 dark:bg-red-900/30">
                                                 <p class="text-base font-semibold text-red-700 dark:text-red-300">
                                                         We couldn&apos;t load the shows right now.
                                                 </p>
                                                 <p class="mt-2 text-sm text-red-600 dark:text-red-200">
-                                                        {errorMessage}
+                                                        {state.message}
                                                 </p>
                                         </div>
                                 )}
 
-                                {status === "empty" && (
+                                {state.kind === "empty" && (
                                         <div class="rounded-xl border border-gray-200 bg-gray-50 p-8 text-center dark:border-gray-800 dark:bg-gray-900/40">
                                                 <p class="text-base text-gray-600 dark:text-gray-300">
                                                         No shows available just yet. Please check back soon!
@@ -99,10 +115,10 @@ try {
                                         </div>
                                 )}
 
-                                {status === "success" && (
+                                {state.kind === "success" && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                                                 {shows.map((show) => (
-                                                        <ShowCard key={show.id} show={show} />
+                                                        <ShowCard show={show} />
                                                 ))}
                                         </div>
                                 )}

--- a/projects/rawkode.academy/website/src/pages/shows/index.astro
+++ b/projects/rawkode.academy/website/src/pages/shows/index.astro
@@ -11,12 +11,6 @@ interface AllShowsResponse {
         allShows?: (ShowSummary | null)[] | null;
 }
 
-type ShowsState =
-        | { kind: "loading" }
-        | { kind: "success"; shows: ShowSummary[] }
-        | { kind: "empty" }
-        | { kind: "error"; message: string };
-
 const showsQuery = /* GraphQL */ `
         query AllShows {
                 allShows {
@@ -38,37 +32,35 @@ Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
 Astro.response.headers.set("Cache-Tag", "shows-page, shows-list");
 Astro.response.headers.set("X-Build-Time", new Date().toISOString());
 
-let state: ShowsState = { kind: "loading" };
+let shows: ShowSummary[] | null = null;
+let errorMessage: string | null = null;
 
 if (!GRAPHQL_ENDPOINT) {
-        state = {
-                kind: "error",
-                message: "GraphQL endpoint is not configured.",
-        };
+        errorMessage = "GraphQL endpoint is not configured.";
 } else {
         try {
                 const data = await request<AllShowsResponse>(GRAPHQL_ENDPOINT, showsQuery);
-                const shows = (data.allShows ?? []).filter((show): show is ShowSummary => Boolean(show?.id && show?.name));
-                state = shows.length > 0 ? { kind: "success", shows } : { kind: "empty" };
+                shows = (data.allShows ?? []).filter((show): show is ShowSummary => Boolean(show?.id && show?.name));
         } catch (error) {
                 console.error("Failed to fetch shows for /shows:", error);
 
-                let message = "Unable to load shows.";
-
                 if (error instanceof ClientError && error.response.errors?.[0]?.message) {
-                        message = error.response.errors[0].message;
+                        errorMessage = error.response.errors[0].message;
                 } else if (error instanceof Error) {
-                        message = error.message;
+                        errorMessage = error.message;
                 } else if (typeof error === "string") {
-                        message = error;
+                        errorMessage = error;
+                } else {
+                        errorMessage = "Unable to load shows.";
                 }
-
-                state = { kind: "error", message };
         }
 }
 
-const shows = state.kind === "success" ? state.shows : [];
+const hasShows = Array.isArray(shows) && shows.length > 0;
+const isEmpty = Array.isArray(shows) && shows.length === 0;
+const isLoading = !errorMessage && shows === null;
 const placeholderTiles = Array.from({ length: 6 }, (_, index) => index);
+const showsToRender: ShowSummary[] = hasShows && shows ? shows : [];
 ---
 
 <Page title="Shows">
@@ -84,7 +76,7 @@ const placeholderTiles = Array.from({ length: 6 }, (_, index) => index);
                         </div>
 
                         <div class="mt-12">
-                                {state.kind === "loading" && (
+                                {isLoading && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                                                 {placeholderTiles.map((placeholder) => (
                                                         <div
@@ -96,18 +88,18 @@ const placeholderTiles = Array.from({ length: 6 }, (_, index) => index);
                                         </div>
                                 )}
 
-                                {state.kind === "error" && (
+                                {errorMessage && (
                                         <div class="rounded-xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/60 dark:bg-red-900/30">
                                                 <p class="text-base font-semibold text-red-700 dark:text-red-300">
                                                         We couldn&apos;t load the shows right now.
                                                 </p>
                                                 <p class="mt-2 text-sm text-red-600 dark:text-red-200">
-                                                        {state.message}
+                                                        {errorMessage}
                                                 </p>
                                         </div>
                                 )}
 
-                                {state.kind === "empty" && (
+                                {isEmpty && (
                                         <div class="rounded-xl border border-gray-200 bg-gray-50 p-8 text-center dark:border-gray-800 dark:bg-gray-900/40">
                                                 <p class="text-base text-gray-600 dark:text-gray-300">
                                                         No shows available just yet. Please check back soon!
@@ -115,9 +107,9 @@ const placeholderTiles = Array.from({ length: 6 }, (_, index) => index);
                                         </div>
                                 )}
 
-                                {state.kind === "success" && (
+                                {hasShows && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                                                {shows.map((show) => (
+                                                {showsToRender.map((show) => (
                                                         <ShowCard show={show} />
                                                 ))}
                                         </div>

--- a/projects/rawkode.academy/website/src/pages/shows/index.astro
+++ b/projects/rawkode.academy/website/src/pages/shows/index.astro
@@ -2,31 +2,26 @@
 export const prerender = false;
 
 import { GRAPHQL_ENDPOINT } from "astro:env/server";
+import { ClientError, request } from "graphql-request";
 import ShowCard from "@/components/show/ShowCard.astro";
 import Page from "@/wrappers/page.astro";
+import type { ShowSummary } from "@/types/show";
 
-interface Host {
-        forename?: string | null;
-        surname?: string | null;
+interface AllShowsResponse {
+        allShows?: (ShowSummary | null)[] | null;
 }
 
-interface Show {
-        id: string;
-        name: string;
-        hosts?: Host[] | null;
-}
-
-const showsQuery = `
-  query AllShows {
-    allShows {
-      id
-      name
-      hosts {
-        forename
-        surname
-      }
-    }
-  }
+const showsQuery = /* GraphQL */ `
+        query AllShows {
+                allShows {
+                        id
+                        name
+                        hosts {
+                                forename
+                                surname
+                        }
+                }
+        }
 `;
 
 Astro.response.headers.set(
@@ -37,41 +32,26 @@ Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
 Astro.response.headers.set("Cache-Tag", "shows-page, shows-list");
 Astro.response.headers.set("X-Build-Time", new Date().toISOString());
 
-let shows: Show[] = [];
+let shows: ShowSummary[] = [];
 let status: "loading" | "success" | "empty" | "error" = "loading";
 let errorMessage = "";
 
 try {
-        const response = await fetch(GRAPHQL_ENDPOINT, {
-                method: "POST",
-                headers: {
-                        "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                        query: showsQuery,
-                }),
-        });
-
-        if (!response.ok) {
-                throw new Error(`Failed to load shows: ${response.status} ${response.statusText}`);
-        }
-
-        const body: { data?: { allShows?: Show[] | null }; errors?: Array<{ message?: string }> } =
-                await response.json();
-
-        if (body.errors?.length) {
-                const firstError = body.errors[0]?.message || "Unknown error";
-                throw new Error(firstError);
-        }
-
-        shows = Array.isArray(body.data?.allShows)
-                ? body.data?.allShows.filter((show): show is Show => Boolean(show?.id && show?.name))
-                : [];
-
+        const data = await request<AllShowsResponse>(GRAPHQL_ENDPOINT, showsQuery);
+        shows = (data.allShows ?? []).filter((show): show is ShowSummary => Boolean(show?.id && show?.name));
         status = shows.length > 0 ? "success" : "empty";
 } catch (error) {
+        console.error("Failed to fetch shows for /shows:", error);
+        if (error instanceof ClientError && error.response.errors?.[0]?.message) {
+                errorMessage = error.response.errors[0].message;
+        } else if (error instanceof Error) {
+                errorMessage = error.message;
+        } else if (typeof error === "string") {
+                errorMessage = error;
+        } else {
+                errorMessage = "Unable to load shows.";
+        }
         status = "error";
-        errorMessage = error instanceof Error ? error.message : "Unable to load shows.";
 }
 ---
 
@@ -90,8 +70,9 @@ try {
                         <div class="mt-12">
                                 {status === "loading" && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                                                {Array.from({ length: 6 }).map(() => (
+                                                {Array.from({ length: 6 }).map((_, index) => (
                                                         <div
+                                                                key={`shows-loading-${index}`}
                                                                 class="h-36 animate-pulse rounded-xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-gray-800"
                                                                 aria-hidden="true"
                                                         />
@@ -121,7 +102,7 @@ try {
                                 {status === "success" && (
                                         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                                                 {shows.map((show) => (
-                                                        <ShowCard show={show} />
+                                                        <ShowCard key={show.id} show={show} />
                                                 ))}
                                         </div>
                                 )}

--- a/projects/rawkode.academy/website/src/pages/shows/index.astro
+++ b/projects/rawkode.academy/website/src/pages/shows/index.astro
@@ -1,0 +1,131 @@
+---
+export const prerender = false;
+
+import { GRAPHQL_ENDPOINT } from "astro:env/server";
+import ShowCard from "@/components/show/ShowCard.astro";
+import Page from "@/wrappers/page.astro";
+
+interface Host {
+        forename?: string | null;
+        surname?: string | null;
+}
+
+interface Show {
+        id: string;
+        name: string;
+        hosts?: Host[] | null;
+}
+
+const showsQuery = `
+  query AllShows {
+    allShows {
+      id
+      name
+      hosts {
+        forename
+        surname
+      }
+    }
+  }
+`;
+
+Astro.response.headers.set(
+        "Cache-Control",
+        "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+);
+Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
+Astro.response.headers.set("Cache-Tag", "shows-page, shows-list");
+Astro.response.headers.set("X-Build-Time", new Date().toISOString());
+
+let shows: Show[] = [];
+let status: "loading" | "success" | "empty" | "error" = "loading";
+let errorMessage = "";
+
+try {
+        const response = await fetch(GRAPHQL_ENDPOINT, {
+                method: "POST",
+                headers: {
+                        "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                        query: showsQuery,
+                }),
+        });
+
+        if (!response.ok) {
+                throw new Error(`Failed to load shows: ${response.status} ${response.statusText}`);
+        }
+
+        const body: { data?: { allShows?: Show[] | null }; errors?: Array<{ message?: string }> } =
+                await response.json();
+
+        if (body.errors?.length) {
+                const firstError = body.errors[0]?.message || "Unknown error";
+                throw new Error(firstError);
+        }
+
+        shows = Array.isArray(body.data?.allShows)
+                ? body.data?.allShows.filter((show): show is Show => Boolean(show?.id && show?.name))
+                : [];
+
+        status = shows.length > 0 ? "success" : "empty";
+} catch (error) {
+        status = "error";
+        errorMessage = error instanceof Error ? error.message : "Unable to load shows.";
+}
+---
+
+<Page title="Shows">
+        <section class="py-12">
+                <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                        <div class="text-center">
+                                <h1 class="text-3xl font-extrabold text-gray-900 dark:text-white sm:text-4xl">
+                                        Shows
+                                </h1>
+                                <p class="mt-4 text-lg text-gray-500 dark:text-gray-400">
+                                        Browse our shows and meet the hosts behind every episode.
+                                </p>
+                        </div>
+
+                        <div class="mt-12">
+                                {status === "loading" && (
+                                        <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                                                {Array.from({ length: 6 }).map(() => (
+                                                        <div
+                                                                class="h-36 animate-pulse rounded-xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-gray-800"
+                                                                aria-hidden="true"
+                                                        />
+                                                ))}
+                                        </div>
+                                )}
+
+                                {status === "error" && (
+                                        <div class="rounded-xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/60 dark:bg-red-900/30">
+                                                <p class="text-base font-semibold text-red-700 dark:text-red-300">
+                                                        We couldn&apos;t load the shows right now.
+                                                </p>
+                                                <p class="mt-2 text-sm text-red-600 dark:text-red-200">
+                                                        {errorMessage}
+                                                </p>
+                                        </div>
+                                )}
+
+                                {status === "empty" && (
+                                        <div class="rounded-xl border border-gray-200 bg-gray-50 p-8 text-center dark:border-gray-800 dark:bg-gray-900/40">
+                                                <p class="text-base text-gray-600 dark:text-gray-300">
+                                                        No shows available just yet. Please check back soon!
+                                                </p>
+                                        </div>
+                                )}
+
+                                {status === "success" && (
+                                        <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                                                {shows.map((show) => (
+                                                        <ShowCard show={show} />
+                                                ))}
+                                        </div>
+                                )}
+                        </div>
+                </div>
+        </section>
+</Page>

--- a/projects/rawkode.academy/website/src/types/show.ts
+++ b/projects/rawkode.academy/website/src/types/show.ts
@@ -1,0 +1,10 @@
+export interface ShowHost {
+        forename?: string | null;
+        surname?: string | null;
+}
+
+export interface ShowSummary {
+        id: string;
+        name: string;
+        hosts?: ShowHost[] | null;
+}

--- a/projects/rawkode.academy/website/src/utils/constants.ts
+++ b/projects/rawkode.academy/website/src/utils/constants.ts
@@ -53,10 +53,11 @@ export const ERROR_MESSAGES = {
 } as const;
 
 export const ROUTES = {
-	HOME: "/",
-	VIDEOS: "/watch",
-	ARTICLES: "/read",
-	COURSES: "/courses",
-	ABOUT: "/about",
-	SEARCH: "/search",
+        HOME: "/",
+        VIDEOS: "/watch",
+        SHOWS: "/shows",
+        ARTICLES: "/read",
+        COURSES: "/courses",
+        ABOUT: "/about",
+        SEARCH: "/search",
 } as const;


### PR DESCRIPTION
## Summary
- add a shows index page that queries the GraphQL endpoint with the same ISR headers as the videos listing
- create a reusable ShowCard component to present each show with its hosts and link to the detail route
- surface the shows catalogue throughout the app navigation and sitemap metadata

## Testing
- pnpm astro check *(fails: command not found in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d80169b790833192f0ad50faf82c57