### PR TITLE
feat(rawkode.academy/website): emit ItemList JSON-LD on the news index

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/news-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/news-itemlist-jsonld.astro
@@ -1,0 +1,34 @@
+---
+import { buildNewsItemListJsonLd } from "@/lib/news-itemlist-jsonld";
+
+interface NewsStoryInput {
+	id: string;
+	data: {
+		title: string;
+		description: string;
+		publishedAt: Date;
+	};
+}
+
+interface Props {
+	stories: ReadonlyArray<NewsStoryInput>;
+	listUrl: string;
+	limit?: number;
+	slot?: string;
+}
+
+const { stories, listUrl, limit } = Astro.props;
+
+const jsonLd = buildNewsItemListJsonLd({
+	siteUrl: (Astro.site ?? Astro.url).origin,
+	listUrl,
+	stories,
+	...(typeof limit === "number" ? { limit } : {}),
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/news-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/news-itemlist-jsonld.ts
@@ -1,0 +1,69 @@
+export interface NewsListEntry {
+	id: string;
+	data: {
+		title: string;
+		description: string;
+		publishedAt: Date;
+	};
+}
+
+export interface BuildNewsItemListJsonLdInput {
+	siteUrl: string;
+	listUrl: string;
+	stories: ReadonlyArray<NewsListEntry>;
+	limit?: number;
+}
+
+const DEFAULT_LIMIT = 20;
+const PUBLISHER_NAME = "Rawkode Academy";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+/**
+ * Build a schema.org ItemList JSON-LD payload for the news index page.
+ *
+ * Each ListItem embeds a NewsArticle item, which is what Google requires for
+ * the Carousel rich result (see https://developers.google.com/search/docs/appearance/structured-data/carousel).
+ */
+export function buildNewsItemListJsonLd(
+	input: BuildNewsItemListJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, listUrl, stories, limit = DEFAULT_LIMIT } = input;
+	const ordered = [...stories]
+		.sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())
+		.slice(0, Math.max(0, limit));
+
+	const itemListElement = ordered.map((story, index) => {
+		const storyUrl = joinUrl(siteUrl, `/news/${story.id}`);
+		return {
+			"@type": "ListItem",
+			position: index + 1,
+			url: storyUrl,
+			item: {
+				"@type": "NewsArticle",
+				headline: story.data.title,
+				description: story.data.description,
+				url: storyUrl,
+				datePublished: new Date(story.data.publishedAt).toISOString(),
+				mainEntityOfPage: { "@type": "WebPage", "@id": storyUrl },
+				publisher: {
+					"@type": "Organization",
+					name: PUBLISHER_NAME,
+					url: siteUrl,
+				},
+			},
+		};
+	});
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: "Cloud Native News",
+		url: listUrl,
+		numberOfItems: itemListElement.length,
+		itemListOrder: "https://schema.org/ItemListOrderDescending",
+		itemListElement,
+	};
+}

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import NewsItemListJsonLd from "@/components/html/news-itemlist-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
@@ -50,6 +51,10 @@ function formatTechnologyLabel(value: string): string {
 
 <Page title={pageTitle} description={pageDescription}>
 	<Fragment slot="extra-head">
+		<NewsItemListJsonLd
+			stories={allNews}
+			listUrl={new URL("/news", Astro.site ?? Astro.url).href}
+		/>
 		<link
 			rel="alternate"
 			type="application/rss+xml"

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -894,6 +894,87 @@ describe("Related news selector", () => {
 	});
 });
 
+describe("News ItemList JSON-LD", () => {
+	it("builds an ItemList of NewsArticle items for the news index, newest first, capped at the limit", async () => {
+		const { buildNewsItemListJsonLd } = await import(
+			"../lib/news-itemlist-jsonld.ts"
+		);
+
+		const stories = [
+			{
+				id: "older",
+				data: {
+					title: "Older story",
+					description: "Older",
+					publishedAt: new Date("2026-04-01T00:00:00.000Z"),
+				},
+			},
+			{
+				id: "newest",
+				data: {
+					title: "Newest story",
+					description: "Newest",
+					publishedAt: new Date("2026-05-15T08:00:00.000Z"),
+				},
+			},
+			{
+				id: "middle",
+				data: {
+					title: "Middle story",
+					description: "Middle",
+					publishedAt: new Date("2026-05-01T00:00:00.000Z"),
+				},
+			},
+		];
+
+		const jsonLd = buildNewsItemListJsonLd({
+			siteUrl: "https://rawkode.academy",
+			listUrl: "https://rawkode.academy/news",
+			stories,
+			limit: 2,
+		});
+
+		expect(jsonLd["@context"]).toBe("https://schema.org");
+		expect(jsonLd["@type"]).toBe("ItemList");
+		expect(jsonLd.url).toBe("https://rawkode.academy/news");
+		expect(jsonLd.numberOfItems).toBe(2);
+		expect(jsonLd.itemListOrder).toBe(
+			"https://schema.org/ItemListOrderDescending",
+		);
+
+		const elements = jsonLd.itemListElement as Array<Record<string, unknown>>;
+		expect(elements).toHaveLength(2);
+		expect(elements[0]?.position).toBe(1);
+		expect(elements[0]?.url).toBe("https://rawkode.academy/news/newest");
+		expect(elements[1]?.position).toBe(2);
+		expect(elements[1]?.url).toBe("https://rawkode.academy/news/middle");
+
+		const firstItem = elements[0]?.item as Record<string, unknown>;
+		expect(firstItem["@type"]).toBe("NewsArticle");
+		expect(firstItem.headline).toBe("Newest story");
+		expect(firstItem.datePublished).toBe("2026-05-15T08:00:00.000Z");
+		const mainEntity = firstItem.mainEntityOfPage as Record<string, unknown>;
+		expect(mainEntity["@id"]).toBe("https://rawkode.academy/news/newest");
+		const publisher = firstItem.publisher as Record<string, unknown>;
+		expect(publisher.name).toBe("Rawkode Academy");
+
+		expect(() => JSON.stringify(jsonLd)).not.toThrow();
+	});
+
+	it("returns an empty ItemList when given no stories", async () => {
+		const { buildNewsItemListJsonLd } = await import(
+			"../lib/news-itemlist-jsonld.ts"
+		);
+		const jsonLd = buildNewsItemListJsonLd({
+			siteUrl: "https://rawkode.academy",
+			listUrl: "https://rawkode.academy/news",
+			stories: [],
+		});
+		expect(jsonLd.numberOfItems).toBe(0);
+		expect(jsonLd.itemListElement).toEqual([]);
+	});
+});
+
 describe("Structured Data Validation", () => {
 	it("should model VideoObject JSON-LD with clip urls, captions, and transcript text", () => {
 		const videoJsonLd = {


### PR DESCRIPTION
## Summary
- New pure-TS builder `src/lib/news-itemlist-jsonld.ts` that produces a `schema.org/ItemList` payload whose `itemListElement` entries are `ListItem` wrappers around full `NewsArticle` items (headline, description, datePublished, mainEntityOfPage, publisher).
- Thin Astro wrapper `src/components/html/news-itemlist-jsonld.astro` that resolves the site origin from context.
- Wired into `/news/index.astro` via the `extra-head` slot so the JSON-LD lands in `<head>` like the rest of the structured data.
- Cap of 20 newest stories (matches Google's recommendation for list-type rich results).
- Two unit tests cover the shape, ordering, limit, embedded item details, and the empty-list case.

## Why
**Reach.** This is the missing third leg of the news structured-data stack:
- **#1041** got news pages into sitemaps (indexability).
- **#1042** added `NewsArticle` JSON-LD on each story (detail-page rich results).
- **This PR** adds `ItemList` JSON-LD on the index (list-page rich results — Google's news Carousel).

Index pages need their own structured data to be eligible for list-shaped rich results; the detail-page schema doesn't carry over. With this in place, `/news` becomes eligible for the news Carousel treatment in Google Search and Discover.

## Test plan
- [ ] Build the site. `view-source:` on `/news` and confirm a `<script type="application/ld+json">` with `@type: "ItemList"` is present, containing the most recent up-to-20 stories as `ListItem` → `NewsArticle` entries.
- [ ] Paste the rendered JSON into `https://validator.schema.org/` and confirm zero errors.
- [ ] Confirm `numberOfItems` matches the actual rendered list (i.e. capped at 20 even if more news exists in the collection).
- [ ] No duplicates with the existing `SearchActionJsonLd` / `OrganizationJsonLd` (those are global and orthogonal).

## Human action required (post-merge / post-deploy)
- [ ] **Validate the production URL** in [Google Rich Results Test](https://search.google.com/test/rich-results?url=https://rawkode.academy/news). Expect "ItemList" reported as detected, no errors. Warnings about optional fields are fine.
- [ ] **Same URL in Schema.org validator**: `https://validator.schema.org/?url=https://rawkode.academy/news`. Expect zero errors.
- [ ] **Watch GSC Enhancements → Sitelinks / Article / ItemList** for the next 1–2 weeks. If the index URL trips a "Missing field" flag, ping me and I'll patch.
- [ ] **Optional** — once visible in GSC, consider the same treatment on `/read` (articles index), `/courses`, `/learning-paths`. Each surface gets its own list rich-result eligibility. Standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)