### PR TITLE
feat(rawkode.academy/website): add RSS and Atom feeds for news

### DIFF
--- a/projects/rawkode.academy/website/src/pages/api/feeds/news.atom.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/news.atom.ts
@@ -1,0 +1,89 @@
+import { getCollection, getEntries } from "astro:content";
+import type { APIContext } from "astro";
+
+function escapeXml(value: string): string {
+	return value.replace(/[<>&'"]/g, (char) => {
+		switch (char) {
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case "&":
+				return "&amp;";
+			case "'":
+				return "&apos;";
+			case '"':
+				return "&quot;";
+			default:
+				return char;
+		}
+	});
+}
+
+export async function GET(context: APIContext) {
+	const news = await getCollection("news");
+
+	const sortedNews = [...news].sort(
+		(a, b) =>
+			new Date(b.data.publishedAt).getTime() -
+			new Date(a.data.publishedAt).getTime(),
+	);
+
+	const site = context.site?.toString() || "https://rawkode.academy";
+	const feedUrl = `${site}/api/feeds/news.atom`;
+
+	const lastUpdated =
+		sortedNews[0]?.data.publishedAt instanceof Date
+			? sortedNews[0].data.publishedAt.toISOString()
+			: new Date().toISOString();
+
+	const entries = await Promise.all(
+		sortedNews.map(async (story) => {
+			const storyUrl = `${site}/news/${story.id}/`;
+			const published = new Date(story.data.publishedAt).toISOString();
+			const authors = await getEntries(story.data.authors);
+
+			const authorTags = authors
+				.map(
+					(author) =>
+						`<author><name>${escapeXml(author.data.name)}</name></author>`,
+				)
+				.join("\n\t\t");
+
+			const categoryTags = (story.data.technologies ?? [])
+				.map((technology) => `<category term="${escapeXml(technology)}"/>`)
+				.join("\n\t\t");
+
+			return `	<entry>
+		<title><![CDATA[${story.data.title}]]></title>
+		<link href="${storyUrl}" rel="alternate" type="text/html"/>
+		<id>${storyUrl}</id>
+		<published>${published}</published>
+		<updated>${published}</updated>
+		<summary><![CDATA[${story.data.description}]]></summary>
+		<content type="html"><![CDATA[${story.data.description}]]></content>
+		${authorTags}
+		${categoryTags}
+	</entry>`;
+		}),
+	);
+
+	const atomFeed = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<title>Rawkode Academy - News</title>
+	<subtitle>Cloud native, Kubernetes, and AI infrastructure news for engineers.</subtitle>
+	<link href="${feedUrl}" rel="self" type="application/atom+xml"/>
+	<link href="${site}/news" rel="alternate" type="text/html"/>
+	<id>${site}/news</id>
+	<updated>${lastUpdated}</updated>
+	<generator>Astro</generator>
+${entries.join("\n")}
+</feed>`;
+
+	return new Response(atomFeed, {
+		headers: {
+			"Content-Type": "application/atom+xml; charset=utf-8",
+			"Cache-Control": "public, max-age=900",
+		},
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/api/feeds/news.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/news.xml.ts
@@ -1,0 +1,37 @@
+import { getCollection, getEntries } from "astro:content";
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+	const news = await getCollection("news");
+
+	const sortedNews = [...news].sort(
+		(a, b) =>
+			new Date(b.data.publishedAt).getTime() -
+			new Date(a.data.publishedAt).getTime(),
+	);
+
+	const items = await Promise.all(
+		sortedNews.map(async (story) => {
+			const authors = await getEntries(story.data.authors);
+			return {
+				title: story.data.title,
+				description: story.data.description,
+				pubDate: new Date(story.data.publishedAt),
+				link: `/news/${story.id}/`,
+				author: authors.map((author) => author.data.name).join(", "),
+				categories: [...(story.data.technologies ?? [])],
+			};
+		}),
+	);
+
+	return rss({
+		title: "Rawkode Academy - News",
+		description:
+			"Cloud native, Kubernetes, and AI infrastructure news for engineers.",
+		site: context.site?.toString() || "https://rawkode.academy",
+		items,
+		customData: "<language>en-us</language>",
+		stylesheet: false,
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/feeds.astro
+++ b/projects/rawkode.academy/website/src/pages/feeds.astro
@@ -60,6 +60,26 @@ const publishedShows = shows.filter((show) => show.data.publish);
 				</div>
 			</div>
 
+			<!-- News Feeds -->
+			<div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
+				<h2 class="text-2xl font-semibold mb-4 text-secondary">News</h2>
+				<p class="text-gray-300 mb-4">Cloud native, Kubernetes, and AI infrastructure news for engineers</p>
+				<div class="space-y-3">
+					<a href="/api/feeds/news.xml" class="flex items-center gap-3 text-primary hover:text-primary/90 transition-colors">
+						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+							<path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3 1h2v2H5V6zm2 4H5v2h2v-2zm2-4h6v2H9V6zm6 4H9v2h6v-2z" clip-rule="evenodd"></path>
+						</svg>
+						RSS Feed
+					</a>
+					<a href="/api/feeds/news.atom" class="flex items-center gap-3 text-primary hover:text-primary/90 transition-colors">
+						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+							<path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3 1h2v2H5V6zm2 4H5v2h2v-2zm2-4h6v2H9V6zm6 4H9v2h6v-2z" clip-rule="evenodd"></path>
+						</svg>
+						Atom Feed
+					</a>
+				</div>
+			</div>
+
 			<!-- Videos Feeds -->
 			<div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
 				<h2 class="text-2xl font-semibold mb-4 text-secondary">Videos</h2>

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -39,7 +39,6 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 	day: "numeric",
 	year: "numeric",
 }).format(article.data.publishedAt);
-
 ---
 
 <Page
@@ -49,6 +48,20 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 	publishedAt={article.data.publishedAt}
 	authors={authors}
 >
+	<Fragment slot="extra-head">
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="Rawkode Academy - News (RSS)"
+			href="/api/feeds/news.xml"
+		/>
+		<link
+			rel="alternate"
+			type="application/atom+xml"
+			title="Rawkode Academy - News (Atom)"
+			href="/api/feeds/news.atom"
+		/>
+	</Fragment>
 	<div class="article-page">
 		<Breadcrumb elements={breadcrumbElements} />
 

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -6,7 +6,9 @@ export const prerender = true;
 
 const allNews = await getCollection("news");
 
-allNews.sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+allNews.sort(
+	(a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf(),
+);
 
 const pageTitle = "Cloud Native News | Rawkode Academy";
 const pageDescription =
@@ -34,6 +36,20 @@ function formatTechnologyLabel(value: string): string {
 ---
 
 <Page title={pageTitle} description={pageDescription}>
+	<Fragment slot="extra-head">
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="Rawkode Academy - News (RSS)"
+			href="/api/feeds/news.xml"
+		/>
+		<link
+			rel="alternate"
+			type="application/atom+xml"
+			title="Rawkode Academy - News (Atom)"
+			href="/api/feeds/news.atom"
+		/>
+	</Fragment>
 	<section class="page-px section-py-tight">
 		<div class="mx-auto max-w-4xl">
 			<header class="mb-6 border-b border-black/10 pb-5 dark:border-white/10 sm:mb-8 sm:pb-6">


### PR DESCRIPTION
## Summary
- Add `/api/feeds/news.xml` (RSS 2.0, via `@astrojs/rss`) and `/api/feeds/news.atom` (Atom 1.0).
- Add a "News" card to `/feeds` so subscribers can find them.
- Add `<link rel="alternate" type="application/rss+xml">` and `application/atom+xml` discovery tags on the news index and detail pages so feed readers auto-suggest subscription when a reader visits.

## Why
**Reach.** Articles, videos, shows, and the combined feed each have RSS + Atom — news was the only collection without one. RSS still drives meaningful subscriber traffic for tech audiences, and `<link rel="alternate">` makes the feeds discoverable in browsers and apps without needing to find `/feeds`.

## Test plan
- [ ] `curl https://<preview>/api/feeds/news.xml` returns valid RSS with news items
- [ ] `curl https://<preview>/api/feeds/news.atom` returns valid Atom
- [ ] Visit `/news` in a browser; feed reader extensions detect both feeds via the `<link>` tags
- [ ] `/feeds` lists the new News card

## Human action required (post-merge / post-deploy)
- [ ] **Validate the RSS feed**: paste `https://rawkode.academy/api/feeds/news.xml` into `https://validator.w3.org/feed/` — expect zero errors. Warnings about `atom:link` are typical and fine.
- [ ] **Validate the Atom feed**: same validator, paste `https://rawkode.academy/api/feeds/news.atom`.
- [ ] **Smoke-test auto-discovery**: with an RSS-aware browser extension (e.g. Feedbro) installed, visit `https://rawkode.academy/news` — both feeds should appear in the extension's detection list.
- [ ] **Announce the feeds**: a one-liner on Bluesky/X/Mastodon with the feed URLs typically picks up the long-tail RSS subscribers who have been waiting for this. Optional but high-leverage.
- [ ] **Decide on inclusion in `/api/feeds/all.xml` and `/api/feeds/all.atom`**: this PR keeps them separate to stay standalone. If you want news in the combined feed too, comment here or open an issue and I'll do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)