### PR TITLE
fix(rawkode.academy/website): link article bylines to /people/{id} instead of GitHub

### DIFF
--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -106,17 +106,18 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 				<div class="byline-authors">
 					{authors.map((author) => (
 						<a
-							href={author.data.github}
-							target="_blank"
-							rel="author noopener noreferrer"
+							href={`/people/${author.data.id}`}
+							rel="author"
 							class="author"
 						>
-							<img
-								src={author.data.avatarUrl}
-								alt=""
-								class="author-avatar"
-								loading="lazy"
-							/>
+							{author.data.avatarUrl && (
+								<img
+									src={author.data.avatarUrl}
+									alt=""
+									class="author-avatar"
+									loading="lazy"
+								/>
+							)}
 							<span class="author-name">{author.data.name}</span>
 						</a>
 					))}


### PR DESCRIPTION
## Summary
Mirror of #1044, applied to `/read/[slug]`:
- Author chip `href` switches from `author.data.github` to `/people/${author.data.id}`.
- Drop `target="_blank"` and the `noopener noreferrer` rel values (no longer needed for same-origin).
- Guard the avatar `<img>` so authors without a GitHub handle don't render a broken image.

## Why
**Retention.** Article bylines used to fire every click straight to github.com — instant exit from the site, no further surfacing of the author's work. The `/people/{id}` destination now (after #1048) lists their authored articles, news, videos, and shows, so the click pays off.

This is the matching fix to what #1044 did for `/news/[slug]`. Articles are the higher-traffic surface, so the win is larger here per-author. Same patch shape, different file.

## Test plan
- [ ] Visit any `/read/<slug>` page, click an author chip → lands on `/people/<id>`, no new tab opens.
- [ ] Visit an article whose author has no GitHub handle → name renders, no broken `<img>`.
- [ ] PostHog / Faro pageviews on `/people/*` should rise once this ships and article-byline traffic flows through.

## Human action required (post-merge / post-deploy)
- [ ] **Verify `/people/{id}` pages your article authors land on are polished**. Same check you'd do for the news byline fix in #1044 — if any author page is sparse, prioritise filling the bio body.
- [ ] **Compare clickthrough**: with both #1044 (news bylines) and this PR live, the `/news → /people` and `/read → /people` edges in PostHog should both materialise. If one is much smaller than the other, the visible affordance differs between the two surfaces — flag it and I'll align them.
- [ ] **Optional** — once both byline fixes are merged, audit `/watch/[slug]` and `/shows/[showId]` for the same pattern. Guest/host chips on videos might also link out instead of landing on the on-site profile. Standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)