### PR TITLE
feat(rawkode.academy/website): add NewsletterCTA to news detail pages

### DIFF
--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -8,6 +8,7 @@ import {
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb.astro";
 import NewsJsonLd from "@/components/html/news-jsonld.astro";
 import RelatedNews from "@/components/news/RelatedNews.astro";
+import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
@@ -132,6 +133,14 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 			<article class="prose">
 				<Content />
 			</article>
+
+			<NewsletterCTA
+				class="my-12 not-prose"
+				audience="news"
+				badge="Cloud Native news weekly"
+				headline="Stay on top of the cloud-native release wire"
+				subtitle="Kubernetes, AI infra, and CNCF moves — delivered when they matter."
+			/>
 
 			{tags.length > 0 && (
 				<footer class="tags-footer">


### PR DESCRIPTION
## Summary
- Import `NewsletterCTA` on `src/pages/news/[...slug].astro` and render it directly under the article body.
- Pass `audience="news"` so newsletter subscriptions originating from news land in a distinct `EMAIL_PREFERENCES` bucket, mirroring the technology-hub pattern (`audience="technology:{id}"`).
- Custom badge/headline/subtitle copy tuned to the news context.

## Why
**Conversion.** Every other long-form surface already runs this play — articles (`/read`), videos (`/watch`), shows, technology hubs, and the homepage all embed `NewsletterCTA`. News was the only major content type without it. The moment a reader finishes a fresh story they care about is the single highest-converting moment on the site; capturing that into the newsletter funnel is what compounds reach over time (every subscriber is durable distribution for *every* future story).

## Test plan
- [ ] Visit `/news/<slug>`. Newsletter CTA renders after the article body, before the footer.
- [ ] Visit a `/news/<slug>` page while signed-in (PROD only path). If the signed-in user is already subscribed to `audience="news"`, the CTA should reflect that state — the component handles this internally.
- [ ] Compare side-by-side with `/read/<slug>` — visual treatment should match (same component, same `my-12 not-prose` class).
- [ ] Toggle light/dark — already covered by `NewsletterCTA` styling.

## Human action required (post-merge / post-deploy)
- [ ] **Decide on the `audience` value**. I used `"news"` so you can segment news-originated subscribers from `"academy"` general subscribers. If your current backend treats anything other than `"academy"` as a separate list, news signups may end up in a brand-new (empty) list with no broadcasts going to it. Two options:
  - **Keep `audience="news"`** — segments cleanly, but you need to send at least one news-themed broadcast to the list, or move them to `"academy"` once enough subscribers accumulate.
  - **Change to `audience="academy"`** — pools with the general list immediately, simpler, but no news-only segmentation later.
  Comment here with the choice and I'll patch.
- [ ] **Confirm the EMAIL_PREFERENCES backend supports the `"news"` audience string** out of the box. If it rejects unknown audience names, signups from news pages will fail silently in PROD — check one signup end-to-end after deploy.
- [ ] **Update marketing copy / homepage CTA** if you want to mention "subscribe for cloud-native news weekly" as a value prop, now that there's a dedicated capture point.
- [ ] **Watch PostHog** for news → newsletter signup conversion over the next 14 days. If the CTA underperforms vs `/read`, try moving it above the related-news block (currently in #1049) or above the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)