### PR TITLE
feat(rawkode.academy/website): link news tech tags to /technology/{id}

### DIFF
--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -28,6 +28,33 @@ const { article } = Astro.props;
 const { Content } = await render(article);
 const authors = await getEntries(article.data.authors);
 
+const allTechnologies = await getCollection("technologies");
+const technologyNameById = new Map<string, string>();
+for (const technology of allTechnologies) {
+	const rawId = technology.id.replace(/\/index$/, "");
+	technologyNameById.set(rawId, technology.data.name);
+}
+
+function formatTechnologyLabel(value: string): string {
+	const fromCollection = technologyNameById.get(value);
+	if (fromCollection) return fromCollection;
+	return value
+		.split(/[-/]/g)
+		.filter(Boolean)
+		.map((segment) =>
+			segment.length <= 3
+				? segment.toUpperCase()
+				: `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`,
+		)
+		.join(" ");
+}
+
+const tags = (article.data.technologies ?? []).map((technologyId) => ({
+	id: technologyId,
+	label: formatTechnologyLabel(technologyId),
+	href: `/technology/${technologyId}`,
+}));
+
 const breadcrumbElements = [
 	{ title: "Home", link: "/" },
 	{ title: "News", link: "/news" },
@@ -102,6 +129,21 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 			<article class="prose">
 				<Content />
 			</article>
+
+			{tags.length > 0 && (
+				<footer class="tags-footer">
+					<span class="tags-label">Tagged in</span>
+					<ul class="tags-list">
+						{tags.map((tag) => (
+							<li>
+								<a href={tag.href} class="tag" rel="tag">
+									{tag.label}
+								</a>
+							</li>
+						))}
+					</ul>
+				</footer>
+			)}
 		</div>
 	</div>
 </Page>
@@ -229,5 +271,71 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 
 	:global(.prose pre) {
 		white-space: pre-wrap;
+	}
+
+	.tags-footer {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem 0.75rem;
+		margin: 2rem 0 3rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid rgb(0 0 0 / 0.1);
+		padding-right: 4rem;
+	}
+
+	:root.dark .tags-footer {
+		border-top-color: rgb(255 255 255 / 0.1);
+	}
+
+	@media (max-width: 767px) {
+		.tags-footer {
+			padding-right: 0;
+		}
+	}
+
+	.tags-label {
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: rgb(107 114 128);
+	}
+
+	:root.dark .tags-label {
+		color: rgb(156 163 175);
+	}
+
+	.tags-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.25rem 0.75rem;
+		border-radius: 9999px;
+		border: 1px solid rgb(0 0 0 / 0.1);
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: rgb(17 24 39);
+		text-decoration: none;
+		transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+	}
+
+	:root.dark .tag {
+		color: rgb(229 231 235);
+		border-color: rgb(255 255 255 / 0.1);
+	}
+
+	.tag:hover {
+		color: rgb(var(--brand-primary));
+		border-color: rgb(var(--brand-primary) / 0.4);
+		background-color: rgb(var(--brand-primary) / 0.05);
 	}
 </style>

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -4,11 +4,22 @@ import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
 
-const allNews = await getCollection("news");
+const [allNews, allTechnologies] = await Promise.all([
+	getCollection("news"),
+	getCollection("technologies"),
+]);
 
 allNews.sort(
 	(a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf(),
 );
+
+// Build a lookup from the raw tech id used in news frontmatter (e.g. "kubernetes")
+// to the canonical display name on the technologies collection (e.g. "Kubernetes").
+const technologyNameById = new Map<string, string>();
+for (const technology of allTechnologies) {
+	const rawId = technology.id.replace(/\/index$/, "");
+	technologyNameById.set(rawId, technology.data.name);
+}
 
 const pageTitle = "Cloud Native News | Rawkode Academy";
 const pageDescription =
@@ -23,6 +34,8 @@ function formatDisplayDate(date: Date): string {
 }
 
 function formatTechnologyLabel(value: string): string {
+	const fromCollection = technologyNameById.get(value);
+	if (fromCollection) return fromCollection;
 	return value
 		.split(/[-/]/g)
 		.filter(Boolean)
@@ -74,7 +87,12 @@ function formatTechnologyLabel(value: string): string {
 												story.data.technologies[0] && (
 													<>
 														<span>/</span>
-														<span>{formatTechnologyLabel(story.data.technologies[0])}</span>
+														<a
+															href={`/technology/${story.data.technologies[0]}`}
+															class="transition-colors hover:text-primary"
+														>
+															{formatTechnologyLabel(story.data.technologies[0])}
+														</a>
 													</>
 												)
 											}


### PR DESCRIPTION
## Summary
- **News index** (`/news`): turn the first-technology badge on each story from plain text into a link to `/technology/{id}`. Use the canonical display name from the `technologies` collection (so `kubernetes` renders as "Kubernetes", not the kebab-case version).
- **News detail** (`/news/[slug]`): add a "Tagged in" footer below the article content with all tagged technologies as pill-shaped `rel="tag"` links. Styled to match the existing news design (rounded border, hover highlight in the active theme primary colour).

## Why
**Retention + internal SEO.** Each news story already declares one or more `technologies` in frontmatter, and `/technology/{id}` is a topic hub with the full video catalogue + JSON-LD for that tech. The data was there, but readers couldn't reach those hubs from a news article. Now every news → tech click stays on-site and lands on a much deeper page (compounding watch time). Internal contextual links also distribute PageRank to the technology hubs — pairs well with the technology hub SEO work that landed in #1023.

## Test plan
- [ ] Visit `/news`. The first-tech badge on each row is a link, hover highlights the brand primary colour, click lands on `/technology/{id}/`.
- [ ] Visit a `/news/<slug>` page with multiple technologies (e.g. `dragonfly-native-huggingface-modelscope-protocols`). The "Tagged in" footer lists every technology as a pill link.
- [ ] Hit a news story with an unknown tech ID — the fallback formatter title-cases the slug so the link still renders.
- [ ] Check dark mode: footer separator, tag border, hover state all look correct.

## Human action required (post-merge / post-deploy)
- [ ] **Skim two or three `/technology/{id}` landing pages** linked from current news (e.g. `/technology/kubernetes`, `/technology/kyverno`) and confirm they're worth landing on. Thin/empty tech pages are an anti-retention destination — if any are bare, prioritise filling them. (Sitemap already excludes thin tech pages with no videos and no body, so the links shouldn't 404 in practice — but visual polish on the destination is on you.)
- [ ] **Check internal-link analytics in PostHog**: in 7–14 days, the `/news → /technology/*` referral chain should appear. If it doesn't show clicks, the entry is too far below the fold on news detail — consider promoting it.
- [ ] **Optional** — once this lands, do the same for `/read/[slug]` (articles already have `technologies` and the same retention gap exists). I left it out of this PR to stay standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)