### PR TITLE
feat(rawkode.academy/website): emit rel=me on people pages for Mastodon/IndieWeb verification

### DIFF
--- a/projects/rawkode.academy/website/src/pages/people/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/people/[id].astro
@@ -70,6 +70,7 @@ const showSummaries: ShowSummary[] = await Promise.all(
 		const showVideos = videos.filter((v) => v.data.show?.id === show.data.id);
 		const hosts = await getEntries(show.data.hosts);
 
+
 		return {
 			id: show.data.id,
 			name: show.data.name,
@@ -205,6 +206,20 @@ const socialLinks = [
 		icon: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71 M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71",
 	},
 ].filter(Boolean);
+
+// rel="me" advertises that this profile owns the linked accounts.
+// Mastodon's verification crawler reads this on visit (either head <link>
+// or body <a>) and shows a green checkmark on the corresponding profile
+// link. Same mechanism works for other Fediverse/IndieWeb tools.
+const relMeUrls = [
+	person.data.mastodon,
+	person.data.github,
+	person.data.bluesky,
+	person.data.twitter,
+	person.data.linkedin,
+	person.data.website,
+	person.data.youtube,
+].filter((url): url is string => typeof url === "string" && url.length > 0);
 ---
 
 <Page
@@ -230,6 +245,11 @@ const socialLinks = [
             person.data.mastodon,
         ]}
     />
+    <Fragment slot="extra-head">
+        {relMeUrls.map((url) => (
+            <link rel="me" href={url} />
+        ))}
+    </Fragment>
     <div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
         <!-- Profile Header -->
         <section class="w-full">
@@ -266,7 +286,7 @@ const socialLinks = [
                                 <a
                                     href={link.url}
                                     target="_blank"
-                                    rel="noopener noreferrer"
+                                    rel="me noopener noreferrer"
                                     class="p-3 rounded-full bg-gray-100 dark:bg-gray-800 text-muted hover:bg-primary hover:text-white dark:hover:bg-primary dark:hover:text-white transition-all duration-300 shadow-sm hover:shadow-md"
                                     aria-label={link.name}
                                 >


### PR DESCRIPTION
## Summary
- Add `<link rel="me">` tags in the head of every `/people/[id]` page, one per known external profile URL (Mastodon, GitHub, Bluesky, Twitter, LinkedIn, website, YouTube).
- Add `me` to the `rel` attribute on the visible social-link chips: `rel="me noopener noreferrer"`.
- No UI change. The behaviour activates the moment any contributor lists their `/people/{id}` URL on Mastodon (or another IndieAuth/IndieWeb tool).

## Why
**Reach via author credibility.** Mastodon's verification protocol works like this: a user adds a personal-site URL to their Mastodon profile, Mastodon's crawler hits that URL, and if it finds a `rel="me"` link pointing back to the user's Mastodon profile, it renders the link with a green checkmark and the word "verified". This visible signal materially increases click-throughs and trust on the Fediverse.

Same mechanism extends to GitHub (which honours `rel="me"` for the IndieAuth protocol), IndieAuth in general, and most modern Fediverse software. Costs nothing — the data was already on the person record — and gives every authored piece of content stronger author credibility wherever it's shared.

Pairs with #1053 (fediverse:creator on shared cards) and #1048 (authored-content on person pages) — same Fediverse audience, complementary touch.

## Test plan
- [ ] Build the site. `view-source:` on `/people/rawkode` — confirm `<link rel="me" href="...">` tags appear in head for each social URL on file.
- [ ] Confirm the visible social-link chips render `rel="me noopener noreferrer"` (DevTools → Elements).
- [ ] Visit `/people/<someone-without-mastodon>` — head should only emit `rel="me"` for profiles the person actually has set.

## Human action required (post-merge / post-deploy)
- [ ] **End-to-end verification test**: pick one author with a Mastodon profile (yourself if convenient). On your Mastodon profile → Edit profile → Profile metadata → add a row pointing at `https://rawkode.academy/people/<your-id>`. Save. Refresh your Mastodon profile within a few minutes — the link should now render with a green checkmark. If it doesn't, paste the academy page URL into [IndieWebify.me](https://indiewebify.me) and the "rel-me" check should pass.
- [ ] **Announce to contributors**: a short heads-up on Discord / the next contributor sync ("Add your academy profile to your Mastodon to get verified") activates the value for the people who'd most benefit.
- [ ] **Backfill `mastodon:` URLs** in `content/people/*.mdx` for active contributors who are on Mastodon but not yet listed. Each filled-in URL unlocks the verification path for that person.
- [ ] **Optional follow-up** — Mastodon also accepts `<a rel="me">` in body. The visible chips on this page already cover Twitter/GitHub/LinkedIn/website. Surfacing Mastodon and Bluesky chips in the visible UI (with icons) is a logical next step. I left it out of this PR to keep the scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)