### PR TITLE
feat(rawkode.academy/website): emit RSS/Atom auto-discovery on /read and /watch

### DIFF
--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -91,6 +91,20 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 	) : (
 		<ArticleJsonLd slot="extra-head" article={article} authors={authors} />
 	)}
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/rss+xml"
+		title="Rawkode Academy - Articles (RSS)"
+		href="/api/feeds/articles.xml"
+	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/atom+xml"
+		title="Rawkode Academy - Articles (Atom)"
+		href="/api/feeds/articles.atom"
+	/>
 
 	<div class="article-page">
 		<!-- Breadcrumb -->

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -31,6 +31,20 @@ const pageDescription =
 ---
 
 <Page title={pageTitle} description={pageDescription}>
+  <Fragment slot="extra-head">
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Rawkode Academy - Articles (RSS)"
+      href="/api/feeds/articles.xml"
+    />
+    <link
+      rel="alternate"
+      type="application/atom+xml"
+      title="Rawkode Academy - Articles (Atom)"
+      href="/api/feeds/articles.atom"
+    />
+  </Fragment>
   <style>
     @reference "../../styles/global.css";
 

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -242,6 +242,20 @@ if (isAuthenticated && user?.id) {
 		category={video.data.category}
 		clips={clips}
 	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/rss+xml"
+		title="Rawkode Academy - Videos (RSS)"
+		href="/api/feeds/videos.xml"
+	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/atom+xml"
+		title="Rawkode Academy - Videos (Atom)"
+		href="/api/feeds/videos.atom"
+	/>
 	<div class="min-h-screen">
 		<div class="container-content content-px py-4 sm:py-6 lg:py-8">
 			{/* Breadcrumb */}

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -121,6 +121,20 @@ const hasNextPage = end < allVideos.length;
 		description="Explore our collection of educational videos about cloud native technologies, development practices, and more."
 		isVideoList={true}
 	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/rss+xml"
+		title="Rawkode Academy - Videos (RSS)"
+		href="/api/feeds/videos.xml"
+	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/atom+xml"
+		title="Rawkode Academy - Videos (Atom)"
+		href="/api/feeds/videos.atom"
+	/>
 
 	<!-- Featured Content Section -->
 	{featuredVideo && (


### PR DESCRIPTION
## Summary
Add `<link rel="alternate" type="application/rss+xml">` and `application/atom+xml` discovery tags to four content surfaces:
- `/read/index.astro` (articles listing) → `articles.xml` + `articles.atom`
- `/read/[...slug].astro` (article detail) → same
- `/watch/index.astro` (videos listing) → `videos.xml` + `videos.atom`
- `/watch/[...slug].astro` (video detail) → same

## Why
**Reach.** RSS + Atom feeds for articles and videos have existed for ages, but until now they were only discoverable by anyone who'd already navigated to `/feeds`. Feed-reader extensions (Feedbro, RSSPreview, Vivaldi's built-in panel, the Firefox sidebar) and standalone readers (NetNewsWire, Feedly, Inoreader) all look for `<link rel="alternate">` in the head and surface "Subscribe to this site" affordances when present.

#1043 already did this for news. This PR finishes the same play for articles and videos — the three content types now all advertise their feeds at the head level of every relevant page.

## Test plan
- [ ] Visit `https://<preview>/read` in a browser with a feed-reader extension installed. The extension should offer to subscribe to the Articles RSS feed.
- [ ] Same for `https://<preview>/watch` → Videos RSS.
- [ ] `view-source:` on each of the four affected pages — confirm both `<link rel="alternate" type="application/rss+xml">` and `<link rel="alternate" type="application/atom+xml">` are present.
- [ ] No regression on news (still has its discovery tags from #1043).

## Human action required (post-merge / post-deploy)
- [ ] **Smoke-test in a feed-reader-aware browser** (Vivaldi or Firefox with Feedbro). Visit `/read`, `/watch`, and `/news` and confirm each suggests the right per-collection feed. If the wrong feed shows up on a page, the `<link>` got crossed — ping me.
- [ ] **Decide on homepage discovery**: this PR doesn't touch `/`. If you want the homepage to advertise the combined `all.xml` feed, comment and I'll do the follow-up. Trade-off: setting the homepage to `all.xml` is the most-inclusive default; not setting anything keeps feed readers from suggesting subscription on the home page (which is sometimes desired so people land on per-collection pages first).
- [ ] **Mention the auto-discovery in marketing copy**: most engineers don't know to look. A single line on the `/feeds` page like "Tip: your browser's feed-reader extension will detect these automatically when you visit /read or /watch" gives the feature a free callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)