### PR TITLE
feat(rawkode.academy/website): add OpenSearch description for browser search bars

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/head.astro
+++ b/projects/rawkode.academy/website/src/components/html/head.astro
@@ -16,7 +16,9 @@ const { userId } = Astro.props;
 const BRAND_NAME = "Rawkode Academy";
 const TITLE_SUFFIX = ` | ${BRAND_NAME}`;
 const baseTitle = (Astro.props.title ?? BRAND_NAME).trim();
-const normalizedTitle = baseTitle.toLowerCase().includes(BRAND_NAME.toLowerCase())
+const normalizedTitle = baseTitle
+	.toLowerCase()
+	.includes(BRAND_NAME.toLowerCase())
 	? baseTitle
 	: `${baseTitle}${TITLE_SUFFIX}`;
 ---
@@ -92,6 +94,12 @@ const normalizedTitle = baseTitle.toLowerCase().includes(BRAND_NAME.toLowerCase(
 	<slot name="extra-head" />
 
 	<link rel="sitemap" href="/sitemap-index.xml" />
+	<link
+		rel="search"
+		type="application/opensearchdescription+xml"
+		title="Rawkode Academy"
+		href="/opensearch.xml"
+	/>
 
 	<!-- PostHog analytics (loaded lazily, respects DNT) -->
 	<PostHog userId={userId} />

--- a/projects/rawkode.academy/website/src/pages/opensearch.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/opensearch.xml.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from "astro";
+
+const DEFAULT_SITE_URL = "https://rawkode.academy";
+
+export function renderOpenSearchDescription(site: URL | string): string {
+	const base = new URL(typeof site === "string" ? site : site.toString());
+	const searchUrl = new URL("/search?q={searchTerms}", base).href;
+	const selfUrl = new URL("/opensearch.xml", base).href;
+	const favicon16 = new URL("/favicon-16x16.png", base).href;
+	const favicon32 = new URL("/favicon-32x32.png", base).href;
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Rawkode Academy</ShortName>
+  <LongName>Search Rawkode Academy</LongName>
+  <Description>Search videos, articles, news, courses, and people across Rawkode Academy.</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/png">${favicon16}</Image>
+  <Image width="32" height="32" type="image/png">${favicon32}</Image>
+  <Url type="text/html" method="get" template="${searchUrl}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="${selfUrl}"/>
+  <moz:SearchForm>${new URL("/search", base).href}</moz:SearchForm>
+</OpenSearchDescription>`;
+}
+
+export const GET: APIRoute = ({ site }) => {
+	const siteUrl = site ?? new URL(DEFAULT_SITE_URL);
+	const body = renderOpenSearchDescription(siteUrl);
+	return new Response(body, {
+		headers: {
+			"Content-Type": "application/opensearchdescription+xml; charset=utf-8",
+			"Cache-Control": "public, max-age=86400",
+		},
+	});
+};
+
+export const prerender = true;

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -795,6 +795,23 @@ describe("Crawlability and Sitemaps", () => {
 			]),
 		);
 	});
+
+	it("renders an OpenSearch description that points browsers at /search?q={searchTerms}", async () => {
+		const { renderOpenSearchDescription } = await import(
+			"../pages/opensearch.xml.ts"
+		);
+		const xml = renderOpenSearchDescription(new URL("https://rawkode.academy"));
+
+		expect(xml).toContain('xmlns="http://a9.com/-/spec/opensearch/1.1/"');
+		expect(xml).toContain("<ShortName>Rawkode Academy</ShortName>");
+		expect(xml).toContain(
+			'<Url type="text/html" method="get" template="https://rawkode.academy/search?q={searchTerms}"/>',
+		);
+		expect(xml).toContain(
+			'<Url type="application/opensearchdescription+xml" rel="self" template="https://rawkode.academy/opensearch.xml"/>',
+		);
+		expect(xml).toContain("https://rawkode.academy/favicon-16x16.png");
+	});
 });
 
 describe("Related news selector", () => {


### PR DESCRIPTION
## Summary
- New prerendered route `src/pages/opensearch.xml.ts` returning an OpenSearch 1.1 description document. The `Url` template points to the existing `/search?q={searchTerms}` page (no new search endpoint needed).
- Site origin is resolved from the Astro context so dev/preview/prod each emit absolute URLs that match the deploy environment.
- `<link rel="search" type="application/opensearchdescription+xml">` added to `head.astro` so every page advertises the description.
- Unit test in `seo.test.ts` covering the rendered XML (namespace, ShortName, search URL template, self-link, favicon).

## Why
**Reach via power-user retention.** OpenSearch is how browsers learn that a site has its own search. Once registered:
- **Firefox** auto-detects the description and offers "Add Rawkode Academy" in the URL bar's search dropdown — zero-click for the reader.
- **Chromium** browsers (Chrome, Edge, Brave, Arc) let users go to Settings → Manage search engines, click "Add", and type a keyword (e.g. `ra`) — then `ra kubernetes` in the address bar searches the academy directly.
- **Vivaldi, Brave, Opera** and most niche browsers behave similarly.

For technical audiences who already keyword-shortcut MDN, GitHub, etc., adding the academy to that mental model durably increases return visits. The cost is one tiny static XML file and one line in head.

## Test plan
- [ ] Build the site. Hit `https://<preview>/opensearch.xml`. Confirm the XML namespaces are correct and the `Url` template matches `/search?q={searchTerms}`.
- [ ] View source on any production page — confirm the `<link rel="search">` tag is present.
- [ ] Open the deployed site in Firefox. The search dropdown in the address bar should offer to add Rawkode Academy as a search engine.
- [ ] In Chrome: Settings → Manage search engines → confirm "Rawkode Academy" appears under "Inactive shortcuts" (or active, depending on detection heuristic). Add a keyword and test a query.

## Human action required (post-merge / post-deploy)
- [ ] **Smoke-test in your daily browser**. Open `https://rawkode.academy/` in Firefox and look for the "+" / "Add search engine" affordance in the URL bar. If it's missing, the description was rejected — likely a malformed `Url` template — and you should send me the URL to debug.
- [ ] **Pick a memorable keyword** (e.g. `ra` or `rawkode`) and add the search engine to your own Chrome/Firefox so you experience the workflow your readers will. Mention it in a social post — "Type `ra kubernetes` in your address bar" is a great little growth hook.
- [ ] **Confirm the search page handles long-tail queries** users will type from the URL bar. If `/search?q=` does anything weird with special chars (`+`, `&`, quotes), worth a follow-up sanitization PR. Send me an example query that fails.
- [ ] **Optional** — once this is live, advertise via a single tweet/skeet and the `/feeds` page so power-users discover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)