### PR TITLE
feat(rawkode.academy/website): add NewsArticle JSON-LD on news pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/news-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/news-jsonld.astro
@@ -1,0 +1,41 @@
+---
+import type { CollectionEntry } from "astro:content";
+import * as utf64 from "utf64";
+import { buildNewsArticleJsonLd } from "@/lib/news-jsonld";
+
+interface Props {
+	article: CollectionEntry<"news">;
+	authors: CollectionEntry<"people">[];
+	// Allow placement into a named slot in parents (for TS exactOptionalPropertyTypes)
+	slot?: string;
+}
+
+const { article, authors } = Astro.props;
+
+// Reuse the dynamic OG image generator so social cards and the structured
+// data image stay in lockstep without a second pipeline.
+const imageUrl = `https://image.rawkode.academy/image?payload=${utf64.encode(
+	JSON.stringify({
+		title: article.data.title,
+		format: "png",
+		template: "gradient",
+	}),
+)}`;
+
+const jsonLd = buildNewsArticleJsonLd({
+	article: article.data,
+	authors: authors.map((author) => ({
+		name: author.data.name,
+		url: author.data.github,
+	})),
+	url: Astro.url.href,
+	imageUrl,
+	siteUrl: (Astro.site ?? Astro.url).origin,
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/news-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/news-jsonld.ts
@@ -1,0 +1,85 @@
+export interface NewsArticleAuthor {
+	name: string;
+	url?: string | undefined;
+}
+
+export interface NewsArticleSource {
+	title: string;
+	description: string;
+	publishedAt: Date;
+	updatedAt?: Date;
+	technologies?: ReadonlyArray<string>;
+}
+
+export interface BuildNewsArticleJsonLdInput {
+	article: NewsArticleSource;
+	authors: ReadonlyArray<NewsArticleAuthor>;
+	url: string;
+	imageUrl: string;
+	siteUrl: string;
+}
+
+const PUBLISHER_NAME = "Rawkode Academy";
+const PUBLISHER_LOGO_PATH = "/android-chrome-512x512.png";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+function formatTechnologyKeyword(technology: string): string {
+	return technology
+		.split(/[-/]/g)
+		.filter(Boolean)
+		.map((segment) =>
+			segment.length <= 3
+				? segment.toUpperCase()
+				: `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`,
+		)
+		.join(" ");
+}
+
+export function buildNewsArticleJsonLd(
+	input: BuildNewsArticleJsonLdInput,
+): Record<string, unknown> {
+	const { article, authors, url, imageUrl, siteUrl } = input;
+	const datePublished = new Date(article.publishedAt).toISOString();
+	const dateModified = new Date(
+		article.updatedAt ?? article.publishedAt,
+	).toISOString();
+
+	const keywords = (article.technologies ?? [])
+		.map(formatTechnologyKeyword)
+		.filter((keyword) => keyword.length > 0);
+
+	const jsonLd: Record<string, unknown> = {
+		"@context": "https://schema.org",
+		"@type": "NewsArticle",
+		headline: article.title,
+		description: article.description,
+		datePublished,
+		dateModified,
+		mainEntityOfPage: { "@type": "WebPage", "@id": url },
+		image: [imageUrl],
+		author: authors.map((author) => ({
+			"@type": "Person",
+			name: author.name,
+			...(author.url ? { url: author.url } : {}),
+		})),
+		publisher: {
+			"@type": "Organization",
+			name: PUBLISHER_NAME,
+			url: siteUrl,
+			logo: {
+				"@type": "ImageObject",
+				url: joinUrl(siteUrl, PUBLISHER_LOGO_PATH),
+			},
+		},
+		articleSection: "News",
+	};
+
+	if (keywords.length > 0) {
+		jsonLd.keywords = keywords.join(", ");
+	}
+
+	return jsonLd;
+}

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -6,6 +6,7 @@ import {
 	render,
 } from "astro:content";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb.astro";
+import NewsJsonLd from "@/components/html/news-jsonld.astro";
 import RelatedNews from "@/components/news/RelatedNews.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
@@ -77,6 +78,7 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 	authors={authors}
 >
 	<Fragment slot="extra-head">
+		<NewsJsonLd article={article} authors={authors} />
 		<link
 			rel="alternate"
 			type="application/rss+xml"

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -1067,4 +1067,80 @@ describe("Structured Data Validation", () => {
 		// Validate JSON structure can be serialized
 		expect(() => JSON.stringify(courseJsonLd)).not.toThrow();
 	});
+
+	it("models NewsArticle JSON-LD with publisher, image, author, keywords, and ISO dates", async () => {
+		const { buildNewsArticleJsonLd } = await import("../lib/news-jsonld.ts");
+
+		const jsonLd = buildNewsArticleJsonLd({
+			article: {
+				title: "Kubernetes 1.36 sneak peek",
+				description: "What's coming in the next Kubernetes release.",
+				publishedAt: new Date("2026-05-15T08:00:00.000Z"),
+				updatedAt: new Date("2026-05-15T09:30:00.000Z"),
+				technologies: ["kubernetes", "cncf"],
+			},
+			authors: [
+				{ name: "David Flanagan", url: "https://github.com/rawkode" },
+				{ name: "Anonymous" },
+			],
+			url: "https://rawkode.academy/news/kubernetes-1-36-sneak-peek",
+			imageUrl: "https://image.rawkode.academy/image?payload=test",
+			siteUrl: "https://rawkode.academy",
+		});
+
+		expect(jsonLd["@context"]).toBe("https://schema.org");
+		expect(jsonLd["@type"]).toBe("NewsArticle");
+		expect(jsonLd.headline).toBe("Kubernetes 1.36 sneak peek");
+		expect(jsonLd.datePublished).toBe("2026-05-15T08:00:00.000Z");
+		expect(jsonLd.dateModified).toBe("2026-05-15T09:30:00.000Z");
+		expect(jsonLd.image).toEqual([
+			"https://image.rawkode.academy/image?payload=test",
+		]);
+		expect(jsonLd.articleSection).toBe("News");
+		expect(jsonLd.keywords).toBe("Kubernetes, CNCF");
+
+		const mainEntity = jsonLd.mainEntityOfPage as Record<string, unknown>;
+		expect(mainEntity["@type"]).toBe("WebPage");
+		expect(mainEntity["@id"]).toBe(
+			"https://rawkode.academy/news/kubernetes-1-36-sneak-peek",
+		);
+
+		const author = jsonLd.author as Array<Record<string, unknown>>;
+		expect(author).toHaveLength(2);
+		expect(author[0]).toEqual({
+			"@type": "Person",
+			name: "David Flanagan",
+			url: "https://github.com/rawkode",
+		});
+		expect(author[1]).toEqual({ "@type": "Person", name: "Anonymous" });
+
+		const publisher = jsonLd.publisher as Record<string, unknown>;
+		expect(publisher["@type"]).toBe("Organization");
+		expect(publisher.name).toBe("Rawkode Academy");
+		expect(publisher.url).toBe("https://rawkode.academy");
+		const logo = publisher.logo as Record<string, unknown>;
+		expect(logo["@type"]).toBe("ImageObject");
+		expect(logo.url).toBe("https://rawkode.academy/android-chrome-512x512.png");
+
+		expect(() => JSON.stringify(jsonLd)).not.toThrow();
+	});
+
+	it("falls back dateModified to publishedAt and omits keywords when no technologies", async () => {
+		const { buildNewsArticleJsonLd } = await import("../lib/news-jsonld.ts");
+
+		const jsonLd = buildNewsArticleJsonLd({
+			article: {
+				title: "Untagged story",
+				description: "No tech tags here.",
+				publishedAt: new Date("2026-05-15T10:00:00.000Z"),
+			},
+			authors: [{ name: "Reporter" }],
+			url: "https://rawkode.academy/news/untagged-story",
+			imageUrl: "https://image.rawkode.academy/image?payload=untagged",
+			siteUrl: "https://rawkode.academy",
+		});
+
+		expect(jsonLd.dateModified).toBe(jsonLd.datePublished);
+		expect(jsonLd.keywords).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary
- Add `schema.org/NewsArticle` JSON-LD to `/news/[slug]` pages with `headline`, `description`, `datePublished`/`dateModified` (ISO 8601), `author` (Person array, GitHub URL when known), `publisher` (Organization with logo), `image` (dynamic OG image at 1200×630), `mainEntityOfPage`, `articleSection: "News"`, and `keywords` derived from tech tags.
- New pure-TS builder `src/lib/news-jsonld.ts` (`buildNewsArticleJsonLd`) so the shape is unit-testable. The Astro component is a thin wrapper.
- Unit tests in `src/tests/seo.test.ts` covering full shape + `dateModified` fallback + `keywords` omission.

## Why
**Reach.** Pairs with `/news-sitemap.xml` shipped in #1041: the sitemap makes stories *discoverable*; this JSON-LD makes them *eligible for rich results* — Top Stories carousel, Discover, and the article rich result in standard search. `NewsArticle` is the specific subtype Google ranks for news.

## Test plan
- [ ] Build site and `view-source:` on a `/news/<slug>` page shows a single `<script type="application/ld+json">` with `@type: NewsArticle`
- [ ] Paste page URL into [Google Rich Results Test](https://search.google.com/test/rich-results) — passes with no errors
- [ ] Confirm no duplicate JSON-LD blocks (the global `OrganizationJsonLd` / `SearchActionJsonLd` are still single-source)

## Human action required (post-merge / post-deploy)
These need a human; I can't run them from the PR.

- [ ] **Validate one production URL** in the Google Rich Results Test: `https://search.google.com/test/rich-results?url=https://rawkode.academy/news/kubernetes-1-36-sneak-peek` (substitute any news slug). Expect `Article` rich result detected with **no errors**. Warnings about optional fields (e.g. `dateline`) are fine.
- [ ] **Validate the same URL** in Schema.org's validator: `https://validator.schema.org/?url=https://rawkode.academy/news/<slug>` — expect zero errors.
- [ ] **Confirm dynamic OG image renders**: open `https://image.rawkode.academy/image?payload=...` (from the page source) directly in a browser; should return a 1200×630 PNG. If it fails, the `image:` array in the JSON-LD will resolve to a broken URL — Google ignores Article rich results without a valid image.
- [ ] **Watch Google Search Console** → Enhancements → **Article** for the next ~1 week. Expect the news URLs to appear under "Valid items" with no critical issues. If "Missing field" warnings appear, file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)