### PR TITLE
feat(rawkode.academy/website): Webfinger so @{id}@rawkode.academy resolves on Mastodon

### DIFF
--- a/projects/rawkode.academy/website/src/lib/webfinger.ts
+++ b/projects/rawkode.academy/website/src/lib/webfinger.ts
@@ -1,0 +1,101 @@
+export interface ParsedAcctResource {
+	user: string;
+	domain: string;
+}
+
+export interface ParsedMastodonProfile {
+	instance: string;
+	username: string;
+	profileUrl: string;
+	actorUrl: string;
+}
+
+export interface WebfingerLink {
+	rel: string;
+	type?: string;
+	href: string;
+}
+
+export interface WebfingerResponse {
+	subject: string;
+	aliases: string[];
+	links: WebfingerLink[];
+}
+
+/**
+ * Parse an `acct:` URI as specified in RFC 7565.
+ * Accepts `acct:user@domain` and returns null for any other shape.
+ */
+export function parseAcctResource(
+	resource: string | null | undefined,
+): ParsedAcctResource | null {
+	if (typeof resource !== "string") return null;
+	if (!resource.startsWith("acct:")) return null;
+	const rest = resource.slice("acct:".length);
+	const atIndex = rest.lastIndexOf("@");
+	if (atIndex <= 0 || atIndex === rest.length - 1) return null;
+	const user = rest.slice(0, atIndex);
+	const domain = rest.slice(atIndex + 1);
+	if (!user || !domain) return null;
+	if (!/^[A-Za-z0-9._-]+$/.test(user)) return null;
+	return { user, domain: domain.toLowerCase() };
+}
+
+/**
+ * Parse a Mastodon-style profile URL (`https://instance.tld/@user`) into the
+ * components Webfinger needs. Returns null for unparseable input.
+ */
+export function parseMastodonProfile(
+	profileUrl: string | undefined,
+): ParsedMastodonProfile | null {
+	if (typeof profileUrl !== "string" || profileUrl.length === 0) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(profileUrl);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+
+	const match = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/?$/);
+	if (!match) return null;
+	const username = match[1] as string;
+
+	return {
+		instance: parsed.host,
+		username,
+		profileUrl: `${parsed.protocol}//${parsed.host}/@${username}`,
+		actorUrl: `${parsed.protocol}//${parsed.host}/users/${username}`,
+	};
+}
+
+/**
+ * Build the Webfinger JRD payload that Mastodon-compatible servers expect
+ * when resolving `@user@domain`. The `subject` echoes the request resource,
+ * which is required by RFC 7033.
+ */
+export function buildWebfingerResponse(input: {
+	subject: string;
+	displayName: string;
+	mastodonProfile: ParsedMastodonProfile;
+	homepage?: string;
+}): WebfingerResponse {
+	const { subject, mastodonProfile, homepage } = input;
+	const aliases = [mastodonProfile.profileUrl, mastodonProfile.actorUrl];
+	const links: WebfingerLink[] = [
+		{
+			rel: "self",
+			type: "application/activity+json",
+			href: mastodonProfile.actorUrl,
+		},
+		{
+			rel: "http://webfinger.net/rel/profile-page",
+			type: "text/html",
+			href: mastodonProfile.profileUrl,
+		},
+	];
+	if (homepage) {
+		aliases.push(homepage);
+	}
+	return { subject, aliases, links };
+}

--- a/projects/rawkode.academy/website/src/pages/.well-known/webfinger.ts
+++ b/projects/rawkode.academy/website/src/pages/.well-known/webfinger.ts
@@ -1,0 +1,78 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+import {
+	buildWebfingerResponse,
+	parseAcctResource,
+	parseMastodonProfile,
+} from "@/lib/webfinger";
+
+const SITE_DOMAIN = "rawkode.academy";
+
+const corsHeaders = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+function badRequest(message: string): Response {
+	return new Response(message, {
+		status: 400,
+		headers: { "Content-Type": "text/plain; charset=utf-8", ...corsHeaders },
+	});
+}
+
+function notFound(): Response {
+	return new Response("Not Found", {
+		status: 404,
+		headers: { "Content-Type": "text/plain; charset=utf-8", ...corsHeaders },
+	});
+}
+
+export const OPTIONS: APIRoute = () =>
+	new Response(null, { status: 204, headers: corsHeaders });
+
+export const GET: APIRoute = async ({ url, site }) => {
+	const resource = url.searchParams.get("resource");
+	const parsed = parseAcctResource(resource);
+	if (!parsed) {
+		return badRequest("Missing or malformed resource= query parameter.");
+	}
+
+	const expectedDomain = (site?.host ?? SITE_DOMAIN).toLowerCase();
+	if (parsed.domain !== expectedDomain) {
+		return notFound();
+	}
+
+	const people = await getCollection("people");
+	const person = people.find((entry) => entry.data.id === parsed.user);
+	if (!person) {
+		return notFound();
+	}
+
+	const mastodonProfile = parseMastodonProfile(person.data.mastodon);
+	if (!mastodonProfile) {
+		return notFound();
+	}
+
+	const subject = `acct:${parsed.user}@${parsed.domain}`;
+	const homepage = new URL(
+		`/people/${person.data.id}`,
+		site ?? `https://${SITE_DOMAIN}`,
+	).href;
+	const jrd = buildWebfingerResponse({
+		subject,
+		displayName: person.data.name,
+		mastodonProfile,
+		homepage,
+	});
+
+	return new Response(JSON.stringify(jrd), {
+		status: 200,
+		headers: {
+			"Content-Type": "application/jrd+json; charset=utf-8",
+			"Cache-Control": "public, max-age=3600, s-maxage=86400",
+			...corsHeaders,
+		},
+	});
+};
+
+export const prerender = false;

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -1296,4 +1296,85 @@ describe("Structured Data Validation", () => {
 		expect(jsonLd.dateModified).toBe(jsonLd.datePublished);
 		expect(jsonLd.keywords).toBeUndefined();
 	});
+
+	it("parses well-formed acct: resources and rejects everything else", async () => {
+		const { parseAcctResource } = await import("../lib/webfinger.ts");
+		expect(parseAcctResource("acct:rawkode@rawkode.academy")).toEqual({
+			user: "rawkode",
+			domain: "rawkode.academy",
+		});
+		expect(parseAcctResource("acct:Some-User_99@Example.COM")).toEqual({
+			user: "Some-User_99",
+			domain: "example.com",
+		});
+		expect(parseAcctResource(null)).toBeNull();
+		expect(parseAcctResource(undefined)).toBeNull();
+		expect(parseAcctResource("")).toBeNull();
+		expect(parseAcctResource("rawkode@rawkode.academy")).toBeNull();
+		expect(parseAcctResource("acct:nodomain")).toBeNull();
+		expect(parseAcctResource("acct:@rawkode.academy")).toBeNull();
+		expect(parseAcctResource("acct:rawkode@")).toBeNull();
+		expect(parseAcctResource("acct:bad space@rawkode.academy")).toBeNull();
+	});
+
+	it("parses Mastodon-style profile URLs into actor URL + components", async () => {
+		const { parseMastodonProfile } = await import("../lib/webfinger.ts");
+		expect(parseMastodonProfile("https://hachyderm.io/@rawkode")).toEqual({
+			instance: "hachyderm.io",
+			username: "rawkode",
+			profileUrl: "https://hachyderm.io/@rawkode",
+			actorUrl: "https://hachyderm.io/users/rawkode",
+		});
+		expect(parseMastodonProfile("https://fromm.social/@thilo/")).toEqual(
+			expect.objectContaining({
+				instance: "fromm.social",
+				username: "thilo",
+				actorUrl: "https://fromm.social/users/thilo",
+			}),
+		);
+		expect(parseMastodonProfile(undefined)).toBeNull();
+		expect(parseMastodonProfile("")).toBeNull();
+		expect(parseMastodonProfile("not a url")).toBeNull();
+		expect(
+			parseMastodonProfile("https://example.com/users/rawkode"),
+		).toBeNull();
+	});
+
+	it("builds a Webfinger JRD with subject, aliases, ActivityPub self, and profile-page links", async () => {
+		const { buildWebfingerResponse, parseMastodonProfile } = await import(
+			"../lib/webfinger.ts"
+		);
+		const mastodonProfile = parseMastodonProfile(
+			"https://hachyderm.io/@rawkode",
+		);
+		expect(mastodonProfile).not.toBeNull();
+		if (!mastodonProfile) return;
+
+		const jrd = buildWebfingerResponse({
+			subject: "acct:rawkode@rawkode.academy",
+			displayName: "David Flanagan",
+			mastodonProfile,
+			homepage: "https://rawkode.academy/people/rawkode",
+		});
+
+		expect(jrd.subject).toBe("acct:rawkode@rawkode.academy");
+		expect(jrd.aliases).toEqual([
+			"https://hachyderm.io/@rawkode",
+			"https://hachyderm.io/users/rawkode",
+			"https://rawkode.academy/people/rawkode",
+		]);
+		expect(jrd.links).toEqual([
+			{
+				rel: "self",
+				type: "application/activity+json",
+				href: "https://hachyderm.io/users/rawkode",
+			},
+			{
+				rel: "http://webfinger.net/rel/profile-page",
+				type: "text/html",
+				href: "https://hachyderm.io/@rawkode",
+			},
+		]);
+		expect(() => JSON.stringify(jrd)).not.toThrow();
+	});
 });


### PR DESCRIPTION
## Summary
- New API route at `src/pages/.well-known/webfinger.ts` (dynamic, `prerender = false`) implementing RFC 7033 Webfinger for `acct:{id}@rawkode.academy` resources.
- Pure-TS helpers in `src/lib/webfinger.ts`:
  - `parseAcctResource(resource)` — parses `acct:user@domain` and rejects malformed input.
  - `parseMastodonProfile(profileUrl)` — parses `https://instance/@user` and derives the matching ActivityPub actor URL (`https://instance/users/user`).
  - `buildWebfingerResponse(...)` — assembles the JRD payload with `subject`, `aliases`, and the two `links` Mastodon expects (`self` → ActivityPub actor, `profile-page` → human profile).
- Endpoint returns `application/jrd+json` per spec, with CORS open and a 24h edge cache.
- Three unit tests cover the parsers and the JRD shape.

## Why
**Reach via Fediverse discoverability.** Today, if a Mastodon user searches for `@rawkode@rawkode.academy`, nothing resolves — they have to know the contributor's actual instance (e.g. `@rawkode@hachyderm.io`). Webfinger lets the academy domain act as a vanity handle: search resolves through the brand, the user lands on the right profile on the right instance, and the contributor never had to host their own Mastodon instance.

Pairs structurally with:
- **#1053** (`fediverse:creator`) — shared cards credit the author with their Fediverse handle.
- **#1057** (`rel="me"` on `/people/{id}`) — when an author claims their academy profile on Mastodon, Mastodon verifies via the reciprocal link.
- **This PR** — `@{id}@rawkode.academy` works as a discoverable alias.

Together that's a three-step Fediverse identity story most academy/training sites don't have.

## Test plan
- [ ] `curl -H "Accept: application/jrd+json" "https://<preview>/.well-known/webfinger?resource=acct:thilo@rawkode.academy"` returns JSON with `links` pointing to `https://fromm.social/users/thilo`.
- [ ] `curl "https://<preview>/.well-known/webfinger?resource=acct:rawkode@rawkode.academy"` returns 404 (no `mastodon:` set on rawkode's record today) — confirming the endpoint correctly distinguishes "person exists but no Fediverse" from "person not found".
- [ ] `curl "https://<preview>/.well-known/webfinger?resource=acct:nobody@rawkode.academy"` → 404.
- [ ] `curl "https://<preview>/.well-known/webfinger?resource=acct:rawkode@example.com"` → 404 (wrong host).
- [ ] `curl "https://<preview>/.well-known/webfinger"` → 400 (missing resource).
- [ ] Content-Type on success is `application/jrd+json`.

## Human action required (post-merge / post-deploy)
- [ ] **End-to-end test in Mastodon.** From any Mastodon client, search for `@thilo@rawkode.academy` — it should resolve to Thilo's actual profile on fromm.social and let you follow without leaving the search UI.
- [ ] **Backfill `mastodon:` URLs** in `content/people/*.mdx` for active contributors on the Fediverse. Each filled-in URL immediately activates this Webfinger alias for that person.
- [ ] **Decide on a brand handle.** If the academy gets its own Fediverse account (e.g. `@rawkodeacademy@hachyderm.io`), add a special case in the endpoint so `@rawkodeacademy@rawkode.academy` resolves to it. Out of scope today since no brand Fediverse account exists. Flag and I'll do the follow-up.
- [ ] **Optional** — announce the feature on Mastodon ("You can now follow Rawkode contributors at @{id}@rawkode.academy"). Free reach on the platform where the audience lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)