### PR TITLE
fix(rawkode.academy/website): link news bylines to /people/{id} instead of GitHub

### DIFF
--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -72,17 +72,18 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 				<div class="byline-authors">
 					{authors.map((author) => (
 						<a
-							href={author.data.github}
-							target="_blank"
-							rel="author noopener noreferrer"
+							href={`/people/${author.data.id}`}
+							rel="author"
 							class="author"
 						>
-							<img
-								src={author.data.avatarUrl}
-								alt=""
-								class="author-avatar"
-								loading="lazy"
-							/>
+							{author.data.avatarUrl && (
+								<img
+									src={author.data.avatarUrl}
+									alt=""
+									class="author-avatar"
+									loading="lazy"
+								/>
+							)}
 							<span class="author-name">{author.data.name}</span>
 						</a>
 					))}


### PR DESCRIPTION
## Summary
- On `/news/[slug]`, change the author chip `href` from `author.data.github` to `/people/${author.data.id}`.
- Drop `target="_blank"` and the `noopener noreferrer` rel values (no longer needed for same-origin).
- Guard the avatar `<img>` so authors without a GitHub handle (and therefore no `avatarUrl`) don't render a broken image — the name still shows.

## Why
**Retention.** Every click on an author byline currently sends the reader off-site to github.com. The site already has a dedicated `/people/{id}` page (sitemap-listed, JSON-LD-aware, surfaces that person's videos and shows). Linking there keeps readers on-site, distributes link equity to person pages, and matches the semantics of `rel="author"` (which points to the canonical author resource — generally a profile, not a code-hosting account).

The same retention leak exists on `/read/[slug]` article bylines, but I left that out of scope to keep this PR standalone. Easy follow-up.

## Test plan
- [ ] Visit any `/news/<slug>` page, click an author chip → lands on `/people/<id>`, no new tab opens
- [ ] Visit a news post with an author who has no GitHub handle (rare today, but a possibility) — name renders, no broken `<img>`
- [ ] PostHog / Faro pageviews on `/people/*` should rise once this ships and news traffic flows through

## Human action required (post-merge / post-deploy)
- [ ] **Skim the people pages your news authors link to** (e.g. `/people/rawkode`) and confirm they're polished enough to be a landing page. If they're sparse, prioritise filling the bio body / linking to a couple of representative videos.
- [ ] **Decide whether to repeat the same fix on `/read/[slug]`** (articles) in a follow-up — the same leak exists there. Comment here or ping me.
- [ ] **Optional** — watch GA/PostHog for the `/people/*` traffic delta over the next 7–14 days to confirm the retention assumption. If it doesn't move, the issue is probably the destination page quality, not the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)