### PR TITLE
feat(rawkode.academy/website): add news sitemap + Google News sitemap

### DIFF
--- a/projects/rawkode.academy/website/scripts/check-sitemap.ts
+++ b/projects/rawkode.academy/website/scripts/check-sitemap.ts
@@ -49,6 +49,8 @@ export const REQUIRED_SITEMAP_PATHS = [
 	"/sitemaps/people.xml",
 	"/sitemaps/shows.xml",
 	"/sitemaps/series.xml",
+	"/sitemaps/news.xml",
+	"/news-sitemap.xml",
 	"/sitemaps/adrs.xml",
 ] as const;
 
@@ -170,7 +172,9 @@ export function buildSupplementalUrlChecks(base: string): UrlExpectation[] {
 	}));
 }
 
-async function getSitemapFetchResult(base: string): Promise<SitemapFetchResult> {
+async function getSitemapFetchResult(
+	base: string,
+): Promise<SitemapFetchResult> {
 	const candidates = [
 		new URL("/sitemap-index.xml", base).href,
 		new URL("/sitemap.xml", base).href,
@@ -237,25 +241,13 @@ async function checkUrl(
 
 	if (ok && contentType.includes("text/html")) {
 		const html = await response.text();
-		canonical = extractTagAttribute(
-			html,
-			"link",
-			{ rel: "canonical" },
-			"href",
-		);
-		robots = extractTagAttribute(
-			html,
-			"meta",
-			{ name: "robots" },
-			"content",
-		);
+		canonical = extractTagAttribute(html, "link", { rel: "canonical" }, "href");
+		robots = extractTagAttribute(html, "meta", { name: "robots" }, "content");
 
 		const expectedCanonical = expectation?.expectedCanonical ?? url;
 		if (canonical) {
-			canonicalOk =
-				normalizeUrl(canonical) === normalizeUrl(expectedCanonical);
-			hostOk =
-				new URL(canonical).hostname.replace(/^www\./, "") === apexHost;
+			canonicalOk = normalizeUrl(canonical) === normalizeUrl(expectedCanonical);
+			hostOk = new URL(canonical).hostname.replace(/^www\./, "") === apexHost;
 		}
 
 		if (expectation?.expectedRobots) {
@@ -287,7 +279,9 @@ export async function run() {
 	const { indexUrl, sitemapLocs, pageUrls } = await getSitemapFetchResult(base);
 	const limitedPageUrls = pageUrls.slice(0, limit);
 	console.log(`Fetched sitemap index: ${indexUrl}`);
-	console.log(`Found ${sitemapLocs.length} child sitemaps and ${pageUrls.length} URLs`);
+	console.log(
+		`Found ${sitemapLocs.length} child sitemaps and ${pageUrls.length} URLs`,
+	);
 
 	const sitemapPaths = new Set(sitemapLocs.map((loc) => new URL(loc).pathname));
 	const missingSitemaps = REQUIRED_SITEMAP_PATHS.filter(
@@ -348,7 +342,9 @@ export async function run() {
 	console.log("\nSummary:");
 	console.log(`  Total sitemap URLs checked: ${pageResults.length}`);
 	console.log(`  Required sitemap files missing: ${missingSitemaps.length}`);
-	console.log(`  Disallowed URLs in sitemap set: ${disallowedSitemapUrls.length}`);
+	console.log(
+		`  Disallowed URLs in sitemap set: ${disallowedSitemapUrls.length}`,
+	);
 	console.log(`  Canonical/page failures: ${pageFailures.length}`);
 	console.log(`  Page fetch errors: ${pageErrorCount}`);
 	console.log(`  Supplemental URL failures: ${supplementalFailures.length}`);

--- a/projects/rawkode.academy/website/src/lib/sitemaps.ts
+++ b/projects/rawkode.academy/website/src/lib/sitemaps.ts
@@ -41,11 +41,27 @@ type StaticPageDefinition = {
 
 const staticPages: StaticPageDefinition[] = [
 	{ path: "/", source: "src/pages/index.astro", changefreq: "daily" },
-	{ path: "/about", source: "src/pages/about/index.astro", changefreq: "monthly" },
-	{ path: "/watch", source: "src/pages/watch/index.astro", changefreq: "daily" },
-	{ path: "/shows", source: "src/pages/shows/index.astro", changefreq: "weekly" },
+	{
+		path: "/about",
+		source: "src/pages/about/index.astro",
+		changefreq: "monthly",
+	},
+	{
+		path: "/watch",
+		source: "src/pages/watch/index.astro",
+		changefreq: "daily",
+	},
+	{
+		path: "/shows",
+		source: "src/pages/shows/index.astro",
+		changefreq: "weekly",
+	},
 	{ path: "/read", source: "src/pages/read/index.astro", changefreq: "daily" },
-	{ path: "/courses", source: "src/pages/courses/index.astro", changefreq: "weekly" },
+	{
+		path: "/courses",
+		source: "src/pages/courses/index.astro",
+		changefreq: "weekly",
+	},
 	{
 		path: "/learning-paths",
 		source: "src/pages/learning-paths/index.astro",
@@ -66,7 +82,11 @@ const staticPages: StaticPageDefinition[] = [
 		source: "src/pages/technology/matrix/advanced.astro",
 		changefreq: "weekly",
 	},
-	{ path: "/people", source: "src/pages/people/index.astro", changefreq: "weekly" },
+	{
+		path: "/people",
+		source: "src/pages/people/index.astro",
+		changefreq: "weekly",
+	},
 	{ path: "/adrs", source: "src/pages/adrs/index.astro", changefreq: "weekly" },
 	{
 		path: "/changelog",
@@ -180,7 +200,9 @@ function escapeXml(value: unknown): string {
 	});
 }
 
-async function getContentMtimes(contentDir: string): Promise<Map<string, Date>> {
+async function getContentMtimes(
+	contentDir: string,
+): Promise<Map<string, Date>> {
 	if (!contentMtimeCache.has(contentDir)) {
 		contentMtimeCache.set(
 			contentDir,
@@ -232,7 +254,10 @@ function getLatestLastmod(entries: SitemapUrlEntry[]): Date | undefined {
 	);
 }
 
-export function toAbsoluteUrl(site: URL | string | undefined, path: string): string {
+export function toAbsoluteUrl(
+	site: URL | string | undefined,
+	path: string,
+): string {
 	const base = site ? new URL(site.toString()) : new URL(DEFAULT_SITE_URL);
 	return new URL(normalizePath(path), base).href;
 }
@@ -321,7 +346,9 @@ export async function getArticleSitemapEntries(): Promise<SitemapUrlEntry[]> {
 	return sortByPath(entries);
 }
 
-export async function getTechnologySitemapEntries(): Promise<SitemapUrlEntry[]> {
+export async function getTechnologySitemapEntries(): Promise<
+	SitemapUrlEntry[]
+> {
 	const [technologies, mtimes, allVideos] = await Promise.all([
 		getCollection("technologies"),
 		getContentMtimes("technologies"),
@@ -531,6 +558,50 @@ export async function getSeriesSitemapEntries(): Promise<SitemapUrlEntry[]> {
 	return sortByPath(entries);
 }
 
+export async function getNewsSitemapEntries(): Promise<SitemapUrlEntry[]> {
+	const [newsItems, mtimes] = await Promise.all([
+		getCollection("news"),
+		getContentMtimes("news"),
+	]);
+
+	const entries = newsItems.map((item) => ({
+		path: `/news/${item.id}`,
+		lastmod: pickLastmod(
+			mtimes.get(item.id),
+			(item.data as Record<string, unknown>).updatedAt,
+			item.data.publishedAt,
+		),
+		changefreq: "weekly" as const,
+	}));
+
+	return sortByPath(entries);
+}
+
+export const GOOGLE_NEWS_FRESHNESS_MS = 2 * 24 * 60 * 60 * 1000;
+
+export function selectFreshNewsItems<T extends { data: { publishedAt: Date } }>(
+	items: readonly T[],
+	now: Date = new Date(),
+): T[] {
+	const cutoff = now.getTime() - GOOGLE_NEWS_FRESHNESS_MS;
+	return [...items]
+		.filter((item) => item.data.publishedAt.getTime() >= cutoff)
+		.sort(
+			(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
+		);
+}
+
+export async function getFreshNewsSitemapEntries(
+	now: Date = new Date(),
+): Promise<SitemapUrlEntry[]> {
+	const newsItems = await getCollection("news");
+	return selectFreshNewsItems(newsItems, now).map((item) => ({
+		path: `/news/${item.id}`,
+		lastmod: item.data.publishedAt,
+		changefreq: "hourly" as const,
+	}));
+}
+
 export async function getAdrSitemapEntries(): Promise<SitemapUrlEntry[]> {
 	const [adrs, mtimes] = await Promise.all([
 		getCollection("adrs"),
@@ -586,6 +657,14 @@ export const sitemapDefinitions: readonly SitemapDefinition[] = [
 	{
 		path: "/sitemaps/series.xml",
 		getEntries: getSeriesSitemapEntries,
+	},
+	{
+		path: "/sitemaps/news.xml",
+		getEntries: getNewsSitemapEntries,
+	},
+	{
+		path: "/news-sitemap.xml",
+		getEntries: getFreshNewsSitemapEntries,
 	},
 	{
 		path: "/sitemaps/adrs.xml",

--- a/projects/rawkode.academy/website/src/pages/news-sitemap.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/news-sitemap.xml.ts
@@ -1,0 +1,79 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+import { selectFreshNewsItems, toAbsoluteUrl } from "@/lib/sitemaps";
+
+const DEFAULT_SITE_URL = "https://rawkode.academy";
+const PUBLICATION_NAME = "Rawkode Academy";
+const PUBLICATION_LANGUAGE = "en";
+
+function escapeXml(value: unknown): string {
+	const unsafe =
+		typeof value === "string" ? value : value == null ? "" : String(value);
+	return unsafe.replace(/[<>&'"]/g, (c) => {
+		switch (c) {
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case "&":
+				return "&amp;";
+			case "'":
+				return "&apos;";
+			case '"':
+				return "&quot;";
+			default:
+				return c;
+		}
+	});
+}
+
+export function renderGoogleNewsSitemap(
+	site: URL | string | undefined,
+	items: ReadonlyArray<{
+		id: string;
+		data: { title: string; publishedAt: Date };
+	}>,
+): string {
+	const siteUrl = site ?? new URL(DEFAULT_SITE_URL);
+	const body = items
+		.map((item) => {
+			const url = toAbsoluteUrl(siteUrl, `/news/${item.id}`);
+			const publishedDate = new Date(item.data.publishedAt).toISOString();
+			return `  <url>
+    <loc>${escapeXml(url)}</loc>
+    <news:news>
+      <news:publication>
+        <news:name>${escapeXml(PUBLICATION_NAME)}</news:name>
+        <news:language>${PUBLICATION_LANGUAGE}</news:language>
+      </news:publication>
+      <news:publication_date>${publishedDate}</news:publication_date>
+      <news:title>${escapeXml(item.data.title)}</news:title>
+    </news:news>
+  </url>`;
+		})
+		.join("\n");
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+${body}
+</urlset>`;
+}
+
+export const GET: APIRoute = async ({ site }) => {
+	const allNews = await getCollection("news");
+	const fresh = selectFreshNewsItems(allNews);
+	const xml = renderGoogleNewsSitemap(site, fresh);
+
+	return new Response(xml, {
+		headers: {
+			"Content-Type": "application/xml; charset=utf-8",
+			// News-eligible window is 48h; revalidate aggressively so newly
+			// published items appear in Top Stories without waiting on the
+			// default 1h sitemap TTL.
+			"Cache-Control": "public, max-age=900",
+		},
+	});
+};
+
+export const prerender = true;

--- a/projects/rawkode.academy/website/src/pages/sitemaps/news.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/sitemaps/news.xml.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+	getNewsSitemapEntries,
+	renderUrlSet,
+	xmlResponse,
+} from "@/lib/sitemaps";
+
+export const GET: APIRoute = async ({ site }) => {
+	const entries = await getNewsSitemapEntries();
+	return xmlResponse(renderUrlSet(site, entries));
+};
+
+export const prerender = true;

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -16,7 +16,10 @@ import {
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const VIDEO_CONTENT_DIR = resolve(TESTS_DIR, "../../../../../content/videos");
-const ARTICLE_CONTENT_DIR = resolve(TESTS_DIR, "../../../../../content/articles");
+const ARTICLE_CONTENT_DIR = resolve(
+	TESTS_DIR,
+	"../../../../../content/articles",
+);
 const TECHNOLOGY_CONTENT_DIR = resolve(
 	TESTS_DIR,
 	"../../../../../content/technologies",
@@ -273,8 +276,8 @@ describe("SEO Validation", () => {
 
 	describe("URL Structure", () => {
 		it("all article URLs should be SEO-friendly", async () => {
-				getCollection.mockResolvedValue([
-					{
+			getCollection.mockResolvedValue([
+				{
 					id: "test-article-seo-friendly-url",
 					data: {
 						title: "SEO Friendly URL Article",
@@ -324,7 +327,7 @@ describe("SEO Validation", () => {
 					},
 					body: "This is a sufficiently long body of content to satisfy the minimal length check for the SEO content structure test. It intentionally exceeds one hundred characters.",
 				},
-				]);
+			]);
 
 			const articles = (await getCollection(
 				"articles",
@@ -624,6 +627,8 @@ describe("Crawlability and Sitemaps", () => {
 		expect(sitemapPaths).toContain("/video-sitemap.xml");
 		expect(sitemapPaths).toContain("/sitemaps/pages.xml");
 		expect(sitemapPaths).toContain("/sitemaps/articles.xml");
+		expect(sitemapPaths).toContain("/sitemaps/news.xml");
+		expect(sitemapPaths).toContain("/news-sitemap.xml");
 		expect(
 			sitemapPaths.some(
 				(path) =>
@@ -632,6 +637,80 @@ describe("Crawlability and Sitemaps", () => {
 					path.startsWith("/private"),
 			),
 		).toBe(false);
+	});
+
+	it("filters Google News sitemap to items published within the last 48 hours, newest first", async () => {
+		const { selectFreshNewsItems } = await import("../lib/sitemaps.ts");
+
+		const now = new Date("2026-05-15T12:00:00.000Z");
+		const items = [
+			{
+				id: "ancient-story",
+				data: {
+					title: "Ancient",
+					publishedAt: new Date("2026-05-01T09:00:00.000Z"),
+				},
+			},
+			{
+				id: "edge-of-window",
+				data: {
+					title: "Edge",
+					// Exactly 48h - 1ms before now; should be included.
+					publishedAt: new Date("2026-05-13T12:00:00.001Z"),
+				},
+			},
+			{
+				id: "fresh-story",
+				data: {
+					title: "Fresh",
+					publishedAt: new Date("2026-05-15T08:00:00.000Z"),
+				},
+			},
+			{
+				id: "stale-story",
+				data: {
+					title: "Stale",
+					publishedAt: new Date("2026-05-13T11:00:00.000Z"),
+				},
+			},
+		];
+
+		const fresh = selectFreshNewsItems(items, now);
+		expect(fresh.map((item) => item.id)).toEqual([
+			"fresh-story",
+			"edge-of-window",
+		]);
+	});
+
+	it("renders the Google News sitemap with the news: namespace and per-item metadata", async () => {
+		const { renderGoogleNewsSitemap } = await import(
+			"../pages/news-sitemap.xml.ts"
+		);
+
+		const xml = renderGoogleNewsSitemap(new URL("https://rawkode.academy"), [
+			{
+				id: "kubernetes-1-36-sneak-peek",
+				data: {
+					title: "Kubernetes 1.36 sneak peek & ampersand",
+					publishedAt: new Date("2026-05-15T08:00:00.000Z"),
+				},
+			},
+		]);
+
+		expect(xml).toContain(
+			'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"',
+		);
+		expect(xml).toContain(
+			"<loc>https://rawkode.academy/news/kubernetes-1-36-sneak-peek</loc>",
+		);
+		expect(xml).toContain("<news:name>Rawkode Academy</news:name>");
+		expect(xml).toContain("<news:language>en</news:language>");
+		expect(xml).toContain(
+			"<news:publication_date>2026-05-15T08:00:00.000Z</news:publication_date>",
+		);
+		expect(xml).toContain(
+			"<news:title>Kubernetes 1.36 sneak peek &amp; ampersand</news:title>",
+		);
 	});
 
 	it("renders video sitemap durations as bounded integer seconds", async () => {


### PR DESCRIPTION
## Summary
- Add `/sitemaps/news.xml` covering every entry in the `news` collection so all news pages enter the sitemap index (they were previously orphaned — the recently-launched News section had no sitemap at all).
- Add `/news-sitemap.xml` following the Google News sitemap protocol (`xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"`), filtered to items published within the last 48 hours per Google's spec. This makes fresh stories eligible for Google News and Top Stories.
- Register both in `sitemapDefinitions`, `check-sitemap.ts` required paths, and `seo.test.ts`.

## Why
**Reach.** Cloud-native news is time-sensitive — a Google News sitemap is the standard way to nudge crawlers to fetch and index fresh items quickly. The 15-minute `Cache-Control: max-age=900` on the Google News endpoint (vs the 1h default for static sitemaps) keeps the surfaced window current without overhauling the prerender pipeline.

## Test plan
- [ ] `bun run build` succeeds and prerenders both new routes
- [ ] `curl https://<preview>/news-sitemap.xml` returns the `news:` namespace and only fresh items
- [ ] `curl https://<preview>/sitemaps/news.xml` lists every news page
- [ ] `curl https://<preview>/sitemap-index.xml` lists both new sitemap paths
- [ ] `bun scripts/check-sitemap.ts --base https://<preview>` passes

## Human action required (post-merge / post-deploy)
These cannot be automated from the PR; do them after this merges and deploys to production.

- [x] **Google Search Console** → `https://search.google.com/search-console` → property `rawkode.academy` → **Sitemaps** → submit `https://rawkode.academy/sitemap-index.xml` (if not already submitted) and additionally submit `https://rawkode.academy/news-sitemap.xml` directly. The Google News sitemap must be submitted separately even when listed in the index.
- [x] **Bing Webmaster Tools** (optional but cheap reach) → `https://www.bing.com/webmasters` → Sitemaps → submit the index URL.
- [x] **Google News Publisher Center** (separate program, optional): if you want eligibility for the dedicated Google News surface (news.google.com) — not just Top Stories in regular search — submit `rawkode.academy` at `https://publishercenter.google.com`. The sitemap shipped here is the technical prerequisite; Publisher Center is the editorial approval step.
- [x] **Verify in GSC after ~48h**: confirm both new sitemaps show "Success" status and that pages are being indexed (`URL Inspection` on one news URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)