### PR TITLE
feat(website): add inline email capture for anonymous visitors

### DIFF
--- a/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
@@ -10,6 +10,7 @@ import CourseModules from "@/components/courses/CourseModules.astro";
 import CourseSignupFormCompact from "@/components/courses/CourseSignupFormCompact.astro";
 import CourseDetailHero from "@/components/courses/CourseDetailHero.vue";
 import CourseJsonLd from "@/components/html/course-jsonld.astro";
+import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
@@ -134,6 +135,16 @@ const formattedAuthors = authors.map((author) => ({
 	<div class="bg-gray-100 dark:bg-gray-900">
 		<!-- Main Content -->
 		<div class="py-16 px-4 mx-auto max-w-screen-xl">
+			<div class="mb-16 max-w-3xl mx-auto">
+				<NewsletterCTA
+					server:defer
+					audience={`course:${course.id}`}
+					badge={`${course.data.title} updates`}
+					headline={`Get updates for ${course.data.title}`}
+					subtitle="Get notified about new modules and weekly cloud native insights."
+				/>
+			</div>
+
 			<!-- Course Overview Content -->
 			{Content && (
 				<div class="mb-16">

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -77,12 +77,12 @@ const formatDuration = (seconds?: number | null) => {
 		highlight="hard"
 		logos={heroLogos}
 		primaryButton={{
-					text: "Start Watching Free",
-					link: "/watch",
+					text: "Get Weekly Insights",
+					link: "#newsletter-signup",
 				}}
 		secondaryButton={{
-			text: "About Us",
-			link: "/about",
+			text: "Start Watching Free",
+			link: "/watch",
 		}}
 		rotatedPrefixes={[
 			"Cloud Native",
@@ -98,6 +98,18 @@ const formatDuration = (seconds?: number | null) => {
 		suffix="may be complex, but it doesn't need to be hard."
 		socialProof={socialProofStats}
 	/>
+
+	<section id="newsletter-signup" class="px-4 pt-6 sm:pt-8">
+		<div class="mx-auto max-w-3xl scroll-mt-24">
+			<NewsletterCTA
+				server:defer
+				class="mb-12"
+				badge="Weekly Cloud Native insights"
+				headline="Get cloud native insights weekly"
+				subtitle="Tutorials, deep dives, and curated events. No spam, unsubscribe anytime."
+			/>
+		</div>
+	</section>
 
 	{/* Latest Content Section */}
 	<section class="py-16 px-4 sm:py-20">
@@ -181,8 +193,6 @@ const formatDuration = (seconds?: number | null) => {
 					))}
 				</div>
 			</div>
-
-			<NewsletterCTA class="mb-16" />
 
 			{/* Featured Technologies Highlight */}
 			<div class="glass-panel rounded-3xl p-8">


### PR DESCRIPTION
## Summary
- add an inline newsletter capture block directly below the homepage hero and point the hero primary CTA to it
- update homepage CTA priority so the primary action is weekly insights capture and the secondary action is watch content
- add an inline newsletter capture block on course landing pages with per-course audience targeting (`course:${course.id}`)
- keep forms inline (non-popup) and reuse existing newsletter action/storage pipeline for anonymous visitors

## Context
- Linear: RKA-94

## Testing
- not run locally in this environment (workspace `astro` CLI dependencies are not installed)
