### PR TITLE
feat(rawkode.academy/website): link learning-path tech chips to /technology/{id}

### DIFF
--- a/projects/rawkode.academy/website/src/components/learning-paths/LearningPathHero.astro
+++ b/projects/rawkode.academy/website/src/components/learning-paths/LearningPathHero.astro
@@ -5,12 +5,17 @@ import Button from "@/components/common/Button.astro";
 import FormattedDate from "@/components/common/FormattedDate.vue";
 import type { CollectionEntry } from "astro:content";
 
+export type LearningPathTechnology = {
+	id: string;
+	label: string;
+};
+
 type Props = {
 	title: string;
 	description: string;
 	difficulty: "beginner" | "intermediate" | "advanced";
 	durationLabel: string;
-	technologies: string[];
+	technologies: LearningPathTechnology[];
 	prerequisites: string[];
 	authors: CollectionEntry<"people">[];
 	publishedAt: Date;
@@ -79,9 +84,15 @@ const hasPrerequisites = prerequisites.length > 0;
 						</h2>
 						<div class="flex flex-wrap gap-2">
 							{technologies.map((technology) => (
-								<Badge variant="secondary" size="xs">
-									{technology}
-								</Badge>
+								<a
+									href={`/technology/${technology.id}`}
+									class="inline-flex"
+									aria-label={`Browse ${technology.label} content`}
+								>
+									<Badge variant="secondary" size="xs">
+										{technology.label}
+									</Badge>
+								</a>
 							))}
 						</div>
 					</div>

--- a/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
@@ -43,6 +43,12 @@ for (const technology of allTechnologies) {
 const technologyLabels = (learningPath.data.technologies ?? []).map(
 	(technologyId) => technologyNameById.get(technologyId) ?? technologyId,
 );
+const technologyTags = (learningPath.data.technologies ?? []).map(
+	(technologyId) => ({
+		id: technologyId,
+		label: technologyNameById.get(technologyId) ?? technologyId,
+	}),
+);
 
 function formatDuration(minutes: number): string {
 	if (!minutes) {
@@ -66,7 +72,6 @@ function formatDuration(minutes: number): string {
 const durationLabel = formatDuration(learningPath.data.estimatedDuration);
 const outline = headings.filter((heading) => heading.depth === 2);
 const prerequisites = learningPath.data.prerequisites ?? [];
-const technologies = learningPath.data.technologies ?? [];
 
 const pageTitle = `${learningPath.data.title} | Learning Path`;
 const pageDescription = learningPath.data.description;
@@ -101,7 +106,7 @@ const pageDescription = learningPath.data.description;
 		description={learningPath.data.description}
 		difficulty={learningPath.data.difficulty}
 		durationLabel={durationLabel}
-		technologies={technologies}
+		technologies={technologyTags}
 		prerequisites={prerequisites}
 		authors={authors}
 		publishedAt={learningPath.data.publishedAt}
@@ -140,14 +145,18 @@ const pageDescription = learningPath.data.description;
 							</p>
 						</div>
 					</li>
-					{technologies.length > 0 && (
+					{technologyTags.length > 0 && (
 						<li>
 							<p class="text-xs uppercase tracking-wide text-muted mb-2">Technologies</p>
 							<div class="flex flex-wrap gap-2">
-								{technologies.map((technology) => (
-									<span class="inline-flex items-center rounded-full bg-secondary/15 px-3 py-1 text-xs font-medium text-secondary dark:bg-secondary/20 dark:text-secondary/90">
-										{technology}
-									</span>
+								{technologyTags.map((technology) => (
+									<a
+										href={`/technology/${technology.id}`}
+										rel="tag"
+										class="inline-flex items-center rounded-full bg-secondary/15 px-3 py-1 text-xs font-medium text-secondary hover:bg-secondary/25 hover:text-secondary dark:bg-secondary/20 dark:text-secondary/90 dark:hover:bg-secondary/30 transition-colors"
+									>
+										{technology.label}
+									</a>
 								))}
 							</div>
 						</li>


### PR DESCRIPTION
## Summary
Mirror of #1047 (news) and #1065 (articles), applied to learning-path detail pages:
- Extend `LearningPathHero`'s `technologies` prop from `string[]` to `Array<{id: string; label: string}>` so the Hero can render linked chips with the canonical display name (only one caller, so the prop refactor is safe).
- Inside the Hero, each `Badge` is wrapped in an `<a href="/technology/{id}">` with an `aria-label`.
- On `/learning-paths/[slug]`, build a `technologyTags` array (`{id, label}`) against the existing `technologyNameById` map (built by #1064's JSON-LD work — no new I/O).
- The "At a Glance" aside chip list now renders `rel="tag"` links with proper hover state instead of plain `<span>` chips.

## Why
**Retention + internal SEO.** Same pattern that closed the gap for news and articles. A reader on a Kubernetes learning path who wants the broader Kubernetes hub (which after #1077 surfaces news + articles + videos + other learning paths for that tech) had no link to it from the page. Now both the Hero chip and the aside chip route to `/technology/{id}` with the canonical display name ("Kubernetes" not "kubernetes").

Completes the tech-tag linking trio: news (#1047), articles (#1065), learning paths (this).

## Test plan
- [ ] Visit a `/learning-paths/<slug>` with tech tags. The Hero "Technologies Covered" badges render as links — click → land on `/technology/{id}/`. Hover state engages the brand primary colour.
- [ ] The aside "Technologies" pill list (At a Glance card) also renders as links with hover state and `rel="tag"`.
- [ ] Display names are canonical: "Kubernetes" not "kubernetes". Unknown tech IDs fall back to the raw slug (no breakage).
- [ ] Toggle light/dark — both surfaces look correct.

## Human action required (post-merge / post-deploy)
- [ ] **Spot-check a tech-tagged learning path** in prod (e.g. `/learning-paths/<one>`); confirm both Hero and aside chips link to the right destination and read "Kubernetes" etc.
- [ ] **Watch PostHog** for `/learning-paths/* → /technology/*` referrals over 7–14 days. With #1077 also live, the `/technology/{id}` hub now surfaces learning paths back, so the loop should be obvious in analytics.
- [ ] **Optional follow-up** — `LearningPathHero` is currently the only `learning-paths` component using string-array tech props. If you later add a `LearningPathCard` (for the index or other surfaces), accept the same `{id, label}` shape for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)