### PR TITLE
feat(rawkode.academy/website): surface recent news on /technology/{id} hubs

### DIFF
--- a/projects/rawkode.academy/website/src/components/technology/TopicHub.astro
+++ b/projects/rawkode.academy/website/src/components/technology/TopicHub.astro
@@ -14,6 +14,8 @@ export interface Props {
 	}>;
 	showArticles?: boolean;
 	showVideos?: boolean;
+	showNews?: boolean;
+	newsLimit?: number;
 }
 
 const {
@@ -22,11 +24,21 @@ const {
 	videos = [],
 	showArticles = true,
 	showVideos = true,
+	showNews = true,
+	newsLimit = 6,
 } = Astro.props;
+
+// Technology IDs from the collection look like "kubernetes/index"; raw IDs
+// (as used in news/article frontmatter) drop the suffix. Match both forms.
+const normalizedTechnologyId = technologyId.replace(/\/index$/, "");
+const matchesTechnology = (technologies: ReadonlyArray<string> | undefined) =>
+	Array.isArray(technologies) &&
+	(technologies.includes(technologyId) ||
+		technologies.includes(normalizedTechnologyId));
 
 // Get all articles that mention this technology
 const allArticles = await getCollection("articles", ({ data }) => {
-	return !data.draft && data.technologies?.includes(technologyId);
+	return !data.draft && matchesTechnology(data.technologies);
 });
 
 // Sort articles by date
@@ -34,16 +46,65 @@ const articles = allArticles.sort(
 	(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
 );
 
+// Get news matching this technology
+const allNews = showNews
+	? (await getCollection("news"))
+			.filter((story) => matchesTechnology(story.data.technologies))
+			.sort(
+				(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
+			)
+			.slice(0, newsLimit)
+	: [];
+
 const hasArticles = showArticles && articles.length > 0;
 const hasVideos = showVideos && videos.length > 0;
-const isEmpty = !hasArticles && !hasVideos;
+const hasNews = showNews && allNews.length > 0;
+const isEmpty = !hasArticles && !hasVideos && !hasNews;
+
+const newsDateFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+});
 ---
 
 <div class="space-y-12">
+  <!-- News Section -->
+  {hasNews && (
+    <section>
+      <SectionHeader
+        title={`Recent ${technologyName} news`}
+        showSeparator={false}
+        class="mb-6"
+      />
+      <ul class="divide-y divide-black/10 border-y border-black/10 dark:divide-white/10 dark:border-white/10">
+        {allNews.map((story) => (
+          <li class="py-5 sm:py-6">
+            <article class="space-y-2">
+              <div class="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted">
+                <time datetime={story.data.publishedAt.toISOString()}>
+                  {newsDateFormatter.format(story.data.publishedAt)}
+                </time>
+              </div>
+              <h3 class="font-display text-xl md:text-2xl font-semibold leading-tight tracking-tight text-primary-content">
+                <a href={`/news/${story.id}`} class="transition-colors hover:text-primary">
+                  {story.data.title}
+                </a>
+              </h3>
+              <p class="max-w-[66ch] text-base leading-7 text-secondary-content">
+                {story.data.description}
+              </p>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
   <!-- Articles Section -->
   {hasArticles && (
     <section>
-      <SectionHeader 
+      <SectionHeader
         title={`Articles about ${technologyName}`}
         showSeparator={false}
         class="mb-6"
@@ -59,7 +120,7 @@ const isEmpty = !hasArticles && !hasVideos;
   <!-- Videos Section -->
   {hasVideos && (
     <section>
-      <SectionHeader 
+      <SectionHeader
         title={`Videos about ${technologyName}`}
         showSeparator={false}
         class="mb-6"
@@ -90,11 +151,7 @@ const isEmpty = !hasArticles && !hasVideos;
   {isEmpty && (
     <div class="text-center py-12">
       <p class="text-gray-500 dark:text-gray-400">
-        {showArticles && !showVideos
-          ? `No articles found for ${technologyName} yet. Check back soon!`
-          : !showArticles && showVideos
-            ? `No videos found for ${technologyName} yet. Check back soon!`
-            : `No content found for ${technologyName} yet. Check back soon!`}
+        No content found for {technologyName} yet. Check back soon!
       </p>
     </div>
   )}


### PR DESCRIPTION
## Summary
- Add `showNews` (default `true`) and `newsLimit` (default `6`) props to `TopicHub`.
- Fetch news where `data.technologies` contains either the raw tech id (e.g. `kubernetes`) or the indexed form (`kubernetes/index`) — the symmetric match also fixes the existing articles filter, which only matched the indexed form.
- Render a "Recent {Tech} news" section at the top of the hub, styled to match the news index list (date eyebrow, linked title, dek).
- Simplify the empty-state copy now that three content types feed the hub.

## Why
**Retention loop.** #1047 routes news tech-tag clicks to `/technology/{id}`. Today that destination shows articles and videos but pretends news doesn't exist — the freshest, most timely content type. Adding it surfaces "what's happening this week in {Tech}" at the top of the hub. The same surface is the natural place for a Kubernetes-curious reader landing from any path (search, internal nav, share) to find current updates.

**Bug fix bonus.** The previous articles filter used `data.technologies?.includes(technologyId)` against the indexed-form `kubernetes/index`, while article frontmatter stores raw `kubernetes`. The new `matchesTechnology` helper handles both forms, so the articles section now actually populates on `/technology/{id}` for tech pages that have articles. (Verify on a tech where articles exist — e.g. `/technology/kubernetes` — to confirm.)

## Test plan
- [ ] Visit `/technology/kubernetes` after build — confirm a "Recent Kubernetes news" section appears at the top with up to 6 stories sorted newest-first.
- [ ] Visit `/technology/<tech-with-articles-only>` — confirm the Articles section now renders (the silent bug from before is gone).
- [ ] Visit `/technology/<tech-with-nothing>` — confirm the empty state renders the simplified copy.
- [ ] Toggle light/dark — list dividers and prose colours look right.

## Human action required (post-merge / post-deploy)
- [ ] **Spot-check the top 3–5 tech hubs by traffic** (`/technology/kubernetes`, `/technology/cncf`, etc.) and confirm the News section is curated correctly. If news bleeds across into unrelated tech hubs because an unrelated tag was set on a story, fix the tags in `content/news/<slug>/*.mdx`.
- [ ] **Confirm the articles fix didn't blow up an existing assumption**: tech pages that *intentionally* hid articles (if any did so by relying on the indexed-form mismatch) will now show them. Glance at GSC's URL Inspection for one or two tech pages 1–2 days post-deploy and confirm no new soft-404 or duplicate-content flags.
- [ ] **Decide on the `newsLimit`**: 6 to match the muscle memory of "Latest stories" lists. If a tech accumulates dozens of news items, the hub may get long-scroll-y. Tell me and I'll swap to paging or a "See all news" link.
- [ ] **Optional** — once this lands, consider adding a "Browse by technology" view to the news index itself (right now there's only a chronological list). Standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)