### PR TITLE
News digest — May 15, 2026

### DIFF
--- a/content/news/kubernetes-1-36-podgroup-workload-scheduling/index.mdx
+++ b/content/news/kubernetes-1-36-podgroup-workload-scheduling/index.mdx
@@ -1,0 +1,28 @@
+---
+title: "Kubernetes 1.36 splits Workload and PodGroup APIs for batch and AI scheduling"
+description: "Kubernetes v1.36 introduces a new PodGroup API alongside the Workload API in scheduling.k8s.io/v1alpha2, separating static templates from runtime state and unlocking DRA for gang-scheduled workloads."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+Kubernetes v1.36 ships the second iteration of workload-aware scheduling, announced on the project blog May 13, 2026. The shape of the API has changed since v1.35.
+
+## A clean split
+
+`v1.35` introduced the Workload API and basic gang scheduling on a Pod-based framework. `v1.36` moves both APIs to `scheduling.k8s.io/v1alpha2` and splits concerns: the Workload acts as a static template containing `podGroupTemplates`, while the new PodGroup object carries the runtime `schedulingPolicy` and `status.conditions`. The Pod field `workloadRef` is replaced with `schedulingGroup`, which references a PodGroup directly so the scheduler can read scheduling state without parsing the Workload.
+
+## What landed under the new shape
+
+- A new PodGroup scheduling cycle in `kube-scheduler` for atomic workload processing
+- First iterations of topology-aware scheduling and workload-aware preemption
+- `ResourceClaim` support for workloads, extending Dynamic Resource Allocation to entire PodGroups
+- The first phase of integration between the Job controller and the new API
+
+## Still alpha
+
+Everything in `v1alpha2` is alpha. Don't migrate production gang-scheduling off Kueue, Volcano, or YuniKorn yet. But the upstream foundations for the same patterns now exist, and the API shape will keep moving until beta.
+
+**Source:** [Kubernetes v1.36: Advancing Workload-Aware Scheduling](https://kubernetes.io/blog/2026/05/13/kubernetes-v1-36-advancing-workload-aware-scheduling/) — May 13, 2026

--- a/content/news/kubernetes-1-36-psi-metrics-ga/index.mdx
+++ b/content/news/kubernetes-1-36-psi-metrics-ga/index.mdx
@@ -1,0 +1,25 @@
+---
+title: "Kubernetes 1.36 graduates PSI metrics to GA"
+description: "Pressure Stall Information metrics are now GA at node, pod, and container levels in Kubernetes v1.36, giving operators a kernel-grade signal for resource contention without out-of-band tooling."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+Pressure Stall Information (PSI) metrics reached general availability in Kubernetes v1.36, with the announcement landing on the project blog on May 12, 2026.
+
+## What PSI actually measures
+
+PSI surfaces percentages of time tasks are stalled on CPU, memory, or I/O — not how much resource was consumed, but how much time was lost waiting. The kernel has exposed this since 2018; Kubernetes now wires it through the kubelet at node, pod, and container granularity. Each metric ships as a cumulative total plus moving averages over 10s, 60s, and 300s windows, distinguishing transient spikes from sustained contention.
+
+## Production overhead
+
+SIG Node measured kubelet collection overhead consistently below 2.5% of total node capacity, with kernel-level tracking between 0.925% and 3.125%, validated under high-density workloads of 80+ pods.
+
+## Why this matters
+
+PSI gives you a first-class upstream answer to "is this pod actually being starved?" without resorting to eBPF tooling or vendor agents. If you've been reading CPU throttling counters to debug noisy-neighbor problems, you now have a directly applicable signal.
+
+**Source:** [Kubernetes v1.36: PSI Metrics for Kubernetes Graduates to GA](https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/) — May 12, 2026

--- a/content/news/kubernetes-1-36-service-externalips-deprecation/index.mdx
+++ b/content/news/kubernetes-1-36-service-externalips-deprecation/index.mdx
@@ -1,0 +1,31 @@
+---
+title: "Kubernetes 1.36 formally deprecates Service externalIPs"
+description: "The .spec.externalIPs field on Service objects is formally deprecated in Kubernetes v1.36, with kube-proxy implementation slated for removal in a future minor release. Driven by CVE-2020-8554."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+The `.spec.externalIPs` field on Kubernetes Service objects is formally deprecated in v1.36, per the project blog post on May 14, 2026. Implementation removal from `kube-proxy` is planned for a future minor release, and conformance criteria will eventually require implementations not to support it.
+
+## Why it's going
+
+The deprecation is security-driven. [CVE-2020-8554](https://www.cvedetails.com/cve/CVE-2020-8554/) showed that any user with permission to create Services could intercept arbitrary external traffic by claiming an IP. The API assumes all cluster users are fully trusted, which has not matched real deployments for years. Kubernetes has been recommending disabling `externalIPs` since v1.21.
+
+## Migration paths
+
+The blog post calls out three replacements:
+
+- **LoadBalancer Services** with manually managed IPs (simplest, least defensive)
+- **MetalLB** for bare-metal clusters needing real load-balancer semantics
+- **Ingress controllers** for HTTP/HTTPS traffic
+
+This deprecation does **not** affect the Node API's `.status.addresses` `ExternalIP` entries or the `EXTERNAL-IP` column kubectl prints for LoadBalancer Services. Only the `Service.spec.externalIPs` field is being removed.
+
+## What to do
+
+Audit your clusters for `Service.spec.externalIPs` usage now. Some clusters have carried this configuration silently since the 1.x era, and removal is no longer hypothetical.
+
+**Source:** [Kubernetes v1.36: Deprecation and removal of Service ExternalIPs](https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/) — May 14, 2026

--- a/content/news/vllm-0-21-blackwell-transformers-v5/index.mdx
+++ b/content/news/vllm-0-21-blackwell-transformers-v5/index.mdx
@@ -1,0 +1,25 @@
+---
+title: "vLLM 0.21 lands Transformers v5 deprecation, C++20 build, and a new Blackwell attention backend"
+description: "vLLM 0.21.0 ships on May 15 with two breaking-class changes — a C++20 compiler requirement and Transformers v4 deprecation — plus the TOKENSPEED_MLA attention backend for DeepSeek-R1 and Kimi-K25 on Blackwell."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+vLLM v0.21.0 dropped on May 15, 2026 with 367 commits from 202 contributors and two breaking-class changes that will force updates before the next image bump.
+
+## Breaking changes to plan around
+
+The release formally deprecates `transformers` v4 support and tells users to migrate to v5. The build itself now requires a C++20-compatible compiler "for compatibility with PyTorch," called out in the release notes as a breaking build change. Pin your CUDA + toolchain carefully on the next rebuild.
+
+## Blackwell gets a new MLA attention backend
+
+The headline runtime change is the `TOKENSPEED_MLA` attention backend on Blackwell, targeting DeepSeek-R1 and Kimi-K25 for both prefill and decode (model names per the release notes verbatim). KV offloading now integrates with the Hybrid Memory Allocator, and speculative decoding respects reasoning/thinking budgets — useful if you've been serving reasoning models with hand-tuned token caps.
+
+## What to do
+
+If you run vLLM in production, verify your build environment supports C++20 before consuming a newer wheel or image, and start the `transformers` v5 migration now rather than at the next breaking jump. On Blackwell, benchmark `TOKENSPEED_MLA` against your current backend before switching defaults.
+
+**Source:** [vLLM v0.21.0 release notes](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) — May 15, 2026

--- a/content/news/vllm-0-21-blackwell-transformers-v5/index.mdx
+++ b/content/news/vllm-0-21-blackwell-transformers-v5/index.mdx
@@ -4,8 +4,7 @@ description: "vLLM 0.21.0 ships on May 15 with two breaking-class changes — a 
 publishedAt: 2026-05-15
 authors:
   - rawkode
-technologies:
-  - kubernetes
+technologies: []
 ---
 
 vLLM v0.21.0 dropped on May 15, 2026 with 367 commits from 202 contributors and two breaking-class changes that will force updates before the next image bump.


### PR DESCRIPTION
## Summary

Four news segments from the past 7 days (May 8–15, 2026). Three deep-dives on Kubernetes 1.36 features that landed on the project blog this week (PSI metrics GA, the new PodGroup API for workload-aware scheduling, and the formal `Service.spec.externalIPs` deprecation), plus today's vLLM 0.21.0 release with two breaking-class changes and a new Blackwell attention backend. All claims trace to Tier 1 primary sources (kubernetes.io/blog and the vLLM GitHub release).

## Segments

- **vLLM 0.21 lands Transformers v5 deprecation, C++20 build, and a new Blackwell attention backend** — actionable today: build pipelines and downstream lib pins need updates.
- **Kubernetes 1.36 graduates PSI metrics to GA** — upstream kernel-grade contention signal at node/pod/container without out-of-band tooling.
- **Kubernetes 1.36 splits Workload and PodGroup APIs for batch and AI scheduling** — architectural shift in upstream gang scheduling; still alpha, worth tracking.
- **Kubernetes 1.36 formally deprecates Service externalIPs** — security-driven (CVE-2020-8554); migration path needed before `kube-proxy` removal.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| vLLM 0.21.0 released May 15, 2026 | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| vLLM 0.21.0 deprecates `transformers` v4, migrate to v5 | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| vLLM 0.21.0 requires C++20 compiler | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| `TOKENSPEED_MLA` attention backend for DeepSeek-R1 / Kimi-K25 on Blackwell | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ (model names verbatim) |
| 367 commits, 202 contributors | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| PSI metrics GA in Kubernetes v1.36 | https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/ | ✅ |
| PSI exposed at node, pod, container; 10s/60s/300s windows | https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/ | ✅ |
| Kubelet PSI overhead <2.5% under 80+ pods | https://kubernetes.io/blog/2026/05/12/kubernetes-v1-36-psi-metrics-ga/ | ✅ |
| `scheduling.k8s.io/v1alpha2` Workload + PodGroup APIs | https://kubernetes.io/blog/2026/05/13/kubernetes-v1-36-advancing-workload-aware-scheduling/ | ✅ |
| Pod `workloadRef` replaced by `schedulingGroup` | https://kubernetes.io/blog/2026/05/13/kubernetes-v1-36-advancing-workload-aware-scheduling/ | ✅ |
| New PodGroup scheduling cycle, topology-aware scheduling, workload-aware preemption, ResourceClaim/DRA support, Job controller integration phase 1 | https://kubernetes.io/blog/2026/05/13/kubernetes-v1-36-advancing-workload-aware-scheduling/ | ✅ |
| `Service.spec.externalIPs` formally deprecated in v1.36; future `kube-proxy` removal | https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/ | ✅ |
| CVE-2020-8554 as security driver | https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/ | ✅ |
| Recommendation against `externalIPs` since v1.21; LB / MetalLB / Ingress migration alternatives | https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/ | ✅ |

## Items considered and dropped

- **CoreWeave SUNK Self-Service / SUNK Anywhere expansion** — primary press release dated 2026-04-30, outside the 7-day window.
- **Microcks promoted to CNCF Incubating** (2026-05-07) — borderline outside window; topic also narrower than the other survivors.
- **OpenTelemetry Collector v0.152.0** (2026-05-12) — incremental release; no Stage-3 substance survives the skeptic stage.
- **Istio 1.30.0-rc.0** (2026-05-05) — release candidate, not GA; outside window. Worth picking up when 1.30 ships.
- **Kubernetes 1.36 DRA driver / partitionable devices deep-dive** (2026-05-07) — substantive but one day outside the strict 7-day window; consider for next digest if it stays relevant.
- **Kubernetes 1.36 Volume Group Snapshots GA** (2026-05-08) — in-window and verified, but narrower storage audience; cut to keep the digest balanced at four segments.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial → Fact-check → Edit → Final
- Total candidates considered: ~14
- Segments shipped: 4
- Time horizon: 2026-05-08 to 2026-05-15
- File layout follows existing repo convention (`content/news/<slug>/index.mdx`, one folder per segment), not the date-prefixed digest path from the task brief — the content collection schema and existing entries all use per-segment folders.
- Branch: `claude/happy-pascal-Tho2m` (per session assignment)

Please do not self-merge; this needs editorial review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKr3w3ivcaEdpNsopewV5B)_