### PR TITLE
feat(rawkode.academy/website): include news in /api/feeds/all.xml and all.atom

### DIFF
--- a/projects/rawkode.academy/website/src/pages/api/feeds/all.atom.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/all.atom.ts
@@ -12,15 +12,16 @@ interface AtomEntry {
 	author?: string;
 	thumbnail?: string;
 	duration?: number;
-	type: "article" | "video";
+	type: "article" | "video" | "news";
 	content?: string;
 }
 
 export async function GET(context: APIContext) {
-	const [articles, videos, technologies] = await Promise.all([
+	const [articles, videos, technologies, news] = await Promise.all([
 		getCollection("articles", ({ data }) => !data.draft),
 		getCollection("videos"),
 		getCollection("technologies"),
+		getCollection("news"),
 	]);
 
 	const techName = new Map(
@@ -77,6 +78,23 @@ export async function GET(context: APIContext) {
 		entries.push(entry);
 	});
 
+	// Add news stories
+	await Promise.all(
+		news.map(async (story) => {
+			const authors = await getEntries(story.data.authors);
+			entries.push({
+				title: story.data.title,
+				description: story.data.description,
+				url: `${site}/news/${story.id}/`,
+				published: new Date(story.data.publishedAt).toISOString(),
+				updated: new Date(story.data.publishedAt).toISOString(),
+				categories: [...(story.data.technologies ?? [])],
+				author: authors.map((author) => author.data.name).join(", "),
+				type: "news",
+			});
+		}),
+	);
+
 	// Sort all entries by published date desc
 	entries.sort(
 		(a, b) => new Date(b.published).getTime() - new Date(a.published).getTime(),
@@ -91,7 +109,7 @@ export async function GET(context: APIContext) {
 	const atomFeed = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 	<title>Rawkode Academy - All Content</title>
-	<subtitle>Latest articles and videos from Rawkode Academy covering Cloud Native, DevOps, and Modern Software Development</subtitle>
+	<subtitle>Latest articles, news, and videos from Rawkode Academy covering Cloud Native, DevOps, and Modern Software Development</subtitle>
 	<link href="${feedUrl}" rel="self" type="application/atom+xml"/>
 	<link href="${site}" rel="alternate" type="text/html"/>
 	<id>${site}/</id>

--- a/projects/rawkode.academy/website/src/pages/api/feeds/all.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/api/feeds/all.xml.ts
@@ -9,10 +9,11 @@ import type { RSSFeedItem } from "@astrojs/rss";
 const logger = createLogger("feeds");
 
 export async function GET(context: APIContext) {
-	const [articles, videos, technologies] = await Promise.all([
+	const [articles, videos, technologies, news] = await Promise.all([
 		getCollection("articles", ({ data }) => !data.draft),
 		getCollection("videos"),
 		getCollection("technologies"),
+		getCollection("news"),
 	]);
 
 	const techName = new Map(
@@ -110,8 +111,36 @@ export async function GET(context: APIContext) {
 		})
 		.filter((item): item is RSSFeedItem => item !== null);
 
+	// Add news (lightweight — description is the body)
+	const newsItems = (
+		await Promise.all(
+			news.map(async (story): Promise<RSSFeedItem | null> => {
+				const title = (story.data.title || "").trim();
+				const description = (story.data.description || "").trim();
+				if (!title || !description) {
+					logger.warn(
+						`Skipping news story with missing title or description: ${story.id}`,
+					);
+					return null;
+				}
+				const authors = await getEntries(story.data.authors);
+				const item: RSSFeedItem = {
+					title,
+					description,
+					pubDate: new Date(story.data.publishedAt),
+					link: `/news/${story.id}/`,
+					categories: [...(story.data.technologies ?? [])],
+				};
+				if (authors.length > 0) {
+					item.author = authors.map((author) => author.data.name).join(", ");
+				}
+				return item;
+			}),
+		)
+	).filter((item): item is RSSFeedItem => item !== null);
+
 	// Combine all items
-	const items = [...articleItems, ...videoItems];
+	const items = [...articleItems, ...videoItems, ...newsItems];
 
 	// Sort all items by date desc
 	items.sort((a, b) => {
@@ -123,7 +152,7 @@ export async function GET(context: APIContext) {
 	return rss({
 		title: "Rawkode Academy - All Content",
 		description:
-			"Latest articles and videos from Rawkode Academy covering Cloud Native, DevOps, and Modern Software Development",
+			"Latest articles, news, and videos from Rawkode Academy covering Cloud Native, DevOps, and Modern Software Development",
 		site: context.site?.toString() || "https://rawkode.academy",
 		items,
 		customData: "<language>en-us</language>",

--- a/projects/rawkode.academy/website/src/pages/feeds.astro
+++ b/projects/rawkode.academy/website/src/pages/feeds.astro
@@ -21,7 +21,7 @@ const publishedShows = shows.filter((show) => show.data.publish);
 			<!-- All Content Feeds -->
 			<div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
 				<h2 class="text-2xl font-semibold mb-4 text-secondary">All Content</h2>
-				<p class="text-gray-300 mb-4">Get both articles and videos in one feed</p>
+				<p class="text-gray-300 mb-4">Get articles, news, and videos in one feed</p>
 				<div class="space-y-3">
 					<a href="/api/feeds/all.xml" class="flex items-center gap-3 text-primary hover:text-primary/90 transition-colors">
 						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">


### PR DESCRIPTION
## Summary
- `/api/feeds/all.xml` and `/api/feeds/all.atom` now fetch the `news` collection alongside articles and videos.
- News entries are merged into the time-sorted timeline with the right `link` (`/news/{slug}/`), author (resolved from references), and tech tags as `categories`.
- Channel `description`/`subtitle` updated to mention news ("Latest articles, news, and videos").
- `/feeds` page copy for the All Content card updated to match.
- News stories with missing title or description are skipped (and logged), consistent with how articles/videos handle the same edge.

## Why
**Reach.** The combined "all content" feed predates the news section (#1043 added the dedicated news feed). Subscribers using `all.xml`/`all.atom` as their "everything from Rawkode" subscription have been silently missing every news story — likely the most time-sensitive content type. Closing this gap means a single existing feed delivers the full output again.

Flagged as a follow-up in #1043; this is that PR.

## Test plan
- [ ] `curl https://<preview>/api/feeds/all.xml` and grep for a recent news slug — confirm the entry appears.
- [ ] Same for `https://<preview>/api/feeds/all.atom`.
- [ ] Confirm entries are merged in correct date order (a recent news story should outrank an older article in the feed).
- [ ] Confirm the channel `<description>` / Atom `<subtitle>` includes the word "news".
- [ ] `/feeds` page renders "Get articles, news, and videos in one feed" under the All Content card.

## Human action required (post-merge / post-deploy)
- [ ] **Validate one feed** in `https://validator.w3.org/feed/` — paste `https://rawkode.academy/api/feeds/all.xml` and confirm zero errors.
- [ ] **Tell existing subscribers** (newsletter, Discord, a single social post): "Our 'All Content' feed now includes news — no action needed if you're already subscribed." Anyone who'd been keeping a separate news feed subscription as a workaround can drop it.
- [ ] **Optional** — once visible in analytics, consider deprecating the standalone `news.xml`/`news.atom` if the all-feed becomes the dominant subscription path. (I'd keep them indefinitely — RSS subscribers value granularity — but it's a real call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)