### PR TITLE
Audit website themes for light and dark mode

### DIFF
--- a/projects/rawkode.academy/website/docs/THEMES.md
+++ b/projects/rawkode.academy/website/docs/THEMES.md
@@ -4,6 +4,8 @@ The website supports multiple color themes that can be switched by users.
 
 ## Available Themes
 
+Each theme exposes dedicated light and dark palettes so typography, borders, and glass panels stay legible regardless of the "dark" class on the `<html>` element. During the audit we introduced shared tokens (`--surface-base`, `--surface-overlay`, `--surface-card`, `--surface-card-muted`, `--surface-border`, `--surface-border-strong`, and shadow definitions) that every theme now sets explicitly for both modes along with bespoke gradients for `--app-backdrop`.
+
 ### 1. Rawkode Green (Default)
 - **Primary Color**: `#04B59C` (Teal)
 - **Secondary Color**: `#85FF95` (Green)
@@ -34,12 +36,16 @@ The website supports multiple color themes that can be switched by users.
 - **Secondary Color**: `#FFCA3A` (Yellow)
 - **Accent Color**: `#6A4C93` (Purple)
 - Vibrant Cotton Candy color palette with 5 colors: Red, Yellow, Green, Blue, Purple
+- **Light Surfaces**: Pastel glass panels with warm highlights keep the cotton candy palette soft while maintaining contrast on white typography.
+- **Dark Surfaces**: Deep berry gradients paired with glowing yellow borders preserve the vibrancy of the pride stripes without washing out controls.
 
 ### 7. LGBTQ+ (Transgender Pride Flag)
 - **Primary Color**: `#5BCEFA` (Light Blue)
 - **Secondary Color**: `#F5A9B8` (Pink)
 - **Accent Color**: `#FFFFFF` (White)
 - Based on the transgender pride flag colors
+- **Light Surfaces**: Frosted cyan cards and subtle borders echo the white stripe of the flag while ensuring icons remain visible on bright backgrounds.
+- **Dark Surfaces**: Midnight blue gradients with luminous cyan and pink glows keep the theme readable when `.dark` is applied.
 
 ## How to Switch Themes
 

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -39,39 +39,86 @@
 
 /* Alternative Theme: Rawkode Blue */
 :root[data-theme="rawkode-blue"] {
-	--brand-primary: 95 94 215; /* Purple #5F5ED7 */
-	--brand-secondary: 0 206 255; /* Cyan #00CEFF */
-	--brand-accent: 17 24 39; /* Dark Blue-Gray */
+        --brand-primary: 95 94 215; /* Purple #5F5ED7 */
+        --brand-secondary: 0 206 255; /* Cyan #00CEFF */
+        --brand-accent: 17 24 39; /* Dark Blue-Gray */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
-			rgba(var(--brand-primary), 0.35) 0%,
-			transparent 40%
-		),
-		radial-gradient(
-			circle at 90% 10%,
-			rgba(var(--brand-secondary), 0.25) 0%,
-			transparent 45%
-		),
-		radial-gradient(
-			circle at 15% 90%,
-			rgba(var(--brand-primary), 0.18) 0%,
-			transparent 50%
-		),
-		linear-gradient(140deg, #ecf2ff 0%, #f7f4ff 35%, #f1fbff 70%, #fdf2ff 100%);
+        --surface-base: #eef2ff;
+        --surface-overlay: rgba(255, 255, 255, 0.94);
+        --surface-card: rgba(255, 255, 255, 0.88);
+        --surface-card-muted: rgba(95, 94, 215, 0.08);
+        --surface-border: rgba(95, 94, 215, 0.16);
+        --surface-border-strong: rgba(0, 206, 255, 0.32);
+        --surface-shadow: 0 35px 80px rgba(22, 28, 45, 0.18);
+        --surface-shadow-strong: 0 45px 120px rgba(17, 24, 39, 0.25);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
+                        rgba(var(--brand-primary), 0.35) 0%,
+                        transparent 40%
+                ),
+                radial-gradient(
+                        circle at 90% 10%,
+                        rgba(var(--brand-secondary), 0.25) 0%,
+                        transparent 45%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-primary), 0.18) 0%,
+                        transparent 50%
+                ),
+                linear-gradient(140deg, #ecf2ff 0%, #f7f4ff 35%, #f1fbff 70%, #fdf2ff 100%);
+}
+
+html.dark[data-theme="rawkode-blue"] {
+        --surface-base: #040712;
+        --surface-overlay: rgba(4, 7, 18, 0.92);
+        --surface-card: rgba(8, 12, 25, 0.9);
+        --surface-card-muted: rgba(0, 206, 255, 0.12);
+        --surface-border: rgba(95, 94, 215, 0.35);
+        --surface-border-strong: rgba(0, 206, 255, 0.45);
+        --surface-shadow: 0 35px 120px rgba(2, 6, 23, 0.7);
+        --surface-shadow-strong: 0 45px 140px rgba(1, 4, 16, 0.85);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.5) 0%,
+                        transparent 35%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.35) 0%,
+                        transparent 45%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-primary), 0.28) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #030510 0%, #050b1f 55%, #081430 100%);
 }
 
 /* Catppuccin Theme */
 :root[data-theme="catppuccin"] {
-	--brand-primary: 203 166 247; /* Mauve #CBA6F7 */
-	--brand-secondary: 245 194 231; /* Pink #F5C2E7 */
-	--brand-accent: 30 30 46; /* Base #1E1E2E */
+        --brand-primary: 203 166 247; /* Mauve #CBA6F7 */
+        --brand-secondary: 245 194 231; /* Pink #F5C2E7 */
+        --brand-accent: 30 30 46; /* Base #1E1E2E */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
-			rgba(var(--brand-primary), 0.3) 0%,
+        --surface-base: #fef6ff;
+        --surface-overlay: rgba(255, 255, 255, 0.94);
+        --surface-card: rgba(255, 255, 255, 0.88);
+        --surface-card-muted: rgba(203, 166, 247, 0.08);
+        --surface-border: rgba(30, 30, 46, 0.12);
+        --surface-border-strong: rgba(245, 194, 231, 0.32);
+        --surface-shadow: 0 35px 80px rgba(69, 46, 95, 0.12);
+        --surface-shadow-strong: 0 45px 120px rgba(69, 46, 95, 0.18);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
+                        rgba(var(--brand-primary), 0.3) 0%,
 			transparent 40%
 		),
 		radial-gradient(
@@ -83,19 +130,57 @@
 			circle at 15% 90%,
 			rgba(var(--brand-primary), 0.15) 0%,
 			transparent 50%
-		),
-		linear-gradient(140deg, #f5e0ff 0%, #faf0ff 35%, #f0f5ff 70%, #fff0fa 100%);
+                ),
+                linear-gradient(140deg, #f5e0ff 0%, #faf0ff 35%, #f0f5ff 70%, #fff0fa 100%);
+}
+
+html.dark[data-theme="catppuccin"] {
+        --surface-base: #120f1b;
+        --surface-overlay: rgba(12, 9, 18, 0.92);
+        --surface-card: rgba(19, 15, 28, 0.92);
+        --surface-card-muted: rgba(203, 166, 247, 0.14);
+        --surface-border: rgba(245, 194, 231, 0.28);
+        --surface-border-strong: rgba(203, 166, 247, 0.38);
+        --surface-shadow: 0 35px 120px rgba(5, 4, 12, 0.7);
+        --surface-shadow-strong: 0 45px 140px rgba(5, 4, 12, 0.85);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.45) 0%,
+                        transparent 32%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.35) 0%,
+                        transparent 42%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-primary), 0.25) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #0c0716 0%, #140b1f 55%, #1c1230 100%);
 }
 
 /* Dracula Theme */
 :root[data-theme="dracula"] {
-	--brand-primary: 189 147 249; /* Purple #BD93F9 */
-	--brand-secondary: 255 121 198; /* Pink #FF79C6 */
-	--brand-accent: 40 42 54; /* Background #282A36 */
+        --brand-primary: 189 147 249; /* Purple #BD93F9 */
+        --brand-secondary: 255 121 198; /* Pink #FF79C6 */
+        --brand-accent: 40 42 54; /* Background #282A36 */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
+        --surface-base: #f7f2ff;
+        --surface-overlay: rgba(255, 255, 255, 0.94);
+        --surface-card: rgba(255, 255, 255, 0.88);
+        --surface-card-muted: rgba(189, 147, 249, 0.08);
+        --surface-border: rgba(40, 42, 54, 0.12);
+        --surface-border-strong: rgba(255, 121, 198, 0.3);
+        --surface-shadow: 0 30px 80px rgba(40, 42, 54, 0.18);
+        --surface-shadow-strong: 0 45px 120px rgba(40, 42, 54, 0.25);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
 			rgba(var(--brand-primary), 0.3) 0%,
 			transparent 40%
 		),
@@ -108,19 +193,57 @@
 			circle at 15% 90%,
 			rgba(var(--brand-primary), 0.15) 0%,
 			transparent 50%
-		),
-		linear-gradient(140deg, #f0e6ff 0%, #fff0f8 35%, #f0f0ff 70%, #ffe6f5 100%);
+                ),
+                linear-gradient(140deg, #f0e6ff 0%, #fff0f8 35%, #f0f0ff 70%, #ffe6f5 100%);
+}
+
+html.dark[data-theme="dracula"] {
+        --surface-base: #0f0d18;
+        --surface-overlay: rgba(11, 9, 20, 0.92);
+        --surface-card: rgba(20, 16, 32, 0.92);
+        --surface-card-muted: rgba(255, 121, 198, 0.18);
+        --surface-border: rgba(189, 147, 249, 0.32);
+        --surface-border-strong: rgba(255, 121, 198, 0.4);
+        --surface-shadow: 0 35px 120px rgba(1, 2, 8, 0.75);
+        --surface-shadow-strong: 0 45px 140px rgba(1, 1, 4, 0.88);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.5) 0%,
+                        transparent 30%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.4) 0%,
+                        transparent 45%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-primary), 0.3) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #0b0512 0%, #140a1f 55%, #1c0f2c 100%);
 }
 
 /* Solarized Theme */
 :root[data-theme="solarized"] {
-	--brand-primary: 38 139 210; /* Blue #268BD2 */
-	--brand-secondary: 42 161 152; /* Cyan #2AA198 */
-	--brand-accent: 0 43 54; /* Base03 #002B36 */
+        --brand-primary: 38 139 210; /* Blue #268BD2 */
+        --brand-secondary: 42 161 152; /* Cyan #2AA198 */
+        --brand-accent: 0 43 54; /* Base03 #002B36 */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
+        --surface-base: #fdf6e3;
+        --surface-overlay: rgba(255, 255, 255, 0.94);
+        --surface-card: rgba(255, 255, 255, 0.88);
+        --surface-card-muted: rgba(42, 161, 152, 0.08);
+        --surface-border: rgba(0, 43, 54, 0.12);
+        --surface-border-strong: rgba(38, 139, 210, 0.3);
+        --surface-shadow: 0 30px 80px rgba(0, 43, 54, 0.18);
+        --surface-shadow-strong: 0 45px 120px rgba(0, 43, 54, 0.25);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
 			rgba(var(--brand-primary), 0.25) 0%,
 			transparent 40%
 		),
@@ -133,19 +256,57 @@
 			circle at 15% 90%,
 			rgba(var(--brand-primary), 0.12) 0%,
 			transparent 50%
-		),
-		linear-gradient(140deg, #fdf6e3 0%, #eee8d5 35%, #f5f5f0 70%, #fffff8 100%);
+                ),
+                linear-gradient(140deg, #fdf6e3 0%, #eee8d5 35%, #f5f5f0 70%, #fffff8 100%);
+}
+
+html.dark[data-theme="solarized"] {
+        --surface-base: #04151a;
+        --surface-overlay: rgba(3, 12, 15, 0.92);
+        --surface-card: rgba(4, 17, 21, 0.92);
+        --surface-card-muted: rgba(42, 161, 152, 0.16);
+        --surface-border: rgba(38, 139, 210, 0.32);
+        --surface-border-strong: rgba(42, 161, 152, 0.38);
+        --surface-shadow: 0 35px 120px rgba(1, 5, 8, 0.75);
+        --surface-shadow-strong: 0 45px 140px rgba(0, 3, 5, 0.85);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.45) 0%,
+                        transparent 32%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.35) 0%,
+                        transparent 40%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-primary), 0.25) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #021016 0%, #041d23 55%, #062a30 100%);
 }
 
 /* Pride Theme - Cotton Candy Palette */
 :root[data-theme="pride"] {
-	--brand-primary: 255 89 94; /* Red #FF595E */
-	--brand-secondary: 255 202 58; /* Yellow #FFCA3A */
-	--brand-accent: 106 76 147; /* Purple #6A4C93 */
+        --brand-primary: 255 89 94; /* Red #FF595E */
+        --brand-secondary: 255 202 58; /* Yellow #FFCA3A */
+        --brand-accent: 106 76 147; /* Purple #6A4C93 */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
+        --surface-base: #fff8f6;
+        --surface-overlay: rgba(255, 255, 255, 0.95);
+        --surface-card: rgba(255, 255, 255, 0.9);
+        --surface-card-muted: rgba(255, 89, 94, 0.12);
+        --surface-border: rgba(106, 76, 147, 0.18);
+        --surface-border-strong: rgba(255, 202, 58, 0.35);
+        --surface-shadow: 0 30px 80px rgba(106, 76, 147, 0.15);
+        --surface-shadow-strong: 0 45px 120px rgba(106, 76, 147, 0.2);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
 			rgba(255, 89, 94, 0.2) 0%,
 			transparent 40%
 		),
@@ -165,20 +326,58 @@
 			#fff9e6 20%,
 			#f0ffe6 40%,
 			#e6f5ff 60%,
-			#ede6ff 80%,
-			#f5e6ff 100%
-		);
+                        #ede6ff 80%,
+                        #f5e6ff 100%
+                );
+}
+
+html.dark[data-theme="pride"] {
+        --surface-base: #1c050d;
+        --surface-overlay: rgba(16, 3, 10, 0.95);
+        --surface-card: rgba(14, 2, 9, 0.9);
+        --surface-card-muted: rgba(255, 202, 58, 0.12);
+        --surface-border: rgba(255, 89, 94, 0.35);
+        --surface-border-strong: rgba(106, 76, 147, 0.45);
+        --surface-shadow: 0 35px 120px rgba(5, 0, 4, 0.8);
+        --surface-shadow-strong: 0 45px 140px rgba(5, 0, 4, 0.9);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.5) 0%,
+                        transparent 32%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.4) 0%,
+                        transparent 40%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(var(--brand-accent), 0.35) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #140009 0%, #190311 55%, #0f0314 100%);
 }
 
 /* LGBTQ+ Theme - Transgender Pride Flag */
 :root[data-theme="lgbtq"] {
-	--brand-primary: 91 206 250; /* Light Blue #5BCEFA */
-	--brand-secondary: 245 169 184; /* Pink #F5A9B8 */
-	--brand-accent: 255 255 255; /* White #FFFFFF */
+        --brand-primary: 91 206 250; /* Light Blue #5BCEFA */
+        --brand-secondary: 245 169 184; /* Pink #F5A9B8 */
+        --brand-accent: 255 255 255; /* White #FFFFFF */
 
-	--app-backdrop:
-		radial-gradient(
-			circle at 10% 20%,
+        --surface-base: #f3f9ff;
+        --surface-overlay: rgba(255, 255, 255, 0.96);
+        --surface-card: rgba(255, 255, 255, 0.92);
+        --surface-card-muted: rgba(91, 206, 250, 0.12);
+        --surface-border: rgba(91, 206, 250, 0.2);
+        --surface-border-strong: rgba(245, 169, 184, 0.35);
+        --surface-shadow: 0 30px 80px rgba(44, 82, 130, 0.12);
+        --surface-shadow-strong: 0 45px 120px rgba(44, 82, 130, 0.18);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 10% 20%,
 			rgba(91, 206, 250, 0.3) 0%,
 			transparent 40%
 		),
@@ -197,10 +396,39 @@
 			#e6f7ff 0%,
 			#ffebf0 20%,
 			#fff 40%,
-			#ffebf0 60%,
-			#e6f7ff 80%,
-			#ffffff 100%
-		);
+                        #ffebf0 60%,
+                        #e6f7ff 80%,
+                        #ffffff 100%
+                );
+}
+
+html.dark[data-theme="lgbtq"] {
+        --surface-base: #031520;
+        --surface-overlay: rgba(3, 11, 17, 0.94);
+        --surface-card: rgba(5, 15, 24, 0.92);
+        --surface-card-muted: rgba(91, 206, 250, 0.18);
+        --surface-border: rgba(91, 206, 250, 0.35);
+        --surface-border-strong: rgba(245, 169, 184, 0.4);
+        --surface-shadow: 0 35px 120px rgba(2, 5, 11, 0.78);
+        --surface-shadow-strong: 0 45px 140px rgba(1, 3, 8, 0.88);
+
+        --app-backdrop:
+                radial-gradient(
+                        circle at 20% 10%,
+                        rgba(var(--brand-primary), 0.45) 0%,
+                        transparent 32%
+                ),
+                radial-gradient(
+                        circle at 85% 15%,
+                        rgba(var(--brand-secondary), 0.4) 0%,
+                        transparent 40%
+                ),
+                radial-gradient(
+                        circle at 15% 90%,
+                        rgba(255, 255, 255, 0.25) 0%,
+                        transparent 45%
+                ),
+                linear-gradient(145deg, #030914 0%, #041b2a 55%, #031324 100%);
 }
 
 html.dark {


### PR DESCRIPTION
## Summary
- add per-theme surface, border, and backdrop tokens so each palette renders cleanly in both light and dark mode
- refresh the theme documentation to describe the shared light/dark token strategy and call out the new Pride and LGBTQ guidance

## Testing
- `bun test` *(fails: existing theme/SEO tests expect browser APIs and richer fixtures and already failed before these styling changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d58b33408331bbb5d563bb5c2a61)