### PR TITLE
feat(rawkode.academy/website): emit fediverse:creator for Mastodon link previews

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/opengraph.astro
+++ b/projects/rawkode.academy/website/src/components/html/opengraph.astro
@@ -48,6 +48,16 @@ const firstAuthorTwitterHandle = shouldShowArticleMeta
 const twitterCreator = firstAuthorTwitterHandle
 	? `@${firstAuthorTwitterHandle.replace(/^@/, "")}`
 	: undefined;
+
+// Mastodon and other Fediverse servers credit the post creator on link
+// previews when this meta tag is present and points at a profile URL.
+const firstAuthorMastodon = shouldShowArticleMeta
+	? authors?.find(
+			(author: CollectionEntry<"people">) =>
+				typeof author.data.mastodon === "string" &&
+				author.data.mastodon.trim().length > 0,
+		)?.data.mastodon
+	: undefined;
 ---
 
 <meta
@@ -61,6 +71,9 @@ const twitterCreator = firstAuthorTwitterHandle
 	property="og:image"
 	content={useImageDirectly ? image?.image : openGraphImageUrl}
 />
+{firstAuthorMastodon && (
+	<meta name="fediverse:creator" content={firstAuthorMastodon} />
+)}
 
 <!-- Article specific Open Graph meta tags -->
 {


### PR DESCRIPTION
## Summary
- Add `<meta name="fediverse:creator" content="{mastodon-profile-url}">` to the OpenGraph head block on article-meta pages (articles, news, series, blog) when the first author has a `mastodon` URL in their people record.
- Skip silently when no author has a Mastodon profile — no broken `content` value.

## Why
**Reach via distribution.** Mastodon and other ActivityPub-compatible servers (Pixelfed, Misskey forks, etc.) honour `fediverse:creator` when rendering link previews. The preview card credits the author and links to their Mastodon profile — same payoff as `twitter:creator` (added in #1045), but for the platform where cloud-native content actually circulates heavily.

This is currently low-saturation territory: most sites don't emit this meta yet. Adding it now means Rawkode Academy posts get a noticeably better treatment on the Fediverse than the median tech publisher, which is exactly the kind of subtle author-friendly polish that earns boosts.

Reference: [Mastodon: "Verify your author rights"](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) — the meta was added in Mastodon 4.3.

## Test plan
- [ ] Build and `view-source:` on a news/article page whose first author has a Mastodon URL set (e.g. `/people/thilo` authors one). Confirm `<meta name="fediverse:creator" content="https://...">` is present.
- [ ] `view-source:` on a news/article page whose authors have no Mastodon URL. Confirm the tag is absent (not rendered as `content=""` or `content="undefined"`).
- [ ] `view-source:` on the homepage (not article-meta). Confirm the tag is absent.

## Human action required (post-merge / post-deploy)
- [ ] **Preview a news/article URL on Mastodon**: paste it into a draft toot from any Mastodon instance (e.g. `mastodon.social/publish`) and confirm the preview card shows the author attribution with a link to their Mastodon profile. If the badge doesn't appear, the Mastodon instance may be on a pre-4.3 version — try a more current instance.
- [ ] **Backfill `mastodon:` URLs** in `content/people/*.mdx` for authors who're on Mastodon but not yet in the file. Without a profile URL, the meta is skipped for that author. Each filled-in profile retroactively benefits every story they've ever written.
- [ ] **Consider adding `mastodon:` for the brand**: there's currently no brand-level fediverse handle. If `@rawkodeacademy@hachyderm.io` (or wherever the official account lives) gets set up, this PR is the place to add a fallback `fediverse:creator` for non-article pages — flag it and I'll do the follow-up.
- [ ] **Optional** — once verified, post one Mastodon toot linking to a fresh news story to flush any cached preview state on relays and confirm the card looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)