### PR TITLE
feat(rawkode.academy/website): add Related News block to news detail pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/news/RelatedNews.astro
+++ b/projects/rawkode.academy/website/src/components/news/RelatedNews.astro
@@ -1,0 +1,202 @@
+---
+import { type CollectionEntry, getCollection } from "astro:content";
+import { selectRelatedNews } from "@/lib/related-news";
+
+interface Props {
+	currentStory: CollectionEntry<"news">;
+	limit?: number;
+}
+
+const { currentStory, limit = 3 } = Astro.props;
+
+const [allNews, allTechnologies] = await Promise.all([
+	getCollection("news"),
+	getCollection("technologies"),
+]);
+
+const technologyNameById = new Map<string, string>();
+for (const technology of allTechnologies) {
+	const rawId = technology.id.replace(/\/index$/, "");
+	technologyNameById.set(rawId, technology.data.name);
+}
+
+function formatTechnologyLabel(value: string): string {
+	const fromCollection = technologyNameById.get(value);
+	if (fromCollection) return fromCollection;
+	return value
+		.split(/[-/]/g)
+		.filter(Boolean)
+		.map((segment) =>
+			segment.length <= 3
+				? segment.toUpperCase()
+				: `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`,
+		)
+		.join(" ");
+}
+
+const formatDisplayDate = (date: Date) =>
+	new Intl.DateTimeFormat("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	}).format(date);
+
+const related = selectRelatedNews(
+	currentStory.id,
+	currentStory.data.technologies ?? [],
+	allNews,
+	limit,
+);
+---
+
+{related.length > 0 && (
+	<section class="related-news">
+		<h2 class="related-heading">More stories</h2>
+		<ul class="related-list">
+			{related.map((story) => {
+				const topTechnology = story.data.technologies?.[0];
+				return (
+					<li class="related-item">
+						<article>
+							<div class="related-meta">
+								<time datetime={story.data.publishedAt.toISOString()}>
+									{formatDisplayDate(story.data.publishedAt)}
+								</time>
+								{topTechnology && (
+									<>
+										<span aria-hidden="true">/</span>
+										<span>{formatTechnologyLabel(topTechnology)}</span>
+									</>
+								)}
+							</div>
+							<h3 class="related-title">
+								<a href={`/news/${story.id}`}>{story.data.title}</a>
+							</h3>
+							<p class="related-dek">{story.data.description}</p>
+						</article>
+					</li>
+				);
+			})}
+		</ul>
+	</section>
+)}
+
+<style>
+	.related-news {
+		margin: 1.5rem 0 4rem;
+		padding-top: 2rem;
+		padding-right: 4rem;
+		border-top: 1px solid rgb(0 0 0 / 0.1);
+	}
+
+	:root.dark .related-news {
+		border-top-color: rgb(255 255 255 / 0.1);
+	}
+
+	@media (max-width: 767px) {
+		.related-news {
+			padding-right: 0;
+		}
+	}
+
+	.related-heading {
+		font-size: 1.5rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: rgb(17 24 39);
+		margin: 0 0 1.25rem;
+	}
+
+	:root.dark .related-heading {
+		color: white;
+	}
+
+	.related-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	@media (min-width: 768px) {
+		.related-list {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 1.5rem;
+		}
+	}
+
+	.related-item {
+		border-radius: 1rem;
+		padding: 1.25rem;
+		border: 1px solid rgb(0 0 0 / 0.08);
+		transition:
+			border-color 0.15s,
+			background-color 0.15s,
+			transform 0.15s;
+	}
+
+	:root.dark .related-item {
+		border-color: rgb(255 255 255 / 0.08);
+	}
+
+	.related-item:hover {
+		border-color: rgb(var(--brand-primary) / 0.4);
+		background-color: rgb(var(--brand-primary) / 0.03);
+	}
+
+	.related-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: rgb(107 114 128);
+		margin-bottom: 0.5rem;
+	}
+
+	:root.dark .related-meta {
+		color: rgb(156 163 175);
+	}
+
+	.related-title {
+		font-size: 1.15rem;
+		line-height: 1.3;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		margin: 0 0 0.5rem;
+		color: rgb(17 24 39);
+	}
+
+	:root.dark .related-title {
+		color: white;
+	}
+
+	.related-title a {
+		color: inherit;
+		text-decoration: none;
+		transition: color 0.15s;
+	}
+
+	.related-title a:hover {
+		color: rgb(var(--brand-primary));
+	}
+
+	.related-dek {
+		font-size: 0.9rem;
+		line-height: 1.5;
+		color: rgb(75 85 99);
+		margin: 0;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	:root.dark .related-dek {
+		color: rgb(209 213 219);
+	}
+</style>

--- a/projects/rawkode.academy/website/src/lib/related-news.ts
+++ b/projects/rawkode.academy/website/src/lib/related-news.ts
@@ -1,0 +1,60 @@
+export interface RelatedNewsCandidate {
+	id: string;
+	data: {
+		title: string;
+		description: string;
+		publishedAt: Date;
+		technologies?: ReadonlyArray<string>;
+	};
+}
+
+interface ScoredCandidate<T> {
+	story: T;
+	shared: number;
+	publishedAt: number;
+}
+
+/**
+ * Pick news stories related to the current one.
+ *
+ * Ordering rules:
+ *  1. Stories sharing at least one technology tag with the current story rank
+ *     above stories with no shared tags. Within that band, more shared tags
+ *     ranks higher.
+ *  2. Within an equal-overlap band (including the zero-overlap fallback band),
+ *     newer `publishedAt` wins.
+ *
+ * The current story is always excluded.
+ */
+export function selectRelatedNews<T extends RelatedNewsCandidate>(
+	currentId: string,
+	currentTechnologies: ReadonlyArray<string>,
+	candidates: ReadonlyArray<T>,
+	limit: number,
+): T[] {
+	if (limit <= 0) return [];
+
+	const currentTechSet = new Set(currentTechnologies);
+
+	const scored: ScoredCandidate<T>[] = candidates
+		.filter((story) => story.id !== currentId)
+		.map((story) => {
+			const shared = (story.data.technologies ?? []).reduce(
+				(count, technology) =>
+					currentTechSet.has(technology) ? count + 1 : count,
+				0,
+			);
+			return {
+				story,
+				shared,
+				publishedAt: story.data.publishedAt.getTime(),
+			};
+		});
+
+	scored.sort((a, b) => {
+		if (a.shared !== b.shared) return b.shared - a.shared;
+		return b.publishedAt - a.publishedAt;
+	});
+
+	return scored.slice(0, limit).map((entry) => entry.story);
+}

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -6,6 +6,7 @@ import {
 	render,
 } from "astro:content";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb.astro";
+import RelatedNews from "@/components/news/RelatedNews.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
@@ -144,6 +145,8 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 					</ul>
 				</footer>
 			)}
+
+			<RelatedNews currentStory={article} limit={3} />
 		</div>
 	</div>
 </Page>

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -797,6 +797,86 @@ describe("Crawlability and Sitemaps", () => {
 	});
 });
 
+describe("Related news selector", () => {
+	function makeStory(id: string, technologies: string[], publishedAt: string) {
+		return {
+			id,
+			data: {
+				title: `Story ${id}`,
+				description: `Description for ${id}`,
+				technologies,
+				publishedAt: new Date(publishedAt),
+			},
+		};
+	}
+
+	it("ranks stories with more shared technology tags above newer-but-unrelated ones", async () => {
+		const { selectRelatedNews } = await import("../lib/related-news.ts");
+		const current = makeStory(
+			"current",
+			["kubernetes", "cncf"],
+			"2026-05-15T00:00:00.000Z",
+		);
+		const candidates = [
+			current,
+			makeStory(
+				"two-shared",
+				["kubernetes", "cncf", "istio"],
+				"2026-04-01T00:00:00.000Z",
+			),
+			makeStory("one-shared", ["kubernetes"], "2026-05-14T00:00:00.000Z"),
+			makeStory(
+				"brand-new-unrelated",
+				["postgres"],
+				"2026-05-15T08:00:00.000Z",
+			),
+		];
+
+		const related = selectRelatedNews(
+			current.id,
+			current.data.technologies,
+			candidates,
+			3,
+		);
+
+		expect(related.map((story) => story.id)).toEqual([
+			"two-shared",
+			"one-shared",
+			"brand-new-unrelated",
+		]);
+	});
+
+	it("falls back to recency when no candidate shares a tag, and excludes the current story", async () => {
+		const { selectRelatedNews } = await import("../lib/related-news.ts");
+		const current = makeStory("current", ["niche"], "2026-05-15T00:00:00.000Z");
+		const candidates = [
+			current,
+			makeStory("older", ["postgres"], "2026-01-01T00:00:00.000Z"),
+			makeStory("newer", ["kubernetes"], "2026-05-14T00:00:00.000Z"),
+		];
+
+		const related = selectRelatedNews(
+			current.id,
+			current.data.technologies,
+			candidates,
+			5,
+		);
+
+		expect(related.map((story) => story.id)).toEqual(["newer", "older"]);
+	});
+
+	it("returns an empty array when limit is non-positive", async () => {
+		const { selectRelatedNews } = await import("../lib/related-news.ts");
+		const related = selectRelatedNews(
+			"current",
+			[],
+			[makeStory("any", [], "2026-05-15T00:00:00.000Z")],
+			0,
+		);
+		expect(related).toEqual([]);
+	});
+});
+
 describe("Structured Data Validation", () => {
 	it("should model VideoObject JSON-LD with clip urls, captions, and transcript text", () => {
 		const videoJsonLd = {


### PR DESCRIPTION
## Summary
- New pure-TS helper `src/lib/related-news.ts` (`selectRelatedNews`) that picks related stories by:
  1. **Shared technology tags** with the current story (more overlap ranks higher).
  2. **Recency** as the tiebreaker, and as the fallback when no story overlaps.
  The current story is always excluded.
- New `src/components/news/RelatedNews.astro` renders the picks as themed cards (date eyebrow, title link, three-line dek, brand-tinted hover).
- Wired into `src/pages/news/[slug]` below the article body — same position the `/read` flow uses for `RelatedArticles`.
- Three unit tests in `seo.test.ts` covering the shared-tag ranking, recency fallback, and the limit-zero guard.

## Why
**Retention.** `/read` already has `RelatedArticles` at the end of every article. `/news` ended with the article body and nothing else — the only paths forward were the browser back button or the breadcrumb. With ~10 news stories live today and growing, "More stories" creates a session-deepening loop that scales as the news collection grows.

## Test plan
- [ ] `bun run test src/tests/seo.test.ts -t "Related news selector"` (once the project-level vitest config is unbroken — pre-existing issue).
- [ ] Visit `/news/kubernetes-1-36-sneak-peek` — confirm 3 cards appear below the article body, the kubernetes-tagged stories rank first, and the current story is excluded.
- [ ] Visit a news story with a tech tag that nothing else uses — confirm the fallback shows the most-recent stories instead.
- [ ] Toggle light/dark — card borders, dek text, and hover state all match the existing news design.

## Human action required (post-merge / post-deploy)
- [ ] **Eyeball the curation** on 2–3 production news URLs after deploy. If a story keeps recommending stale-but-tag-matched picks, we can swap in a freshness decay (e.g. half-life weight on `publishedAt`) — flag the URL here and I'll do the follow-up.
- [ ] **Decide on the `limit`**: currently 3 to match `RelatedArticles`. If your news cadence grows past a couple stories per week, 4 or 6 (with a 2×N grid on desktop) may convert better. Comment if you want me to change it.
- [ ] **Watch PostHog** for the `/news/* → /news/*` referral edge over 7–14 days. If session length on news increases, we got the retention win. If not, the block is probably below the fold on mobile and we should consider promoting it.
- [ ] **Optional** — once `/read` and `/news` both have related blocks, consider adding `RelatedNews` to the bottom of `/read` articles too when the article shares tags with current news (cross-content surfacing). Standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)