### PR TITLE
feat(rawkode.academy/website): add TechArticle JSON-LD on ADR pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/adr-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/adr-jsonld.astro
@@ -1,0 +1,35 @@
+---
+import type { CollectionEntry } from "astro:content";
+import { buildAdrJsonLd } from "@/lib/adr-jsonld";
+
+interface Props {
+	adr: CollectionEntry<"adrs">;
+	authors: ReadonlyArray<CollectionEntry<"people">>;
+	slot?: string;
+}
+
+const { adr, authors } = Astro.props;
+
+const siteUrl = (Astro.site ?? Astro.url).origin;
+const adrUrl = new URL(`/adrs/${adr.id}`, siteUrl).href;
+
+const jsonLd = buildAdrJsonLd({
+	siteUrl,
+	adrUrl,
+	source: {
+		id: adr.id,
+		title: adr.data.title,
+		adoptedAt: adr.data.adoptedAt,
+	},
+	authors: authors.map((author) => ({
+		id: author.data.id,
+		name: author.data.name,
+	})),
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/adr-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/adr-jsonld.ts
@@ -1,0 +1,84 @@
+export interface AdrAuthor {
+	id: string;
+	name: string;
+}
+
+export interface AdrSource {
+	id: string;
+	title: string;
+	adoptedAt: Date;
+}
+
+export interface BuildAdrJsonLdInput {
+	siteUrl: string;
+	adrUrl: string;
+	source: AdrSource;
+	authors: ReadonlyArray<AdrAuthor>;
+}
+
+const PUBLISHER_NAME = "Rawkode Academy";
+const PUBLISHER_LOGO_PATH = "/android-chrome-512x512.png";
+const ARTICLE_SECTION = "Architecture Decision Records";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+export function extractAdrNumber(adrId: string): string | undefined {
+	const match = adrId.match(/^(\d{4})-/);
+	return match?.[1];
+}
+
+/**
+ * Build a schema.org TechArticle JSON-LD payload for an Architecture Decision
+ * Record. ADRs are technical documents with a fixed structure (context,
+ * decision, consequences); TechArticle is the closest standard mapping that
+ * Google's Article rich result pipeline already understands.
+ */
+export function buildAdrJsonLd(
+	input: BuildAdrJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, adrUrl, source, authors } = input;
+	const adoptedAtIso = new Date(source.adoptedAt).toISOString();
+	const adrNumber = extractAdrNumber(source.id);
+	const headline = adrNumber
+		? `ADR-${adrNumber}: ${source.title}`
+		: source.title;
+
+	const jsonLd: Record<string, unknown> = {
+		"@context": "https://schema.org",
+		"@type": "TechArticle",
+		headline,
+		url: adrUrl,
+		datePublished: adoptedAtIso,
+		dateModified: adoptedAtIso,
+		inLanguage: "en",
+		articleSection: ARTICLE_SECTION,
+		mainEntityOfPage: { "@type": "WebPage", "@id": adrUrl },
+		publisher: {
+			"@type": "Organization",
+			name: PUBLISHER_NAME,
+			url: siteUrl,
+			logo: {
+				"@type": "ImageObject",
+				url: joinUrl(siteUrl, PUBLISHER_LOGO_PATH),
+			},
+		},
+		keywords:
+			"Architecture Decision Record, ADR, cloud native, software architecture",
+	};
+
+	if (adrNumber) {
+		jsonLd.identifier = `ADR-${adrNumber}`;
+	}
+
+	if (authors.length > 0) {
+		jsonLd.author = authors.map((author) => ({
+			"@type": "Person",
+			name: author.name,
+			url: joinUrl(siteUrl, `/people/${author.id}`),
+		}));
+	}
+
+	return jsonLd;
+}

--- a/projects/rawkode.academy/website/src/pages/adrs/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/adrs/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, getEntries, render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
+import AdrJsonLd from "@/components/html/adr-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 import { createLogger } from "@/lib/logger";
@@ -52,6 +53,7 @@ const adrNumber = adr.id.match(/^(\d{4})-/)?.[1] || "0000";
 ---
 
 <Page title={`ADR-${adrNumber}: ${adr.data.title}`} description={`Architecture Decision Record: ${adr.data.title}`}>
+  <AdrJsonLd slot="extra-head" adr={adr} authors={authors} />
   <h1 class="text-5xl font-extrabold dark:text-white">
     <span class="text-secondary dark:text-secondary">ADR-{adrNumber}:</span> {adr.data.title}
   </h1>

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -1296,4 +1296,68 @@ describe("Structured Data Validation", () => {
 		expect(jsonLd.dateModified).toBe(jsonLd.datePublished);
 		expect(jsonLd.keywords).toBeUndefined();
 	});
+
+	it("extracts the 4-digit ADR number from canonical IDs and falls back when absent", async () => {
+		const { extractAdrNumber } = await import("../lib/adr-jsonld.ts");
+		expect(extractAdrNumber("0042-use-cloudflare-d1")).toBe("0042");
+		expect(extractAdrNumber("0001-adopt-astro")).toBe("0001");
+		expect(extractAdrNumber("not-a-numbered-adr")).toBeUndefined();
+		expect(extractAdrNumber("42-missing-padding")).toBeUndefined();
+	});
+
+	it("builds ADR TechArticle JSON-LD with identifier, ISO dates, publisher, and internal author links", async () => {
+		const { buildAdrJsonLd } = await import("../lib/adr-jsonld.ts");
+
+		const jsonLd = buildAdrJsonLd({
+			siteUrl: "https://rawkode.academy",
+			adrUrl: "https://rawkode.academy/adrs/0042-use-cloudflare-d1",
+			source: {
+				id: "0042-use-cloudflare-d1",
+				title: "Use Cloudflare D1 for all new services",
+				adoptedAt: new Date("2026-05-15T10:00:00.000Z"),
+			},
+			authors: [{ id: "rawkode", name: "David Flanagan" }],
+		});
+
+		expect(jsonLd["@type"]).toBe("TechArticle");
+		expect(jsonLd.headline).toBe(
+			"ADR-0042: Use Cloudflare D1 for all new services",
+		);
+		expect(jsonLd.identifier).toBe("ADR-0042");
+		expect(jsonLd.datePublished).toBe("2026-05-15T10:00:00.000Z");
+		expect(jsonLd.dateModified).toBe(jsonLd.datePublished);
+		expect(jsonLd.articleSection).toBe("Architecture Decision Records");
+
+		const mainEntity = jsonLd.mainEntityOfPage as Record<string, unknown>;
+		expect(mainEntity["@id"]).toBe(
+			"https://rawkode.academy/adrs/0042-use-cloudflare-d1",
+		);
+
+		const publisher = jsonLd.publisher as Record<string, unknown>;
+		expect(publisher.name).toBe("Rawkode Academy");
+
+		const author = jsonLd.author as Array<Record<string, unknown>>;
+		expect(author).toHaveLength(1);
+		expect(author[0]?.name).toBe("David Flanagan");
+		expect(author[0]?.url).toBe("https://rawkode.academy/people/rawkode");
+
+		expect(() => JSON.stringify(jsonLd)).not.toThrow();
+	});
+
+	it("omits identifier and author when ADR id is unnumbered and no authors are given", async () => {
+		const { buildAdrJsonLd } = await import("../lib/adr-jsonld.ts");
+		const jsonLd = buildAdrJsonLd({
+			siteUrl: "https://rawkode.academy",
+			adrUrl: "https://rawkode.academy/adrs/some-text-only-id",
+			source: {
+				id: "some-text-only-id",
+				title: "Adopt X",
+				adoptedAt: new Date("2026-05-15T10:00:00.000Z"),
+			},
+			authors: [],
+		});
+		expect(jsonLd.identifier).toBeUndefined();
+		expect(jsonLd.headline).toBe("Adopt X");
+		expect(jsonLd.author).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary
- New pure-TS builder `src/lib/adr-jsonld.ts` (`buildAdrJsonLd`) producing a `schema.org/TechArticle` payload with `articleSection: "Architecture Decision Records"`, ISO dates, internal author links, publisher, and a canonical `identifier: "ADR-NNNN"` derived from the ID prefix.
- Helper `extractAdrNumber` is exported so the regex-extraction is unit-testable independently of the builder.
- Thin Astro wrapper `src/components/html/adr-jsonld.astro` resolves the site origin and delegates.
- Wired into `/adrs/[...slug].astro` via `extra-head` slot.
- Three unit tests cover the number extractor, the full TechArticle shape (with numbered ID + author), and the unnumbered/anonymous fallback.

## Why
**Reach.** ADRs are already in the sitemap (#1041's broader sitemap work) but had no structured data. That means when someone searches for "rawkode adr cloudflare d1" or similar, Google shows a plain SERP entry while other technical-doc sites (Stripe, GitHub, ASF) get article rich results. Adding `TechArticle` JSON-LD puts the ADRs into Google's Article rich result pipeline, where they're eligible for the title + datePublished + author treatment.

This is the same pattern used for `/read` (`TechArticle`) and `/news` (`NewsArticle`) — applying it to ADRs completes structured-data coverage of the long-form text content types.

## Test plan
- [ ] Build the site. `view-source:` on an ADR detail page (e.g. `/adrs/<id>`) and confirm a single `<script type="application/ld+json">` with `@type: "TechArticle"`.
- [ ] Paste the rendered JSON into `https://validator.schema.org/` — zero errors.
- [ ] Confirm `identifier` is `"ADR-NNNN"` for the standard numbered IDs.
- [ ] Confirm `author[].url` points at `/people/{id}` (not GitHub).
- [ ] No regression on `/read` or `/news` JSON-LD (orthogonal files).

## Human action required (post-merge / post-deploy)
- [ ] **Validate one production URL** in [Google Rich Results Test](https://search.google.com/test/rich-results) — paste an ADR detail URL. Expect "Article" detected, no errors.
- [ ] **Same URL in Schema.org validator**: `https://validator.schema.org/?url=https://rawkode.academy/adrs/<id>` — zero errors.
- [ ] **Watch GSC Enhancements → Article** for the next 1–2 weeks. ADR URLs should appear under "Valid items".
- [ ] **Optional follow-up** — ADRs would benefit from an `ItemList` JSON-LD on the `/adrs` index too (parallel to #1056 for news, #1061 for articles). Standalone follow-up if you want the list rich-result eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)