### PR TITLE
fix(rawkode.academy): remove Partytown from PostHog init (RKA-89)

### DIFF
--- a/projects/rawkode.academy/website/astro.config.mts
+++ b/projects/rawkode.academy/website/astro.config.mts
@@ -1,6 +1,5 @@
 import cloudflare from "@astrojs/cloudflare";
 import mdx from "@astrojs/mdx";
-import partytown from "@astrojs/partytown";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import vue from "@astrojs/vue";
@@ -311,30 +310,6 @@ export default defineConfig({
 			template: {
 				compilerOptions: {
 					isCustomElement: (tag) => tag.startsWith("media-"),
-				},
-			},
-		}),
-		partytown({
-			config: {
-				forward: [
-					"posthog.capture",
-					"posthog.identify",
-					"posthog.register",
-					"posthog.opt_in_capturing",
-					"posthog.opt_out_capturing",
-				],
-				lib: "/_partytown/",
-				// Prevent service worker registration attempts from Partytown
-				mainWindowAccessors: ["navigator.serviceWorker"],
-				resolveUrl: (url) => {
-					// Allow all URLs except service worker registrations
-					if (
-						url.pathname.includes("sw.js") ||
-						url.pathname.includes("service-worker")
-					) {
-						return null;
-					}
-					return url;
 				},
 			},
 		}),

--- a/projects/rawkode.academy/website/src/components/posthog/index.astro
+++ b/projects/rawkode.academy/website/src/components/posthog/index.astro
@@ -1,5 +1,6 @@
 ---
-// PostHog analytics initialization with Partytown web worker isolation
+// PostHog analytics initialization on main thread.
+// RKA-89: Partytown + PostHog produced runtime crashes in production.
 interface Props {
 	userId?: string | undefined;
 }
@@ -7,7 +8,7 @@ interface Props {
 const { userId } = Astro.props;
 ---
 
-<script is:inline type="text/partytown">
+<script is:inline>
   // PostHog loader
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 


### PR DESCRIPTION
## Summary
- remove the `@astrojs/partytown` integration from the website Astro config
- run PostHog initialization on the main thread instead of `type="text/partytown"`
- keep existing consent-gated PostHog behavior intact

## Why
`RKA-89` tracks a production crash in `partytown-atomics.js` affecting PostHog reliability. This change removes the failing execution path so analytics can run reliably.

## Changes
- `projects/rawkode.academy/website/astro.config.mts`
  - removed Partytown import and integration block
- `projects/rawkode.academy/website/src/components/posthog/index.astro`
  - changed PostHog loader script to standard inline script

## Validation
- confirmed Partytown wiring is removed from website config/scripts
- build/test tools (`node`/`bun`/`npm`/`pnpm`) are unavailable in this environment, so full project build/tests were not run here

## Linear
- RKA-89
