### PR TITLE
News digest — May 15, 2026

### DIFF
--- a/content/news/cilium-may-2026-patch-wave/index.mdx
+++ b/content/news/cilium-may-2026-patch-wave/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "Cilium Ships Coordinated Patch Wave Across 1.17, 1.18, and 1.19"
+description: "Cilium published v1.19.4, v1.18.10, and v1.17.16 on May 13, fixing IPsec packet drops during key rotation, ARP failures for LoadBalancer services, and a CiliumLocalRedirectPolicy edge case that could override an existing Service frontend."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - cilium
+---
+
+Cilium published patch releases for all three supported branches on May 13: v1.19.4, v1.18.10, and v1.17.16. No new CVEs were assigned in this wave, but the bug list is dominated by production-stability fixes worth tracking, especially for clusters using IPsec, the egress gateway, or LocalRedirectPolicies.
+
+## What's fixed
+
+- **IPsec packet drops during key rotation.** Rolling restarts with key rotation could drop packets — fixed across the wave.
+- **WireGuard MTU clamping.** MTU is now clamped to `IPV6_MIN_MTU` (1280) to prevent packet loss in tunnel-plus-encryption scenarios.
+- **ARP failures for LoadBalancer services.** Caused by pointer reuse during BPF map iteration; this manifested as intermittent service unreachability.
+- **CiliumLocalRedirectPolicy edge case.** The `addressMatcher` could override an existing Service's frontend when its backend pods were not yet `Ready`. Patched.
+- **L7 LoadBalancer / Ingress drops on bridged kernels.** Specific kernel/bridge combinations saw traffic drops; resolved.
+- **SocketLB error codes.** Returned incorrect codes when services lacked backends, breaking client retry logic that keyed on errno.
+- **Datapath reinitialization deadlock** when triggered from the local API.
+
+## Notable smaller items
+
+- `EndpointSlices` are now filtered by the `service-proxy-name` label at watch level, reducing apiserver load in clusters that segment proxies.
+- iptables masquerading respects longest-prefix-match via route sorting — fixes a subtle correctness issue when overlapping CIDRs are configured.
+- The SPIRE client is now configurable for `ztunnel`, useful for service-mesh integrations.
+- `x/net` was bumped to v0.53 and base images refreshed.
+
+## What to do
+
+If you run IPsec with periodic key rotation, or rely on LoadBalancer services on hosts where ARP behavior is sensitive, this patch wave is worth scheduling promptly. Operators on 1.18.0–1.18.5 should also confirm they're past v1.18.6 if they ever ran WireGuard with the beta Node Encryption feature — that earlier fix addressed CVE-2026-26963 and is unrelated to this wave.
+
+**Sources:** [Cilium v1.19.4](https://github.com/cilium/cilium/releases/tag/v1.19.4), [Cilium v1.18.10](https://github.com/cilium/cilium/releases/tag/v1.18.10), [Cilium v1.17.16](https://github.com/cilium/cilium/releases/tag/v1.17.16) — May 13, 2026.

--- a/content/news/kubernetes-may-2026-patch-wave/index.mdx
+++ b/content/news/kubernetes-may-2026-patch-wave/index.mdx
@@ -1,0 +1,25 @@
+---
+title: "Kubernetes Ships May Patch Wave Across 1.33–1.36, Fixes IPv6 ServiceCIDR Allocation Bug"
+description: "Kubernetes 1.36.1, 1.35.5, 1.34.8, and 1.33.12 landed on the May 12 cherry-pick window. No CVEs, but a real correctness bug — services getting IPv6 addresses outside their allocated CIDR — is among the fixes."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+Kubernetes shipped its scheduled May patch wave: v1.36.1, v1.35.5, v1.34.8, and v1.33.12, all built off the May 8 cherry-pick deadline with target dates of May 12–13. No CVEs were rolled in this cycle, but the v1.34.8 changelog includes a handful of fixes that production operators should read before skipping the upgrade.
+
+## Notable fixes
+
+- **IPv6 ServiceCIDR allocation correctness ([#138385](https://github.com/kubernetes/kubernetes/pull/138385)).** A bug allowed 64-bit IPv6 ServiceCIDRs to allocate addresses outside the configured subnet range. If you run dual-stack or IPv6-only services, validate your allocations after upgrading.
+- **Scheduler in-flight queue cleanup ([#138435](https://github.com/kubernetes/kubernetes/pull/138435)).** Stale state could persist after failed scheduling attempts, with cascading effects on subsequent decisions.
+- **Kube-proxy large-cluster sync ([#138637](https://github.com/kubernetes/kubernetes/pull/138637)).** Full-sync was being skipped under "large cluster mode" in cases where it shouldn't have been.
+- **Windows HNS endpoint cleanup ([#138601](https://github.com/kubernetes/kubernetes/pull/138601)).** Addresses DNS timeouts on L2Bridge networks — a long-standing pain point for Windows nodes.
+- **Kubeadm and kubelet fixes ([#138685](https://github.com/kubernetes/kubernetes/pull/138685) and others).** Better handling of delayed load balancers during init, etcd cluster status checks, LocalAPIEndpoint defaulting, and pod-startup SLI metric accuracy.
+
+## Support context
+
+v1.34 enters maintenance mode on August 27, 2026, with end-of-life on October 27. Operators still on v1.33 should be planning their move; the 1.33.12 patch is a continuity release rather than a destination.
+
+**Sources:** [Kubernetes patch release schedule](https://kubernetes.io/releases/patch-releases/), [CHANGELOG-1.34](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md) — May 12–13, 2026.

--- a/content/news/vllm-0-21-blackwell-breaking-changes/index.mdx
+++ b/content/news/vllm-0-21-blackwell-breaking-changes/index.mdx
@@ -1,0 +1,36 @@
+---
+title: "vLLM 0.21 Lands With C++20 Requirement, Transformers v5 Migration, and a New Blackwell MLA Backend"
+description: "vLLM 0.21.0 ships breaking compiler and dependency requirements alongside KV-offload integration and a TOKENSPEED_MLA attention backend for DeepSeek-R1 and Kimi-K25 on Blackwell GPUs."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies: []
+---
+
+vLLM cut the v0.21.0 release on May 15. The notes record 367 commits from 202 contributors (49 of them new) since v0.20.0. Two breaking changes lead the list, so anyone running v0.20.x in production should treat this as a planned upgrade rather than a drop-in.
+
+## Breaking changes
+
+- **C++20 compiler required.** PyTorch's own toolchain bump propagates here. Custom build pipelines pinned to older toolchains will fail.
+- **Transformers v4 deprecated.** vLLM now expects Transformers v5. Any model loader paths or tokenizer code coupled to v4 internals needs to move.
+
+## KV offloading and the Hybrid Memory Allocator
+
+The release integrates KV offloading with the Hybrid Memory Allocator (HMA), adds scheduler-side sliding-window group support, and ships a `MooncakeStoreConnector` for distributed KV stores. For long-context and multi-tenant inference, this consolidates a set of features that previously lived behind different connectors and flags.
+
+## Speculative decoding for reasoning models
+
+Speculative decoding now respects reasoning/thinking budgets, which was a correctness gap for spec-decoding against models that emit hidden reasoning tokens. Drafter attention backends can be selected independently from the main model. Multimodal speculative decoding lands with warnings — usable, but not yet a recommended production path.
+
+## New attention backend on Blackwell
+
+A new `TOKENSPEED_MLA` attention backend targets DeepSeek-R1 and Kimi-K25 prefill+decode on Blackwell GPUs. Faster FP8 group-quant kernels are also in. AMD ROCm 7.2.2 support, Dynamic Batch Optimization, and a Fused Shared Expert path for Qwen3-Next round out the hardware story; Intel XPU gains a top-k/top-p sample kernel and LoRA support.
+
+## What to do
+
+- If you're on v0.20.x, plan the Transformers v5 migration before upgrading.
+- Custom container builds need a C++20-capable compiler.
+- DeepSeek-R1 / Kimi-K25 on Blackwell is the most concrete reason to move quickly.
+- Validate spec-decoding behavior on any reasoning-model deployments — the budget-aware path changes prior outputs.
+
+**Source:** [vLLM v0.21.0 release notes](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) — May 15, 2026.


### PR DESCRIPTION
## Summary

Three news segments covering the May 8–15 window. Two are coordinated patch waves from production-critical projects (Kubernetes, Cilium); one is a fast-moving inference engine release (vLLM v0.21.0) with breaking changes that warrant a planned upgrade. Items selected for technical substance and operational relevance — no vendor announcements, no event/scheduling PR, no items widely covered without a non-obvious angle.

## Segments

- **vLLM 0.21 lands with C++20 requirement, Transformers v5 migration, and a new Blackwell MLA backend** — Breaking compiler/dependency requirements plus KV-offload integration and TOKENSPEED_MLA for DeepSeek-R1/Kimi-K25. Anyone on v0.20.x needs to plan the migration.
- **Cilium ships coordinated patch wave across 1.17, 1.18, and 1.19** — IPsec packet drops during key rotation, ARP failures for LoadBalancer services, and a CiliumLocalRedirectPolicy edge case. Production stability fixes worth scheduling.
- **Kubernetes ships May patch wave across 1.33–1.36, fixes IPv6 ServiceCIDR allocation bug** — No CVEs, but a real correctness bug in IPv6 ServiceCIDR allocation, plus scheduler queue cleanup, kube-proxy large-cluster sync, and Windows DNS fixes.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| vLLM v0.21.0 released May 15, 367 commits, 202 contributors | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| vLLM v0.21.0 breaking changes: C++20 required, Transformers v4 deprecated | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| TOKENSPEED_MLA backend for DeepSeek-R1/Kimi-K25 on Blackwell | https://github.com/vllm-project/vllm/releases/tag/v0.21.0 | ✅ |
| Cilium v1.19.4 / v1.18.10 / v1.17.16 released May 13 | https://github.com/cilium/cilium/releases | ✅ |
| CiliumLocalRedirectPolicy addressMatcher fix for not-Ready backends | https://github.com/cilium/cilium/releases/tag/v1.19.4 | ✅ |
| IPsec packet drops during rolling restart with key rotation, fixed | https://github.com/cilium/cilium/releases/tag/v1.19.4 | ✅ |
| WireGuard MTU clamped to IPV6_MIN_MTU (1280) | https://github.com/cilium/cilium/releases/tag/v1.19.4 | ✅ |
| CVE-2026-26963 affects Cilium 1.18.0–1.18.5, fixed in 1.18.6 (referenced for context, not as part of this wave) | https://nvd.nist.gov/vuln/detail/CVE-2026-26963 | ✅ |
| Kubernetes 1.36.1 / 1.35.5 / 1.34.8 / 1.33.12 target dates May 12–13 | https://kubernetes.io/releases/patch-releases/ | ✅ |
| IPv6 ServiceCIDR 64-bit allocation bug (#138385) | CHANGELOG-1.34 | ✅ |
| Scheduler in-flight queue cleanup (#138435) | CHANGELOG-1.34 | ✅ |
| Kube-proxy large-cluster mode full-sync (#138637) | CHANGELOG-1.34 | ✅ |
| Windows HNS endpoint cleanup / DNS timeout fix (#138601) | CHANGELOG-1.34 | ✅ |
| K8s 1.34 maintenance mode Aug 27, EOL Oct 27, 2026 | https://kubernetes.io/releases/patch-releases/ | ✅ |

## Items considered and dropped

- **Microcks → CNCF Incubation (May 7)** — Solid primary source, but May 7 falls just outside the 7-day window and the project move was already covered elsewhere.
- **Anthropic Claude Platform on AWS GA (May 11)** — Vendor partnership announcement; failed the "never republish vendor press releases" rule. Real technical distinction (Anthropic processes data, vs Bedrock model) wasn't enough to clear the substance bar for this audience.
- **CNCF KubeCon Japan 2026 schedule (May 13)** — Event scheduling, not technical news.
- **Anthropic / Gates Foundation, SpaceX compute, Blackstone JV (various May)** — Out of scope.
- **vLLM v0.20.2 (May 10)** — Subsumed by v0.21.0, no need for two segments on the same project.
- **Cilium v1.20.0-pre.2 (May 4)** — Pre-release, not stable; outside 7-day window.
- **OpenTelemetry OBI v0.8.0 (April 16)** — Outside 7-day window; no May release to anchor.
- **Kyverno 1.18 CNCF blog post (May 11)** — Underlying release was April 29; the May post is a delayed announcement, not new material.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial → Fact-check → Edit → Final
- Total candidates considered: ~18
- Segments shipped: 3
- Time horizon: May 8–15, 2026
- Format note: Used the existing repo convention (one article per topic in `content/news/{slug}/index.mdx`) rather than a single digest file, since that matches the established schema and existing news entries.
- Caveat: The vLLM v0.21.0 release-page header was rendered ambiguously on at least one fetch attempt (year not always extractable). Date confirmed via cross-referencing the release schedule, feature set (Blackwell, DeepSeek V4, Kimi-K25, MiMo-V2.5), and the project's documented release cadence.


---
_Generated by [Claude Code](https://claude.ai/code/session_011LphDozMKspjt5FajhXYK7)_