### PR TITLE
fix(rawkode.academy/website): Improve sidebar menu organization and design

### DIFF
--- a/projects/rawkode.academy/website/src/components/sidebar/sidebar.vue
+++ b/projects/rawkode.academy/website/src/components/sidebar/sidebar.vue
@@ -338,6 +338,7 @@ const currentNavItems = computed(() => {
 									fill="none"
 									stroke="currentColor"
 									viewBox="0 0 24 24"
+									aria-hidden="true"
 								>
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
 								</svg>


### PR DESCRIPTION
- Reorder mode toggle buttons: Learn, Partner, Connect
- Add Discord link (rawkode.chat) to Connect section with external link indicator
- Reorder Learn items with visual separators: Videos, Articles | Learning Paths, Courses | Shows, Technologies
- Clean up styling with softer gradients and improved hover states

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes sidebar: groups Learn items with separators, adds external Discord link in Connect, updates mode toggle order/labels, and refines styles with external-link indicator.
> 
> - **Sidebar Navigation**
>   - **Learn**: Regroups items with separators; order is `Videos`, `Articles` | `Learning Paths`, `Courses` | `Shows`, `Technologies`.
>   - **Connect**: Adds `Discord` external link (`https://rawkode.chat`) with new `ChatBubbleLeftRightIcon` and external-link indicator; opens in new tab.
> - **Mode Toggle**
>   - Changes cycle to `learn → collaborate → connect → learn` and reorders buttons to `Learn`, `Partner`, `Connect` with updated labels/icons/ARIA.
> - **UI/Styling**
>   - Softens borders/gradients, hover/focus states; adjusts spacing/typography.
>   - Adds separators rendering, external link target/rel handling, and minor submenu style tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63eba44ca85e031ca209cef05173649f8cac39c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->