### PR TITLE
feat(rawkode.academy/website): emit twitter:site and twitter:creator on shares

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/opengraph.astro
+++ b/projects/rawkode.academy/website/src/components/html/opengraph.astro
@@ -34,6 +34,20 @@ const openGraphImageUrl = `https://image.rawkode.academy/image?payload=${utf64.e
 const isPath = (path: string) => Astro.url.pathname.startsWith(path);
 const isBlogOrSeriesPath = isPath("/blog/") || isPath("/series/");
 const shouldShowArticleMeta = isArticle || isBlogOrSeriesPath;
+
+// X / Twitter handles. site = brand; creator = first author with a handle
+// on article-meta pages. The card spec requires `@handle` form.
+const TWITTER_SITE_HANDLE = "@RawkodeAcademy";
+const firstAuthorTwitterHandle = shouldShowArticleMeta
+	? authors?.find(
+			(author: CollectionEntry<"people">) =>
+				typeof author.data.handles?.twitter === "string" &&
+				author.data.handles.twitter.trim().length > 0,
+		)?.data.handles?.twitter
+	: undefined;
+const twitterCreator = firstAuthorTwitterHandle
+	? `@${firstAuthorTwitterHandle.replace(/^@/, "")}`
+	: undefined;
 ---
 
 <meta
@@ -74,6 +88,8 @@ const shouldShowArticleMeta = isArticle || isBlogOrSeriesPath;
 }
 
 <meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content={TWITTER_SITE_HANDLE} />
+{twitterCreator && <meta name="twitter:creator" content={twitterCreator} />}
 <meta property="twitter:domain" content={openGraphUrl.hostname} />
 <meta property="twitter:url" content={openGraphUrl} />
 <meta name="twitter:title" content={title} />


### PR DESCRIPTION
## Summary
- Add `<meta name="twitter:site" content="@RawkodeAcademy">` to every page.
- Add `<meta name="twitter:creator" content="@{handle}">` on article-meta pages (articles, news, series, blog) when the first author has a Twitter/X handle.
- Strip a leading `@` defensively in case the source handle already includes one.

## Why
**Reach.** When a story is shared on X, the existing card carries title/description/image but doesn't credit either the brand or the author. With `twitter:site` and `twitter:creator` set:

- The card shows "via @RawkodeAcademy" — a free, durable follow-prompt on every share.
- The card attributes the author's @handle — authors see themselves credited, are much more likely to retweet/amplify the share, and pick up follows from the audience.

This costs ~5 lines of code per share path and compounds with every social impression the academy already gets.

## Test plan
- [ ] Build and `view-source:` on `/` — confirm `twitter:site` is `@RawkodeAcademy` and no `twitter:creator` (homepage isn't article-meta)
- [ ] `view-source:` on a `/news/<slug>` page authored by someone with a Twitter handle (e.g. `rawkode`) — confirm both `twitter:site` and `twitter:creator` are emitted with leading `@`
- [ ] `view-source:` on a news/article page authored by someone without a Twitter handle — confirm `twitter:site` is present but `twitter:creator` is absent (rather than a broken `@undefined`)

## Human action required (post-merge / post-deploy)
- [ ] **Validate one production URL** in the X Card Validator (now under the developer portal — `https://cards-dev.twitter.com/validator` redirects, currently `https://twitter.com/intent/post?url=https://rawkode.academy/news/<slug>` will preview the actual card). Confirm the rendered card shows the brand and author attribution.
- [ ] **Confirm the brand handle is current**: if `@RawkodeAcademy` has changed (e.g. ownership transfer, rebrand on X), update the `TWITTER_SITE_HANDLE` constant before merging.
- [ ] **Optional** — backfill missing Twitter handles in `content/people/*.mdx` for high-traffic authors so they actually get attribution. This is the second-order win; the code is ready for it.
- [ ] **Optional** — once verified working, post one social share of a fresh news/article URL and check the rendered card actually shows the author attribution in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)