### PR TITLE
fix(rawkode.academy): tighten robots policy for internal routes (RKA-91)

### DIFF
--- a/projects/rawkode.academy/website/src/middleware.ts
+++ b/projects/rawkode.academy/website/src/middleware.ts
@@ -1,6 +1,7 @@
 import { sequence } from "astro:middleware";
 import { authMiddleware } from "./middleware/auth";
 import { corsMiddleware } from "./middleware/cors";
+import { robotsMiddleware } from "./middleware/robots";
 
-// Ensure canonical redirects happen first
-export const onRequest = sequence(corsMiddleware, authMiddleware);
+// Apply CORS/auth first, then attach robots headers to internal endpoints.
+export const onRequest = sequence(corsMiddleware, authMiddleware, robotsMiddleware);

--- a/projects/rawkode.academy/website/src/middleware/robots.ts
+++ b/projects/rawkode.academy/website/src/middleware/robots.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareHandler } from "astro";
+
+const NOINDEX_PREFIXES = ["/api/", "/_server-islands/"];
+const NOINDEX_EXACT_PATHS = new Set(["/graphql", "/settings"]);
+
+export const robotsMiddleware: MiddlewareHandler = async (context, next) => {
+	const response = await next();
+	const pathname = context.url.pathname;
+
+	const shouldNoindex =
+		NOINDEX_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+		NOINDEX_EXACT_PATHS.has(pathname);
+
+	if (shouldNoindex && !response.headers.has("X-Robots-Tag")) {
+		response.headers.set("X-Robots-Tag", "noindex, nofollow");
+	}
+
+	return response;
+};

--- a/projects/rawkode.academy/website/src/pages/robots.txt.ts
+++ b/projects/rawkode.academy/website/src/pages/robots.txt.ts
@@ -8,11 +8,15 @@ Host: rawkode.academy
 User-agent: *
 Allow: /
 
-# Except for
-Disallow: /api/
+# Keep private areas out of search
 Disallow: /admin/
 Disallow: /private/
-Disallow: /_server-islands/
+Disallow: /settings/
+Disallow: /api/auth/
+Disallow: /api/comments/
+Disallow: /api/watch-position
+Disallow: /api/subscriptions/
+Disallow: /graphql
 
 # Sitemap locations
 Sitemap: ${sitemapURL.href}


### PR DESCRIPTION
## Summary
- narrow `robots.txt` disallow rules to private/sensitive paths instead of blanket-disallowing all `/api/` and `/_server-islands/`
- add middleware that sets `X-Robots-Tag: noindex, nofollow` for internal endpoints (`/api/*`, `/_server-islands/*`, `/graphql`, `/settings`)
- keep sitemap declarations unchanged

## Why
`RKA-91` flagged a large set of URLs as blocked by robots. The previous broad disallow rules could hide non-content internal routes from crawl, but also create noisy "blocked by robots" coverage signals.

This change keeps sensitive/private endpoints out of search while shifting internal endpoint control to explicit `X-Robots-Tag` noindex semantics.

## Changes
- `projects/rawkode.academy/website/src/pages/robots.txt.ts`
  - removed blanket `Disallow: /api/` and `Disallow: /_server-islands/`
  - added targeted disallow rules for private/sensitive endpoints
- `projects/rawkode.academy/website/src/middleware/robots.ts` (new)
  - applies `X-Robots-Tag: noindex, nofollow` to internal endpoint paths
- `projects/rawkode.academy/website/src/middleware.ts`
  - wires in `robotsMiddleware`

## Validation
- reviewed resulting route policy in diff for robots + middleware
- full build/tests were not run in this environment because `node`/`bun`/`npm`/`pnpm` are unavailable

## Linear
- RKA-91
