### PR TITLE
feat(rawkode.academy/website): add per-author RSS feed

### DIFF
--- a/projects/rawkode.academy/website/src/pages/api/feeds/people/[id].xml.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/people/[id].xml.ts
@@ -1,0 +1,128 @@
+import { getCollection } from "astro:content";
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+
+import type { RSSFeedItem } from "@astrojs/rss";
+
+interface Props {
+	personId: string;
+	personName: string;
+}
+
+const matchRef = (
+	ref: { collection?: string; id?: string } | string | undefined,
+	id: string,
+): boolean => {
+	if (!ref) return false;
+	if (typeof ref === "string") return ref === id;
+	return ref.id === id;
+};
+
+const hasContribution = async (personId: string): Promise<boolean> => {
+	const [articles, news, videos] = await Promise.all([
+		getCollection("articles", ({ data }) => !data.draft),
+		getCollection("news"),
+		getCollection("videos"),
+	]);
+
+	const inArticles = articles.some((article) =>
+		article.data.authors.some((author) => matchRef(author, personId)),
+	);
+	if (inArticles) return true;
+
+	const inNews = news.some((story) =>
+		story.data.authors.some((author) => matchRef(author, personId)),
+	);
+	if (inNews) return true;
+
+	const inVideos = videos.some((video) =>
+		video.data.guests.some((guest) => matchRef(guest, personId)),
+	);
+	return inVideos;
+};
+
+export async function getStaticPaths() {
+	const people = await getCollection("people");
+	const results = await Promise.all(
+		people.map(async (person) => {
+			const has = await hasContribution(person.data.id);
+			if (!has) return null;
+			return {
+				params: { id: person.data.id },
+				props: {
+					personId: person.data.id,
+					personName: person.data.name,
+				} satisfies Props,
+			};
+		}),
+	);
+	return results.filter(
+		(entry): entry is NonNullable<typeof entry> => entry !== null,
+	);
+}
+
+export async function GET(context: APIContext) {
+	const { personId, personName } = context.props as Props;
+
+	const [articles, news, videos] = await Promise.all([
+		getCollection("articles", ({ data }) => !data.draft),
+		getCollection("news"),
+		getCollection("videos"),
+	]);
+
+	const items: RSSFeedItem[] = [];
+
+	for (const article of articles) {
+		if (!article.data.authors.some((author) => matchRef(author, personId))) {
+			continue;
+		}
+		items.push({
+			title: article.data.title,
+			description: article.data.description ?? "",
+			pubDate: new Date(article.data.publishedAt),
+			link: `/read/${article.id}/`,
+			categories: ["Article"],
+		});
+	}
+
+	for (const story of news) {
+		if (!story.data.authors.some((author) => matchRef(author, personId))) {
+			continue;
+		}
+		items.push({
+			title: story.data.title,
+			description: story.data.description ?? "",
+			pubDate: new Date(story.data.publishedAt),
+			link: `/news/${story.id}/`,
+			categories: ["News"],
+		});
+	}
+
+	for (const video of videos) {
+		if (!video.data.guests.some((guest) => matchRef(guest, personId))) {
+			continue;
+		}
+		items.push({
+			title: video.data.title,
+			description: video.data.description ?? "",
+			pubDate: new Date(video.data.publishedAt),
+			link: `/watch/${video.data.slug}/`,
+			categories: ["Video"],
+		});
+	}
+
+	items.sort((a, b) => {
+		const aTime = a.pubDate instanceof Date ? a.pubDate.getTime() : 0;
+		const bTime = b.pubDate instanceof Date ? b.pubDate.getTime() : 0;
+		return bTime - aTime;
+	});
+
+	return rss({
+		title: `Rawkode Academy — ${personName}`,
+		description: `Articles, news, and video appearances by ${personName} on Rawkode Academy.`,
+		site: context.site?.toString() || "https://rawkode.academy",
+		items,
+		customData: "<language>en-us</language>",
+		stylesheet: false,
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/people/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/people/[id].astro
@@ -249,6 +249,12 @@ const relMeUrls = [
         {relMeUrls.map((url) => (
             <link rel="me" href={url} />
         ))}
+        <link
+            rel="alternate"
+            type="application/rss+xml"
+            title={`Rawkode Academy — ${person.data.name} (RSS)`}
+            href={`/api/feeds/people/${person.data.id}.xml`}
+        />
     </Fragment>
     <div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
         <!-- Profile Header -->


### PR DESCRIPTION
## Summary
- New prerendered route `src/pages/api/feeds/people/[id].xml.ts`. `getStaticPaths` enumerates the people collection, generates one feed per person who has at least one published contribution (article, news, or video appearance). People with no contributions are filtered out to avoid empty feeds.
- Aggregates **articles + news + videos** where the person is in `data.authors` (articles/news) or `data.guests` (videos), sorted newest-first. Content type carried as an RSS `category` so feed-reader UIs can group entries.
- `<link rel="alternate" type="application/rss+xml">` on `/people/[id]` so feed-reader extensions auto-detect on visit.

## Why
**Reach.** The author-focused chain so far:
1. **#1044 / #1058** — news and article bylines now route to `/people/{id}` (on-site, not GitHub).
2. **#1048** — that page lists the person's authored articles, news, and video appearances.
3. **#1057** — emits `rel="me"` so the page can be set as a verified Mastodon link.
4. **This PR** — adds the missing "follow this author" capability for RSS readers.

Pairs structurally with #1055 (per-technology feed). Together they cover the two most common "narrow my firehose" subscription axes for an academy's audience: by-topic and by-creator.

## Test plan
- [ ] Build. Hit `https://<preview>/api/feeds/people/rawkode.xml` — confirm RSS with a mix of articles, news, and videos sorted newest-first.
- [ ] Hit a person who has no contributions (e.g. a host-only person with no videos as guest, no authored content) — confirm the route 404s rather than ships an empty feed.
- [ ] `view-source:` on `/people/rawkode` — confirm `<link rel="alternate" type="application/rss+xml">` is present pointing at the per-author feed.
- [ ] Open `/people/rawkode` in a feed-reader-aware browser — extension should detect the per-author feed.

## Human action required (post-merge / post-deploy)
- [ ] **Validate one feed** in `https://validator.w3.org/feed/` — paste `https://rawkode.academy/api/feeds/people/rawkode.xml` and confirm zero errors.
- [ ] **Decide on `/feeds` page surfacing**: today `/feeds` lists global feeds. Adding "Browse feeds by person" and "Browse feeds by technology" (#1055) would help discoverability. Comment with preference and I'll do the follow-up.
- [ ] **Tell active contributors** they have their own RSS feed now. "Subscribe to all of David's posts at `https://rawkode.academy/api/feeds/people/rawkode.xml`" makes a strong launch tweet/toot and gives every contributor a small personal megaphone.
- [ ] **Optional follow-up** — extend video matching to include `hosts` (currently only matches `guests`). Today a host's per-author feed shows their authored content + guest spots, but not videos where they're the host. Standalone follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)