### PR TITLE
fix(rawkode.academy/website): unbreak astro check on /read index

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/article-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/article-itemlist-jsonld.astro
@@ -7,7 +7,7 @@ interface ArticleEntryInput {
 		title: string;
 		description: string;
 		publishedAt: Date;
-		updatedAt?: Date;
+		updatedAt?: Date | undefined;
 	};
 }
 

--- a/projects/rawkode.academy/website/src/lib/article-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/article-itemlist-jsonld.ts
@@ -4,7 +4,7 @@ export interface ArticleListEntry {
 		title: string;
 		description: string;
 		publishedAt: Date;
-		updatedAt?: Date;
+		updatedAt?: Date | undefined;
 	};
 }
 


### PR DESCRIPTION
## Summary
`#1061` shipped `ArticleItemListJsonLd` with an `ArticleEntryInput` whose `updatedAt` is typed `updatedAt?: Date`. Under `astro/tsconfigs/strictest` (which enables `exactOptionalPropertyTypes`), that is **not** assignable from the articles collection's `updatedAt: Date | undefined` (Zod's `.optional()` produces the always-present-but-may-be-undefined shape).

`bun run build` on `main` fails:

```
src/pages/read/index.astro:37:7 - error ts(2322): Type '...' is not
assignable to type 'readonly ArticleEntryInput[]'.
  The types of 'data.updatedAt' are incompatible between these types.
    Type 'Date | undefined' is not assignable to type 'Date'.
```

Widen the optional field to `Date | undefined` in both the lib type and the Astro component prop type so both shapes assign.

## Why
`#1061`'s PR check went red on the same error but the merge happened anyway. This unbreaks the website build on `main`.

## Test plan
- [x] Local `bunx astro check` → 0 errors (was 1 before).
- [ ] CI on this PR goes green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMeoQ5gMjQmqLD6FtDyDCy)_