### PR TITLE
feat(rawkode.academy/website): add Kubernetes 1.35 lead magnet

### DIFF
--- a/projects/rawkode.academy/website/src/actions/newsletter.ts
+++ b/projects/rawkode.academy/website/src/actions/newsletter.ts
@@ -24,6 +24,7 @@ export const newsletter = {
 	subscribe: defineAction({
 		input: z.object({
 			audience: z.string().default("academy"),
+			channel: z.string().default("newsletter"),
 			source: z.string().optional(),
 		}),
 		handler: async (input, context) => {
@@ -38,9 +39,9 @@ export const newsletter = {
 					prefixedUserId,
 					{
 						audience: input.audience,
-						channel: "newsletter",
+						channel: input.channel,
 						status: "subscribed",
-						source: input.source || "website:newsletter:unknown",
+						source: input.source || `website:${input.channel}:unknown`,
 					},
 				);
 
@@ -151,6 +152,7 @@ export const newsletter = {
 		input: z.object({
 			email: z.string().email("Please enter a valid email address"),
 			audience: z.string().default("academy"),
+			channel: z.string().default("newsletter"),
 			source: z.string().optional(),
 		}),
 		handler: async (input, context) => {
@@ -162,9 +164,9 @@ export const newsletter = {
 					prefixedUserId,
 					{
 						audience: input.audience,
-						channel: "newsletter",
+						channel: input.channel,
 						status: "subscribed",
-						source: input.source || "website:newsletter:unknown",
+						source: input.source || `website:${input.channel}:unknown`,
 					},
 				);
 

--- a/projects/rawkode.academy/website/src/components/hero/typewriter.tsx
+++ b/projects/rawkode.academy/website/src/components/hero/typewriter.tsx
@@ -11,6 +11,12 @@ interface TechLogo {
 	iconUrl: string;
 }
 
+interface SocialProofStat {
+	icon: string;
+	value: string;
+	label: string;
+}
+
 interface Props {
 	rotatedPrefixes: string[];
 	suffix: string;
@@ -18,6 +24,7 @@ interface Props {
 	logos: TechLogo[];
 	primaryButton: ButtonProps;
 	secondaryButton: ButtonProps;
+	socialProof?: SocialProofStat[];
 }
 
 const shuffle = (array: string[]): string[] => {
@@ -102,6 +109,19 @@ const Typewriter = (props: Props) => {
 							{props.secondaryButton.text}
 						</a>
 					</div>
+
+					{/* Social Proof - Clean stat badges */}
+					{props.socialProof && props.socialProof.length > 0 && (
+						<div className="flex flex-wrap items-center gap-4 pt-4">
+							{props.socialProof.map((stat, index) => (
+								<div key={index} className="flex items-center gap-2">
+									<span className="text-lg">{stat.icon}</span>
+									<span className="font-bold text-gray-900 dark:text-white">{stat.value}</span>
+									<span className="text-gray-500 dark:text-gray-400 text-sm">{stat.label}</span>
+								</div>
+							))}
+						</div>
+					)}
 				</div>
 				<div className="hidden lg:col-span-6 lg:flex lg:items-center lg:justify-center">
 					{/* 

--- a/projects/rawkode.academy/website/src/components/lead-magnet/K8sCheatsheetCTA.astro
+++ b/projects/rawkode.academy/website/src/components/lead-magnet/K8sCheatsheetCTA.astro
@@ -1,0 +1,33 @@
+---
+export const prerender = false;
+
+import K8sCheatsheetCTA from "./K8sCheatsheetCTA.vue";
+
+interface Props {
+	class?: string;
+}
+
+const { class: className } = Astro.props;
+
+const user = Astro.locals.user;
+const pagePath = Astro.url.pathname;
+const signInUrl = `/sign-in?returnTo=${encodeURIComponent(pagePath)}`;
+
+// Check for the cheatsheet download cookie (server-side)
+const hasCheatsheetCookie =
+	Astro.cookies.get("lead-magnet:k8s-1-35-cheatsheet")?.value === "true";
+
+// For anonymous users who already downloaded, we still show it but the component handles the state
+---
+
+<section class:list={["w-full", className]}>
+	<div class="mx-auto max-w-7xl">
+		<K8sCheatsheetCTA
+			client:visible
+			isSignedIn={!!user}
+			isSubscribed={hasCheatsheetCookie}
+			signInUrl={signInUrl}
+			pagePath={pagePath}
+		/>
+	</div>
+</section>

--- a/projects/rawkode.academy/website/src/components/lead-magnet/K8sCheatsheetCTA.vue
+++ b/projects/rawkode.academy/website/src/components/lead-magnet/K8sCheatsheetCTA.vue
@@ -1,0 +1,256 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { actions } from "astro:actions";
+
+const props = defineProps<{
+	isSignedIn: boolean;
+	isSubscribed: boolean;
+	signInUrl: string;
+	pagePath: string;
+}>();
+
+const CHEATSHEET_COOKIE_NAME = "lead-magnet:k8s-1-35-cheatsheet";
+const AUDIENCE = "kubernetes-release-updates";
+const CHANNEL = "newsletter";
+
+const isLoading = ref(false);
+const isSuccess = ref(false);
+const error = ref<string | null>(null);
+const hasCookieSubscription = ref(false);
+
+function createSource(): string {
+	return `website:lead-magnet:k8s-1-35:${props.pagePath}`;
+}
+
+function checkCheatsheetCookie(): boolean {
+	try {
+		const cookies = document.cookie;
+		if (!cookies) return false;
+		const cookiePairs = cookies.split(";");
+		for (const pair of cookiePairs) {
+			const [name, value] = pair.trim().split("=");
+			if (name === CHEATSHEET_COOKIE_NAME && value === "true") {
+				return true;
+			}
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+onMounted(() => {
+	hasCookieSubscription.value = checkCheatsheetCookie();
+});
+
+const showSuccessState = computed(() => {
+	return isSuccess.value || hasCookieSubscription.value;
+});
+
+const subscribeAsLearner = async () => {
+	if (isLoading.value) return;
+	isLoading.value = true;
+	error.value = null;
+
+	try {
+		const { data, error: actionError } = await actions.newsletter.subscribe({
+			audience: AUDIENCE,
+			channel: CHANNEL,
+			source: createSource(),
+		});
+		if (actionError) throw new Error(actionError.message);
+		if (data?.success) {
+			isSuccess.value = true;
+			// Redirect to cheatsheet page
+			window.location.href = "/resources/kubernetes-1-35-cheatsheet?subscribed=1";
+		}
+	} catch (err: unknown) {
+		error.value =
+			err instanceof Error
+				? err.message
+				: "Failed to subscribe. Please try again.";
+	} finally {
+		isLoading.value = false;
+	}
+};
+</script>
+
+<template>
+	<section class="relative overflow-hidden glass-card-shimmer p-8 md:p-12 bg-gradient-primary">
+		<!-- Dark overlay for text contrast -->
+		<div class="absolute inset-0 bg-black/30"></div>
+
+		<!-- Background decoration using brand colors -->
+		<div class="absolute inset-0 opacity-20">
+			<div class="absolute top-0 left-0 w-72 h-72 bg-brand-secondary rounded-full blur-3xl -translate-x-1/2 -translate-y-1/2"></div>
+			<div class="absolute bottom-0 right-0 w-96 h-96 bg-brand-primary rounded-full blur-3xl translate-x-1/3 translate-y-1/3"></div>
+		</div>
+
+		<!-- Kubernetes helm icon decoration -->
+		<div class="absolute top-4 right-4 md:top-8 md:right-8 opacity-20">
+			<svg class="w-24 h-24 md:w-32 md:h-32 text-white" viewBox="0 0 32 32" fill="currentColor">
+				<path d="M15.9.476a2.14 2.14 0 0 0-.823.218L3.932 6.01c-.582.277-1.005.804-1.15 1.432L.054 19.373c-.13.56-.015 1.15.314 1.627l.039.048 7.64 9.814c.39.5.99.793 1.63.793h12.648a2.14 2.14 0 0 0 1.63-.793l7.64-9.814.039-.048a2.14 2.14 0 0 0 .314-1.627l-2.728-11.93a2.14 2.14 0 0 0-1.15-1.432L16.924.694A2.14 2.14 0 0 0 15.9.476Zm.1 2.96 10.947 5.207 2.592 11.342-7.253 9.315H9.715l-7.253-9.315L5.054 8.643Z"/>
+				<path d="M16.002 7.27a1.07 1.07 0 0 0-.424.096c-.152.065-.296.168-.424.319-.476.558-.588 1.608-.283 2.8a9.2 9.2 0 0 0-3.202 1.837c-.924-.596-1.867-.856-2.57-.639-.238.074-.432.198-.58.374-.15.176-.245.412-.26.68-.059.992.7 2.242 1.99 3.287a9.2 9.2 0 0 0-.093 3.694c-1.131.638-1.91 1.478-2.084 2.381-.06.306-.036.6.068.877.104.277.299.518.583.709.767.515 1.934.52 3.162.063a9.2 9.2 0 0 0 2.529 2.711c-.294 1.137-.256 2.135.15 2.715.138.197.318.34.538.427.22.086.483.105.753.05.98-.2 2.038-1.006 2.811-2.2a9.2 9.2 0 0 0 3.548.041c.759 1.213 1.808 2.039 2.794 2.256.27.06.534.043.756-.042.221-.084.403-.225.542-.42.41-.576.458-1.574.17-2.72a9.2 9.2 0 0 0 2.521-2.682c1.216.458 2.377.46 3.147-.044.286-.188.483-.427.588-.702.105-.275.13-.567.072-.871-.17-.896-.94-1.729-2.052-2.368a9.2 9.2 0 0 0-.088-3.723c1.294-1.04 2.06-2.282 2.008-3.272-.014-.266-.107-.5-.255-.675a1.07 1.07 0 0 0-.576-.38c-.705-.222-1.654.033-2.587.625a9.2 9.2 0 0 0-3.186-1.849c.3-1.185.19-2.229-.282-2.788a1.07 1.07 0 0 0-.424-.32c-.152-.068-.323-.095-.5-.086-.978.049-1.939 1.043-2.568 2.593a9.2 9.2 0 0 0-3.534-.012c-.622-1.57-1.58-2.586-2.567-2.649a1.07 1.07 0 0 0-.076-.003Z"/>
+			</svg>
+		</div>
+
+		<div class="relative z-10 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
+			<!-- Content -->
+			<div class="flex-1 max-w-2xl">
+				<div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/20 text-white text-sm font-medium mb-4">
+					<span class="relative flex h-2 w-2">
+						<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-brand-secondary opacity-75"></span>
+						<span class="relative inline-flex rounded-full h-2 w-2 bg-brand-secondary"></span>
+					</span>
+					Release: December 17, 2025
+				</div>
+
+				<h2 class="text-2xl md:text-3xl lg:text-4xl font-bold text-white mb-4 font-display">
+					Kubernetes 1.35 Cheat Sheet
+				</h2>
+
+				<p class="text-lg text-white/90 mb-6">
+					The release that changes everything: mandatory cgroup v2 enforcement, AI/ML scheduler primitives,
+					and structured authentication going GA. Don't get caught off-guard.
+				</p>
+
+				<!-- Feature highlights with category icons -->
+				<ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-8">
+					<!-- Breaking Changes (red warning) -->
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+						</svg>
+						<span><strong class="text-red-300">cgroup v2 mandatory</strong> - kubelet fails on v1</span>
+					</li>
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+						</svg>
+						<span><strong class="text-red-300">containerd 2.0</strong> - last v1.x support</span>
+					</li>
+					<!-- GA Features (green checkmark) -->
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+						</svg>
+						<span><strong class="text-green-300">In-place scaling</strong> - resize without restarts</span>
+					</li>
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+						</svg>
+						<span><strong class="text-green-300">Structured auth</strong> - hot-swap OIDC</span>
+					</li>
+					<!-- AI/ML (purple chip) -->
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-purple-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
+						</svg>
+						<span><strong class="text-purple-300">Gang scheduling</strong> - all-or-nothing pods</span>
+					</li>
+					<!-- Security (blue shield) -->
+					<li class="flex items-center gap-2 text-white/90">
+						<svg class="w-5 h-5 text-blue-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+						</svg>
+						<span><strong class="text-blue-300">User namespaces</strong> - root in container only</span>
+					</li>
+				</ul>
+			</div>
+
+			<!-- Form -->
+			<div class="w-full lg:w-auto lg:min-w-[340px]">
+				<div class="glass-card card-padding">
+					<!-- Success State -->
+					<Transition
+						enter-active-class="transition duration-300 ease-out"
+						enter-from-class="opacity-0 scale-95"
+						enter-to-class="opacity-100 scale-100"
+					>
+						<div
+							v-if="showSuccessState"
+							class="text-center py-4"
+						>
+							<div class="w-16 h-16 mx-auto mb-4 rounded-full bg-brand-secondary/20 flex items-center justify-center">
+								<svg class="w-8 h-8 text-brand-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+								</svg>
+							</div>
+							<h3 class="text-lg font-semibold text-primary-content mb-2 font-display">You're on the list!</h3>
+							<p class="text-sm text-secondary-content">
+								Redirecting to your cheatsheet...
+							</p>
+						</div>
+					</Transition>
+
+					<!-- Form -->
+					<div v-if="!showSuccessState">
+						<h3 class="text-lg font-semibold text-primary-content mb-2 font-display">
+							Get the free cheat sheet
+						</h3>
+						<p class="text-sm text-secondary-content mb-4">
+							Join 30K+ cloud native engineers
+						</p>
+
+						<!-- Error State -->
+						<Transition
+							enter-active-class="transition duration-200 ease-out"
+							enter-from-class="opacity-0 -translate-y-1"
+							enter-to-class="opacity-100 translate-y-0"
+						>
+							<div
+								v-if="error"
+								class="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/50 text-red-600 dark:text-red-400 text-sm"
+							>
+								{{ error }}
+							</div>
+						</Transition>
+
+						<!-- Signed-in user -->
+						<template v-if="isSignedIn">
+							<button
+								@click="subscribeAsLearner"
+								:disabled="isLoading"
+								class="btn-solid w-full py-3 px-4 text-base font-semibold shadow-lg hover:shadow-xl disabled:opacity-70 disabled:cursor-wait"
+							>
+								<span class="flex items-center justify-center gap-2">
+									<svg v-if="isLoading" class="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+										<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+									</svg>
+									<svg v-else class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+										<path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+									</svg>
+									{{ isLoading ? "Please wait..." : "Download Free Cheat Sheet" }}
+								</span>
+							</button>
+						</template>
+
+						<!-- Anonymous user - must sign in to access -->
+						<template v-else>
+							<div class="space-y-4">
+								<p class="text-sm text-secondary-content">
+									Sign in with GitHub to get instant access to the cheat sheet and join 30K+ cloud native engineers.
+								</p>
+								<a
+									:href="signInUrl"
+									class="btn-solid flex items-center justify-center w-full py-3 px-4 text-base font-semibold shadow-lg hover:shadow-xl"
+								>
+									<svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+										<path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
+									</svg>
+									Sign in with GitHub
+								</a>
+							</div>
+						</template>
+
+						<p class="mt-4 text-xs text-center text-muted">
+							No spam. Unsubscribe anytime.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+</template>

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -7,6 +7,7 @@ import Page from "@/wrappers/page.astro";
 import { getCollection } from "astro:content";
 import ArticleCard from "@/components/articles/ArticleCard.astro";
 import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
+import K8sCheatsheetCTA from "@/components/lead-magnet/K8sCheatsheetCTA.astro";
 import { resolveTechnologyIconUrl } from "@/utils/resolve-technology-icon";
 
 // Fetch random technologies for hero
@@ -32,6 +33,23 @@ const latestVideos = allVideos
 	.sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())
 	.slice(0, 4); // Showing 4 videos looks better in a 2x2 or 4-col grid, but 3 matches articles. Let's do 3 for symmetry or 4 for a grid. Let's do 3 and use a 3-col grid.
 // Actually, let's stick to 3 to match the 3 articles if we do a 3-col grid.
+
+// Social proof stats - simplified metrics
+const allCourses = await getCollection("courses");
+const totalContent = allVideos.length + allArticles.length + allCourses.length;
+
+// Calculate total hours from video durations (duration is in seconds)
+const totalSeconds = allVideos.reduce((acc, video) => {
+	const duration = video.data.duration;
+	return acc + (typeof duration === "number" && duration > 0 ? duration : 0);
+}, 0);
+const totalHours = Math.floor(totalSeconds / 3600);
+
+const socialProofStats = [
+	{ icon: "📚", value: `${totalContent}+`, label: "Resources" },
+	{ icon: "⏱️", value: `${totalHours}+`, label: "Hours of Video" },
+	{ icon: "👥", value: "30K+", label: "Learners" },
+];
 
 const pageTitle = "Cloud Native & Kubernetes Education | Rawkode Academy";
 const pageDescription =
@@ -61,7 +79,7 @@ const formatDuration = (seconds?: number | null) => {
 		highlight="hard"
 		logos={heroLogos}
 		primaryButton={{
-					text: "Latest Videos",
+					text: "Start Watching Free",
 					link: "/watch",
 				}}
 		secondaryButton={{
@@ -80,7 +98,11 @@ const formatDuration = (seconds?: number | null) => {
 			"Infrastructure as Code",
 		]}
 		suffix="may be complex, but it doesn't need to be hard."
+		socialProof={socialProofStats}
 	/>
+
+	{/* Lead Magnet - Kubernetes 1.35 Cheatsheet */}
+	<K8sCheatsheetCTA class="py-12 px-4 sm:py-16" />
 
 	{/* Latest Content Section */}
 	<section class="py-16 px-4 sm:py-20">

--- a/projects/rawkode.academy/website/src/pages/resources/kubernetes-1-35-cheatsheet.astro
+++ b/projects/rawkode.academy/website/src/pages/resources/kubernetes-1-35-cheatsheet.astro
@@ -1,0 +1,699 @@
+---
+import Page from "@/wrappers/page.astro";
+
+export const prerender = false;
+
+const user = Astro.locals.user;
+
+// Require authentication to view this resource
+if (!user) {
+	return Astro.redirect(`/sign-in?returnTo=${encodeURIComponent(Astro.url.pathname)}`);
+}
+
+const pageTitle = "Kubernetes 1.35 Cheat Sheet | Rawkode Academy";
+const pageDescription =
+	"Your comprehensive guide to Kubernetes 1.35 - new features, deprecated APIs, migration tips, and kubectl commands all in one place. Release date: December 17, 2025.";
+
+// Set the cookie to track that user has accessed this resource (for CTA suppression)
+if (Astro.url.searchParams.has("subscribed")) {
+	Astro.cookies.set("lead-magnet:k8s-1-35-cheatsheet", "true", {
+		path: "/",
+		maxAge: 60 * 60 * 24 * 365, // 1 year
+		sameSite: "lax",
+	});
+}
+---
+
+<Page title={pageTitle} description={pageDescription}>
+	<section class="py-16 px-4 sm:py-20">
+		<div class="mx-auto max-w-4xl">
+			<!-- Success Header -->
+			<div class="text-center mb-12">
+				<div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-green-100 dark:bg-green-900/30 mb-6">
+					<svg class="w-10 h-10 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+					</svg>
+				</div>
+				<h1 class="text-3xl md:text-4xl font-bold text-primary-content mb-4">
+					Your Kubernetes 1.35 Cheat Sheet is Ready!
+				</h1>
+				<p class="text-lg text-muted max-w-2xl mx-auto">
+					Thank you for joining the Rawkode Academy community. Here's everything you need to know about Kubernetes 1.35.
+				</p>
+			</div>
+
+			<!-- Release Info Banner -->
+			<div class="bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-2xl p-6 mb-8 border border-blue-200 dark:border-blue-800/50">
+				<div class="flex flex-wrap items-center justify-between gap-4">
+					<div>
+						<h2 class="text-lg font-semibold text-primary-content">📅 Release Date: December 17, 2025</h2>
+						<p class="text-sm text-muted">Cycle started September 15, 2025 • Code Freeze: November 6, 2025</p>
+					</div>
+					<div class="flex items-center gap-2 px-3 py-1 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-sm font-medium">
+						<span class="relative flex h-2 w-2">
+							<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+							<span class="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+						</span>
+						17 Enhancements
+					</div>
+				</div>
+			</div>
+
+			<!-- Cheatsheet Content Card -->
+			<div class="glass-panel rounded-3xl p-8 md:p-12 mb-12">
+				<h2 class="text-2xl font-bold text-primary-content mb-8">
+					What's New in Kubernetes 1.35
+				</h2>
+
+				<div class="space-y-10">
+					<!-- Breaking Changes - Most Important -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-red-500">🚨</span> Breaking Changes (Action Required!)
+						</h3>
+						<div class="bg-red-50 dark:bg-red-900/20 rounded-xl p-6 border border-red-200 dark:border-red-800/50 space-y-6">
+
+							<!-- cgroup v1 -->
+							<div>
+								<h4 class="font-semibold text-primary-content mb-2">cgroup v1 Support Disabled by Default</h4>
+								<p class="text-muted text-sm mb-3">The Kubelet config <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">failCgroupV1</code> now defaults to <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">true</code>. If a node boots with legacy cgroup v1 hierarchy, the Kubelet <strong>crashes immediately on startup</strong>. This effectively deprecates CentOS 7, Ubuntu 18.04, and older RHEL versions.</p>
+								<div class="bg-gray-900 rounded-lg p-4 font-mono text-sm overflow-x-auto space-y-2">
+									<div>
+										<p class="text-gray-400"># Check if your nodes use cgroups v2</p>
+										<p class="text-green-400">stat -fc %T /sys/fs/cgroup/</p>
+										<p class="text-gray-400"># Returns: cgroup2fs (v2) or tmpfs (v1 - WILL FAIL!)</p>
+									</div>
+									<div>
+										<p class="text-gray-400"># Temporary override (NOT recommended for production)</p>
+										<p class="text-green-400">--fail-cgroup-v1=false</p>
+										<p class="text-gray-400"># Will be removed entirely in v1.38</p>
+									</div>
+								</div>
+								<p class="text-muted text-xs mt-2">Upgrade to Ubuntu 22.04+, Amazon Linux 2023, Flatcar, or Bottlerocket.</p>
+							</div>
+
+							<!-- containerd deprecation -->
+							<div>
+								<h4 class="font-semibold text-primary-content mb-2">containerd 1.x End of Support</h4>
+								<p class="text-muted text-sm mb-3">Kubernetes 1.35 is the <strong>last version</strong> to support containerd 1.7. You must upgrade to containerd 2.0+ before upgrading to Kubernetes 1.36.</p>
+								<div class="bg-gray-900 rounded-lg p-4 font-mono text-sm overflow-x-auto">
+									<p class="text-gray-400"># Monitor affected nodes with this metric</p>
+									<p class="text-green-400">kubelet_cri_losing_support</p>
+								</div>
+							</div>
+
+							<!-- SPDY to WebSockets -->
+							<div>
+								<h4 class="font-semibold text-primary-content mb-2">SPDY → WebSockets Transition (RBAC Impact)</h4>
+								<p class="text-muted text-sm mb-3">kubectl exec/attach/port-forward now uses WebSockets. This requires <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">create</code> verb permissions for connection upgrades.</p>
+								<div class="bg-gray-900 rounded-lg p-4 font-mono text-sm overflow-x-auto">
+									<p class="text-gray-400"># Update RBAC: users need 'create' permission for pods/exec</p>
+									<p class="text-green-400">kubectl auth can-i create pods/exec --as=your-user</p>
+								</div>
+							</div>
+
+							<!-- Image Pull Verification -->
+							<div>
+								<h4 class="font-semibold text-primary-content mb-2">Image Pull Credential Verification (Enabled by Default)</h4>
+								<p class="text-muted text-sm mb-3">The <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">KubeletEnsureSecretPulledImages</code> feature is now enabled. Pods must have valid credentials for cached images.</p>
+								<div class="bg-yellow-100 dark:bg-yellow-900/30 rounded-lg p-3 text-sm text-yellow-800 dark:text-yellow-200">
+									May cause pod creation failures if credentials are missing. Use <code>imagePullCredentialsVerificationPolicy: NeverVerify</code> as a temporary workaround.
+								</div>
+							</div>
+
+							<!-- Gogo Protobuf Removal -->
+							<div>
+								<h4 class="font-semibold text-primary-content mb-2">Gogo Protobuf Removal (Go Developers)</h4>
+								<p class="text-muted text-sm mb-3">The <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">gogo/protobuf</code> library is removed from Kubernetes API Go types. Custom controllers using client-go will see compilation failures if they rely on gogo-specific extensions.</p>
+								<div class="bg-gray-900 rounded-lg p-4 font-mono text-sm overflow-x-auto space-y-2">
+									<div>
+										<p class="text-gray-400"># One-release escape hatch (deleted in 1.36)</p>
+										<p class="text-green-400">go build -tags kubernetes_protomessage_one_more_release</p>
+									</div>
+								</div>
+								<p class="text-muted text-xs mt-2">Migrate to <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded">google.golang.org/protobuf</code> before upgrading to 1.36.</p>
+							</div>
+						</div>
+					</div>
+
+					<!-- Graduating to Stable (GA) -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-green-500">🎓</span> Graduating to Stable (GA)
+						</h3>
+						<div class="bg-green-50 dark:bg-green-900/20 rounded-xl p-6 border border-green-200 dark:border-green-800/50">
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-green-500 mt-1 font-bold">✓</span>
+									<div>
+										<strong>In-place Pod Resource Updates</strong>
+										<p class="text-sm text-muted mt-1">Adjust CPU and memory without restarting pods! No more recreating stateful workloads for vertical scaling.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+											<p class="text-green-400">kubectl patch pod my-pod --subresource='resize' -p '&#123;"spec":&#123;"containers":[&#123;"name":"app","resources":&#123;"requests":&#123;"memory":"512Mi"&#125;&#125;&#125;]&#125;&#125;'</p>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- New Beta Features -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-blue-500">🚀</span> Now Enabled by Default (Beta → On)
+						</h3>
+						<div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-800/50">
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1">•</span>
+									<div>
+										<strong>User Namespaces Support</strong> (<code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">UserNamespacesSupport</code>)
+										<p class="text-sm text-muted mt-1">Run containers as UID 0 inside, but unprivileged on the host. Set <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">hostUsers: false</code> in your pod spec.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1">•</span>
+									<div>
+										<strong>OCI Image Volumes</strong> (<code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">ImageVolume</code>)
+										<p class="text-sm text-muted mt-1">Mount OCI artifacts/images as volumes. Perfect for ML models, configs, or static assets.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+<pre class="text-green-400">volumes:
+- name: oci-data
+  image:
+    reference: "myregistry.io/my-data:v1"
+    pullPolicy: IfNotPresent</pre>
+										</div>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1">•</span>
+									<div>
+										<strong>Pod Certificates</strong> (<code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">PodCertificateRequest</code>)
+										<p class="text-sm text-muted mt-1">Native workload identity! Kubelet provisions and rotates mTLS certificates automatically via projected volumes.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1">•</span>
+									<div>
+										<strong>kuberc User Preferences</strong>
+										<p class="text-sm text-muted mt-1">Separate kubectl preferences from cluster configs with <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">~/.kube/kuberc</code>. New <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">credentialPluginPolicy</code> restricts credential plugins for security.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- New Alpha Features -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-purple-500">🧪</span> New Alpha Features (Try These!)
+						</h3>
+						<div class="bg-purple-50 dark:bg-purple-900/20 rounded-xl p-6 border border-purple-200 dark:border-purple-800/50">
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>Node Declared Features</strong>
+										<p class="text-sm text-muted mt-1">Nodes report their supported features to <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">.status.declaredFeatures</code>. Prevents scheduling pods on incompatible nodes during version skew.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>Constrained Impersonation</strong>
+										<p class="text-sm text-muted mt-1">When impersonating another user, you can't do anything you couldn't do yourself. Closes privilege escalation risk.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>Numeric Taints for SLA Scheduling</strong>
+										<p class="text-sm text-muted mt-1">Use <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">Gt</code> (greater than) and <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">Lt</code> (less than) operators in tolerations. Example: only schedule on nodes with SLA > 99.5%.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>HostNetwork + User Namespaces</strong>
+										<p class="text-sm text-muted mt-1">Pods can now access host network stack while keeping user namespace isolation (<code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">hostNetwork: true</code> + <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">hostUsers: false</code>).</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>Kubelet Certificate CN Validation</strong>
+										<p class="text-sm text-muted mt-1">API server validates kubelet certificate Common Name matches <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">system:node:&lt;nodename&gt;</code>. Prevents node impersonation attacks.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1">α</span>
+									<div>
+										<strong>Flagz Endpoint</strong>
+										<p class="text-sm text-muted mt-1">Runtime diagnostics showing command-line args used to start Kubernetes components. Great for compliance auditing.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- AI/ML & Scheduler Enhancements -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-purple-500">🤖</span> AI/ML & Scheduler Enhancements
+						</h3>
+						<div class="bg-purple-50 dark:bg-purple-900/20 rounded-xl p-6 border border-purple-200 dark:border-purple-800/50">
+							<p class="text-sm text-muted mb-4">Kubernetes 1.35 aggressively targets AI/ML workloads with scheduler primitives designed for expensive, hardware-bound training jobs.</p>
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1 font-bold">α</span>
+									<div>
+										<strong>Gang Scheduling (PodGroup)</strong>
+										<p class="text-sm text-muted mt-1">Native "all-or-nothing" scheduling for distributed training. If a job needs 16 GPUs and only 10 are free, the scheduler waits for all 16 rather than starting partial workers that idle.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+<pre class="text-green-400">apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: llama-training-job
+spec:
+  minMember: 16
+  scheduleTimeoutSeconds: 300</pre>
+										</div>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1 font-bold">β</span>
+									<div>
+										<strong>DRA Binding Conditions</strong>
+										<p class="text-sm text-muted mt-1">Dynamic Resource Allocation now waits for hardware initialization. GPUs and FPGAs that take seconds to configure won't cause pod failures from race conditions.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1 font-bold">GA</span>
+									<div>
+										<strong>JobManagedBy</strong>
+										<p class="text-sm text-muted mt-1">Jobs can delegate pod management to external controllers (Kueue, Volcano). Use standard Job API while custom schedulers handle execution.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-purple-500 mt-1 font-bold">β</span>
+									<div>
+										<strong>Mutable Resources for Suspended Jobs</strong>
+										<p class="text-sm text-muted mt-1">Modify <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">nodeSelector</code>, <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">tolerations</code>, and <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">resources</code> on suspended Jobs. Right-size pending workloads based on real-time capacity.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- Security Architecture -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-blue-500">🔐</span> Security Architecture
+						</h3>
+						<div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-800/50">
+							<p class="text-sm text-muted mb-4">Security moves from flag-based configuration to structured, versioned APIs. "Identity as Code" enables GitOps for authentication.</p>
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1 font-bold">GA</span>
+									<div>
+										<strong>Structured Authentication Configuration</strong>
+										<p class="text-sm text-muted mt-1">Configure multiple OIDC providers via file, not flags. Hot-reload without API server restarts. Use CEL expressions for complex claim mapping.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+<pre class="text-green-400"># Example: Multi-tenant claim transformation
+claimMappings:
+  username:
+    expression: 'claims.tenant_id + ":" + claims.email'
+  groups:
+    expression: 'claims.groups.filter(g, g.startsWith("k8s-"))'</pre>
+										</div>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1 font-bold">α</span>
+									<div>
+										<strong>Constrained Impersonation</strong>
+										<p class="text-sm text-muted mt-1">When impersonating another user, you can't escalate beyond your own privileges. Closes a long-standing privilege escalation vector.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-blue-500 mt-1 font-bold">α</span>
+									<div>
+										<strong>ServiceAccount Tokens in CSI Secrets</strong>
+										<p class="text-sm text-muted mt-1">CSI drivers receive tokens via the secrets field, not disk mounts. Reduces attack surface if driver container is compromised.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- Networking Updates -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-cyan-500">🌐</span> Networking Updates
+						</h3>
+						<div class="bg-cyan-50 dark:bg-cyan-900/20 rounded-xl p-6 border border-cyan-200 dark:border-cyan-800/50">
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-cyan-500 mt-1 font-bold">GA</span>
+									<div>
+										<strong>SPDY → WebSockets Transition</strong>
+										<p class="text-sm text-muted mt-1"><code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">kubectl exec</code>, <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">attach</code>, and <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">port-forward</code> now use WebSockets (RFC 6455). Better reliability through corporate proxies and ALBs.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-cyan-500 mt-1 font-bold">GA</span>
+									<div>
+										<strong>Traffic Distribution: PreferSameNode</strong>
+										<p class="text-sm text-muted mt-1">Services prefer local endpoints when available. Reduces cross-zone latency and data transfer costs for DaemonSet-backed services.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+<pre class="text-green-400">spec:
+  trafficDistribution: PreferSameNode</pre>
+										</div>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-cyan-500 mt-1 font-bold">v1.4</span>
+									<div>
+										<strong>Gateway API v1.4</strong>
+										<p class="text-sm text-muted mt-1">BackendTLSPolicy standardizes TLS re-encryption to backends. Named rules in routes improve debugging complex routing tables.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- Storage Enhancements -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-orange-500">💾</span> Storage Enhancements
+						</h3>
+						<div class="bg-orange-50 dark:bg-orange-900/20 rounded-xl p-6 border border-orange-200 dark:border-orange-800/50">
+							<ul class="space-y-4 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-orange-500 mt-1 font-bold">β</span>
+									<div>
+										<strong>VolumeAttributesClass</strong>
+										<p class="text-sm text-muted mt-1">Modify volume attributes (IOPS, throughput) without unmounting. StorageClass defines immutable props, VolumeAttributesClass defines mutable ones.</p>
+										<div class="bg-gray-900 rounded-lg p-3 mt-2 font-mono text-xs overflow-x-auto">
+<pre class="text-green-400"># Change EBS IOPS without pod restart
+kubectl patch pvc my-pvc -p \
+  '&#123;"spec":&#123;"volumeAttributesClassName":"high-iops"&#125;&#125;'</pre>
+										</div>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-orange-500 mt-1 font-bold">β</span>
+									<div>
+										<strong>Volume Attach Limits + Autoscaler</strong>
+										<p class="text-sm text-muted mt-1">Cluster Autoscaler now simulates CSINode volume limits when scaling. Prevents spinning up nodes that can't actually host pending pods due to EBS/disk attachment caps.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- Deprecations -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-yellow-500">⚠️</span> Deprecations
+						</h3>
+						<div class="bg-yellow-50 dark:bg-yellow-900/20 rounded-xl p-6 border border-yellow-200 dark:border-yellow-800/50">
+							<ul class="space-y-3 text-primary-content">
+								<li class="flex items-start gap-3">
+									<span class="text-yellow-500 mt-1">⚠</span>
+									<div>
+										<strong>kube-proxy ipvs mode</strong>
+										<p class="text-sm text-muted mt-1">Deprecated in favor of <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">nftables</code> mode. Feature parity became too difficult to maintain.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-yellow-500 mt-1">⚠</span>
+									<div>
+										<strong>cgroup v1 (removal imminent)</strong>
+										<p class="text-sm text-muted mt-1">Disabled by default now. Will be fully removed in a future release.</p>
+									</div>
+								</li>
+								<li class="flex items-start gap-3">
+									<span class="text-yellow-500 mt-1">⚠</span>
+									<div>
+										<strong>CSI tokens in VolumeContext</strong>
+										<p class="text-sm text-muted mt-1">Service account tokens should now use the new <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">Secrets</code> field via <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">serviceAccountTokenInSecrets: true</code>.</p>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- kubectl Quick Reference -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-blue-500">$</span> kubectl Quick Reference for 1.35
+						</h3>
+						<div class="bg-gray-900 rounded-xl p-6 font-mono text-sm overflow-x-auto">
+							<div class="space-y-4">
+								<div>
+									<p class="text-gray-400"># Check cluster version</p>
+									<p class="text-green-400">kubectl version</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Check if your nodes support cgroups v2</p>
+									<p class="text-green-400">kubectl get nodes -o jsonpath='&#123;range .items[*]&#125;&#123;.metadata.name&#125;&#123;"\t"&#125;&#123;.status.nodeInfo.containerRuntimeVersion&#125;&#123;"\n"&#125;&#123;end&#125;'</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Check for deprecated API usage</p>
+									<p class="text-green-400">kubectl get --raw /metrics | grep apiserver_requested_deprecated_apis</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># In-place resize a pod's memory (1.35 GA feature!)</p>
+									<p class="text-green-400">kubectl patch pod my-pod --subresource='resize' \</p>
+									<p class="text-green-400">  -p '&#123;"spec":&#123;"containers":[&#123;"name":"app","resources":&#123;"requests":&#123;"memory":"1Gi"&#125;&#125;&#125;]&#125;&#125;'</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Check containerd version (before 1.36 upgrade)</p>
+									<p class="text-green-400">kubectl get nodes -o jsonpath='&#123;range .items[*]&#125;&#123;.metadata.name&#125;: &#123;.status.nodeInfo.containerRuntimeVersion&#125;&#123;"\n"&#125;&#123;end&#125;'</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Dry-run manifest validation</p>
+									<p class="text-green-400">kubectl apply --dry-run=server -f manifest.yaml</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Debug with custom profile (new in 1.35)</p>
+									<p class="text-green-400">kubectl debug my-pod --image=busybox \</p>
+									<p class="text-green-400">  --custom=debug-profile.yaml</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Check authentication config reload timestamp</p>
+									<p class="text-green-400">kubectl get --raw /metrics | grep \</p>
+									<p class="text-green-400">  apiserver_authentication_config_controller_automatic_reload</p>
+								</div>
+								<div>
+									<p class="text-gray-400"># Verify RBAC for WebSocket exec (breaking change!)</p>
+									<p class="text-green-400">kubectl auth can-i create pods/exec -n default</p>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<!-- Migration Checklist -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-purple-500">✓</span> 1.35 Migration Checklist
+						</h3>
+						<div class="bg-purple-50 dark:bg-purple-900/20 rounded-xl p-6 border border-purple-200 dark:border-purple-800/50">
+							<ul class="space-y-3">
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Verify cgroups v2</strong> - Run <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">stat -fc %T /sys/fs/cgroup/</code> on all nodes</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Check containerd version</strong> - Must be 1.7+ (2.0+ recommended)</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Update RBAC policies</strong> - Add <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">create</code> verb for pods/exec users</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Verify image pull secrets</strong> - Pods need valid credentials for cached images</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Review kube-proxy mode</strong> - Migrate from ipvs to nftables if applicable</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Check kubelet certificates</strong> - CN should match <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-sm">system:node:&lt;nodename&gt;</code></span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Test in staging</strong> - Upgrade staging cluster first</span>
+								</li>
+								<li class="flex items-center gap-3">
+									<input type="checkbox" class="w-5 h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+									<span class="text-primary-content"><strong>Backup etcd</strong> - Always before any upgrade</span>
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<!-- Feature Gates Reference -->
+					<div>
+						<h3 class="text-xl font-semibold text-primary-content mb-4 flex items-center gap-2">
+							<span class="text-gray-500">⚙️</span> Key Feature Gates
+						</h3>
+						<div class="overflow-x-auto">
+							<table class="w-full text-sm">
+								<thead>
+									<tr class="border-b border-gray-200 dark:border-gray-700">
+										<th class="text-left py-3 px-4 text-primary-content">Feature Gate</th>
+										<th class="text-left py-3 px-4 text-primary-content">Stage</th>
+										<th class="text-left py-3 px-4 text-primary-content">Default</th>
+									</tr>
+								</thead>
+								<tbody class="text-muted">
+									<!-- GA Features -->
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">InPlacePodVerticalScaling</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400">GA</span></td>
+										<td class="py-3 px-4">true (locked)</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">StructuredAuthenticationConfiguration</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400">GA</span></td>
+										<td class="py-3 px-4">true (locked)</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">JobManagedBy</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400">GA</span></td>
+										<td class="py-3 px-4">true (locked)</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">SidecarContainers</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400">GA</span></td>
+										<td class="py-3 px-4">true (locked)</td>
+									</tr>
+									<!-- Beta Features -->
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">UserNamespacesSupport</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">true</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">ImageVolume</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">true</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">PodCertificateRequest</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">true</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">KubeletEnsureSecretPulledImages</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">true</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">DeviceBindingConditions</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">false</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">VolumeAttributesClass</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">Beta</span></td>
+										<td class="py-3 px-4">false</td>
+									</tr>
+									<!-- Alpha Features -->
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">ConstrainedImpersonation</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400">Alpha</span></td>
+										<td class="py-3 px-4">false</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">NodeDeclaredFeatures</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400">Alpha</span></td>
+										<td class="py-3 px-4">false</td>
+									</tr>
+									<tr class="border-b border-gray-100 dark:border-gray-800">
+										<td class="py-3 px-4 font-mono text-xs">ServiceAccountTokenInCSISecrets</td>
+										<td class="py-3 px-4"><span class="px-2 py-1 rounded text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400">Alpha</span></td>
+										<td class="py-3 px-4">false</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Official Resources -->
+			<div class="glass-panel rounded-2xl p-8 mb-8">
+				<h3 class="text-xl font-semibold text-primary-content mb-4">📚 Official Resources</h3>
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<a href="https://kubernetes.io/blog/2025/11/26/kubernetes-v1-35-sneak-peek/" target="_blank" rel="noopener" class="flex items-center gap-3 p-4 rounded-xl bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
+						<span class="text-2xl">📰</span>
+						<div>
+							<p class="font-medium text-primary-content">Official Sneak Peek</p>
+							<p class="text-sm text-muted">kubernetes.io/blog</p>
+						</div>
+					</a>
+					<a href="https://www.kubernetes.dev/resources/release/" target="_blank" rel="noopener" class="flex items-center gap-3 p-4 rounded-xl bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
+						<span class="text-2xl">📅</span>
+						<div>
+							<p class="font-medium text-primary-content">Release Timeline</p>
+							<p class="text-sm text-muted">kubernetes.dev</p>
+						</div>
+					</a>
+					<a href="https://www.sysdig.com/blog/kubernetes-1-35-whats-new" target="_blank" rel="noopener" class="flex items-center gap-3 p-4 rounded-xl bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
+						<span class="text-2xl">🔒</span>
+						<div>
+							<p class="font-medium text-primary-content">Security Features Deep Dive</p>
+							<p class="text-sm text-muted">Sysdig Blog</p>
+						</div>
+					</a>
+					<a href="https://github.com/kubernetes/kubernetes/milestone/69" target="_blank" rel="noopener" class="flex items-center gap-3 p-4 rounded-xl bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
+						<span class="text-2xl">🐙</span>
+						<div>
+							<p class="font-medium text-primary-content">GitHub Milestone</p>
+							<p class="text-sm text-muted">Track Issues & PRs</p>
+						</div>
+					</a>
+				</div>
+			</div>
+
+			<!-- Stay Updated CTA -->
+			<div class="text-center">
+				<div class="glass-panel rounded-2xl p-8">
+					<h3 class="text-xl font-semibold text-primary-content mb-2">
+						Continue Your Cloud Native Journey
+					</h3>
+					<p class="text-muted mb-6">
+						Watch our hands-on Kubernetes tutorials and stay up-to-date with the latest cloud native content.
+					</p>
+					<div class="flex flex-col sm:flex-row gap-4 justify-center">
+						<a
+							href="/"
+							class="inline-flex items-center justify-center px-6 py-3 rounded-xl bg-primary text-white font-semibold hover:bg-primary/90 transition-colors"
+						>
+							<svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+							</svg>
+							Back to Academy
+						</a>
+						<a
+							href="/watch"
+							class="inline-flex items-center justify-center px-6 py-3 rounded-xl border-2 border-gray-200 dark:border-gray-700 text-primary-content font-semibold hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+						>
+							<svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+								<path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+							</svg>
+							Watch Kubernetes Videos
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+</Page>


### PR DESCRIPTION
## Summary

- Add K8s 1.35 cheatsheet CTA component with categorized feature highlights (breaking changes, GA features, AI/ML, security) using distinct colored icons
- Add server-rendered cheatsheet download page requiring authentication
- Comprehensive content covering breaking changes (cgroup v2 mandatory, containerd 2.0), GA features (in-place pod scaling, structured auth config), AI/ML scheduler enhancements, security architecture, networking, and storage updates
- Feature gates reference table and expanded kubectl quick reference

## Test plan

- [ ] Verify CTA displays correctly on homepage (both signed-in and anonymous states)
- [ ] Verify anonymous users see "Sign in with GitHub" button
- [ ] Verify signed-in users see "Download Free Cheat Sheet" button
- [ ] Verify cheatsheet page redirects to sign-in when not authenticated
- [ ] Verify cheatsheet page displays content when authenticated
- [ ] Test both rawkode-green and rawkode-blue themes