### PR TITLE
Add theme submenu to command palette

### DIFF
--- a/projects/rawkode.academy/website/src/components/command-palette/icons.tsx
+++ b/projects/rawkode.academy/website/src/components/command-palette/icons.tsx
@@ -236,10 +236,10 @@ export const PagesIcon = ({ className = "w-4 h-4", ...props }: IconProps) => (
 );
 
 export const ThemeIcon = ({ className = "w-4 h-4", ...props }: IconProps) => (
-	<svg
-		className={className}
-		fill="none"
-		stroke="currentColor"
+        <svg
+                className={className}
+                fill="none"
+                stroke="currentColor"
 		viewBox="0 0 24 24"
 		{...props}
 	>
@@ -249,7 +249,24 @@ export const ThemeIcon = ({ className = "w-4 h-4", ...props }: IconProps) => (
 			strokeWidth={2}
 			d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
 		/>
-	</svg>
+        </svg>
+);
+
+export const CommandIcon = ({ className = "w-4 h-4", ...props }: IconProps) => (
+        <svg
+                className={className}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                {...props}
+        >
+                <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 3a3 3 0 00-3 3v1H5a2 2 0 00-2 2v2a2 2 0 002 2h1v1a3 3 0 003 3h2a2 2 0 002-2v-1h1a3 3 0 003-3V9a2 2 0 00-2-2h-1V6a3 3 0 00-3-3H9z"
+                />
+        </svg>
 );
 
 export function getCategoryIcon(
@@ -276,9 +293,11 @@ export function getCategoryIcon(
 			return ToolsIcon;
 		case "external":
 			return ExternalIcon;
-		case "themes":
-			return ThemeIcon;
-		default:
-			return PagesIcon;
-	}
+                case "themes":
+                        return ThemeIcon;
+                case "commands":
+                        return CommandIcon;
+                default:
+                        return PagesIcon;
+        }
 }


### PR DESCRIPTION
## Summary
- add a commands page stack to the palette so that "Change theme" opens a sub menu of themes instead of listing them at the root level
- reset search state when navigating between pages and limit article search results to the root view for a more consistent command experience
- add a dedicated icon for the new Commands category used throughout the palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f575b0fc8331a0a95b6c490b70a5)