### PR TITLE
fix(rawkode.academy/website): add missing unsubscribe action for newsletter

### DIFF
--- a/projects/rawkode.academy/website/src/actions/newsletter.ts
+++ b/projects/rawkode.academy/website/src/actions/newsletter.ts
@@ -28,4 +28,30 @@ export const newsletter = {
 			};
 		},
 	}),
+	unsubscribe: defineAction({
+		input: z.object({
+			source: z.string().optional(),
+		}),
+		handler: async (input, context) => {
+			if (!context.locals.user) {
+				throw new Error("Unauthorized");
+			}
+
+			const result =
+				await context.locals.runtime.env.EMAIL_PREFERENCES.setPreference(
+					context.locals.user.id,
+					{
+						audience: "academy",
+						channel: "newsletter",
+						status: "unsubscribed",
+						source: input.source || "website-cta",
+					},
+				);
+
+			return {
+				...result,
+				success: true,
+			};
+		},
+	}),
 };


### PR DESCRIPTION
The EmailPreferences component called actions.newsletter.unsubscribe()
but this action was not defined, causing a 500 error when users tried
to unsubscribe from the newsletter on the settings page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `newsletter.unsubscribe` action to set user email preference to `unsubscribed` with auth and optional `source`.
> 
> - **Backend Actions**:
>   - **`src/actions/newsletter.ts`**:
>     - Add `newsletter.unsubscribe` action mirroring `subscribe`, calling `EMAIL_PREFERENCES.setPreference` with `status: "unsubscribed"`.
>     - Includes auth guard (`context.locals.user`), optional `source` input, and returns `{ ...result, success: true }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cab78c08f08ffb6d5796d24de15fb639f27f4185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->