### PR TITLE
feat(rawkode.academy/website): add per-technology RSS feed

### DIFF
--- a/projects/rawkode.academy/website/src/pages/api/feeds/technology/[id].xml.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/technology/[id].xml.ts
@@ -1,0 +1,100 @@
+import { getCollection } from "astro:content";
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+
+import type { RSSFeedItem } from "@astrojs/rss";
+
+interface Props {
+	technologyName: string;
+	technologyRawId: string;
+	technologyIndexedId: string;
+}
+
+export async function getStaticPaths() {
+	const technologies = await getCollection("technologies");
+	return technologies.map((technology) => {
+		const rawId = technology.id.replace(/\/index$/, "");
+		return {
+			params: { id: rawId },
+			props: {
+				technologyName: technology.data.name,
+				technologyRawId: rawId,
+				technologyIndexedId: technology.id,
+			} satisfies Props,
+		};
+	});
+}
+
+export async function GET(context: APIContext) {
+	const { technologyName, technologyRawId, technologyIndexedId } =
+		context.props as Props;
+
+	const matches = (
+		technologies: ReadonlyArray<string | { id?: string }> | undefined,
+	): boolean => {
+		if (!Array.isArray(technologies)) return false;
+		for (const value of technologies) {
+			const id = typeof value === "string" ? value : value?.id;
+			if (id === technologyRawId || id === technologyIndexedId) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	const [articles, news, videos] = await Promise.all([
+		getCollection("articles", ({ data }) => !data.draft),
+		getCollection("news"),
+		getCollection("videos"),
+	]);
+
+	const items: RSSFeedItem[] = [];
+
+	for (const article of articles) {
+		if (!matches(article.data.technologies)) continue;
+		items.push({
+			title: article.data.title,
+			description: article.data.description ?? "",
+			pubDate: new Date(article.data.publishedAt),
+			link: `/read/${article.id}/`,
+			categories: ["Article", technologyName],
+		});
+	}
+
+	for (const story of news) {
+		if (!matches(story.data.technologies)) continue;
+		items.push({
+			title: story.data.title,
+			description: story.data.description ?? "",
+			pubDate: new Date(story.data.publishedAt),
+			link: `/news/${story.id}/`,
+			categories: ["News", technologyName],
+		});
+	}
+
+	for (const video of videos) {
+		if (!matches(video.data.technologies as ReadonlyArray<string>)) continue;
+		items.push({
+			title: video.data.title,
+			description: video.data.description ?? "",
+			pubDate: new Date(video.data.publishedAt),
+			link: `/watch/${video.data.slug}/`,
+			categories: ["Video", technologyName],
+		});
+	}
+
+	items.sort((a, b) => {
+		const aTime = a.pubDate instanceof Date ? a.pubDate.getTime() : 0;
+		const bTime = b.pubDate instanceof Date ? b.pubDate.getTime() : 0;
+		return bTime - aTime;
+	});
+
+	return rss({
+		title: `Rawkode Academy — ${technologyName}`,
+		description: `Articles, news, and videos about ${technologyName} from Rawkode Academy.`,
+		site: context.site?.toString() || "https://rawkode.academy",
+		items,
+		customData: "<language>en-us</language>",
+		stylesheet: false,
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -131,7 +131,7 @@ export const getStaticPaths = (async () => {
 								name: id,
 								videos,
 								status: DEFAULT_TECHNOLOGY_STATUS,
-								website: '',
+								website: "",
 								license: DEFAULT_TECHNOLOGY_LICENSE,
 							} as Technology,
 						},
@@ -225,7 +225,8 @@ const placeholderLogo = "/apple-touch-icon.png";
 
 const videoCount = technology.videos?.length ?? 0;
 const featuredVideos = (technology.videos ?? []).slice(0, 4);
-const categoryLabel = technology.subcategory ?? technology.category ?? "Cloud Native";
+const categoryLabel =
+	technology.subcategory ?? technology.category ?? "Cloud Native";
 
 const seoTitle =
 	technology.seo?.title ??
@@ -255,7 +256,10 @@ const seoDescription = (() => {
 // noindex these so Google doesn't classify the site as low-quality.
 const noindex = !hasContent && videoCount === 0;
 
-const technologyUrl = new URL(`/technology/${technology.id.replace(/\/index$/, "")}`, Astro.site).href;
+const technologyUrl = new URL(
+	`/technology/${technology.id.replace(/\/index$/, "")}`,
+	Astro.site,
+).href;
 const absoluteLogo = technology.logo
 	? technology.logo.startsWith("http")
 		? technology.logo
@@ -347,6 +351,14 @@ const hasCommunityLinks =
 		documentation={technology.documentation}
 		category={categoryLabel}
 	/>
+	<Fragment slot="extra-head">
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title={`Rawkode Academy — ${technology.name} (RSS)`}
+			href={`/api/feeds/technology/${technology.id.replace(/\/index$/, "")}.xml`}
+		/>
+	</Fragment>
 	<div class="technology-stage page-px section-py section-pt-0">
 		<section class="w-full">
 			<div class="glass-panel technology-header-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto">


### PR DESCRIPTION
## Summary
- New prerendered route `/api/feeds/technology/{id}.xml`. `getStaticPaths` enumerates the technologies collection; one feed is generated per tech, with `/index` stripped so the feed URL matches the canonical `/technology/{id}` page URL.
- Aggregates **articles + news + videos** that tag the technology, sorted newest-first. Carries the content type as an RSS `category` so feed readers can group or theme entries.
- Symmetric matcher handles both the raw id form (`kubernetes`) used by news/articles and the indexed form (`kubernetes/index`) used by videos.
- `<link rel="alternate" type="application/rss+xml">` on `/technology/{id}` pages so feed-reader extensions and apps auto-suggest subscription.

## Why
**Reach.** Today the only feed granularity is global (`articles.xml`, `news.xml`, `videos.xml`, `all.xml`). Anyone who only cares about Kubernetes either subscribes to the firehose (and unsubscribes when noisy) or doesn't subscribe at all — both lossy outcomes. Per-tech feeds match how learners actually think ("I want Rawkode's take on Kubernetes") and convert engaged-but-niche visitors into durable subscribers.

Pairs naturally with the loop already shipped: news → tech tag (#1047) → tech hub with recent news (#1050) → "subscribe to this tech" via the new `<link rel="alternate">`.

## Test plan
- [ ] Build the site. Hit `https://<preview>/api/feeds/technology/kubernetes.xml` — confirm RSS XML with a mix of articles, news, and videos sorted newest-first.
- [ ] Open `https://<preview>/technology/kubernetes` in a feed-reader-aware browser — extension should detect the feed via the `<link rel="alternate">`.
- [ ] Try a tech with only one content type (e.g. a tech that has only videos) — feed renders correctly, doesn't include sections for empty types.
- [ ] Try a tech with no content at all — feed renders an empty `<channel>` (valid RSS).

## Human action required (post-merge / post-deploy)
- [ ] **Validate one feed** in `https://validator.w3.org/feed/` — paste `https://rawkode.academy/api/feeds/technology/kubernetes.xml` and confirm zero errors.
- [ ] **Pick 3–5 hero technologies** (Kubernetes, CNCF, whatever the academy is centred on) and add the feed URL to your launch announcement copy. "Subscribe to our Kubernetes feed" is a more compelling pitch than "subscribe to our feed" and converts better.
- [ ] **Decide on per-tech feeds on the `/feeds` index page**: the `/feeds` page currently lists global feeds. If you want me to add a "Browse feeds by technology" section there, flag it — easy follow-up.
- [ ] **Optional** — once visible in feed analytics, add a small "Subscribe" pill on `/technology/{id}` hub pages near the NewsletterCTA so casual visitors discover the feed without view-source. I left it out of this PR to keep the diff tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)