### PR TITLE
feat(rawkode.academy/website): surface Learning Paths on the homepage

### DIFF
--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -39,6 +39,27 @@ const allVideos = await getPublishedVideos();
 const latestVideos = allVideos.slice(0, 4); // Already sorted by getPublishedVideos
 const [featuredVideo, ...secondaryVideos] = latestVideos;
 
+// Fetch latest learning paths
+const allLearningPaths = await getCollection("learningPaths");
+const latestLearningPaths = allLearningPaths
+	.sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())
+	.slice(0, 4);
+
+function formatLearningPathDuration(minutes: number): string {
+	if (!minutes) return "Self-paced";
+	const h = Math.floor(minutes / 60);
+	const m = minutes % 60;
+	if (!h) return `${m}m`;
+	if (!m) return `${h}h`;
+	return `${h}h ${m}m`;
+}
+
+const difficultyDisplayLabel: Record<string, string> = {
+	beginner: "Beginner",
+	intermediate: "Intermediate",
+	advanced: "Advanced",
+};
+
 // Social proof stats - simplified metrics
 const allCourses = await getCollection("courses");
 const totalContent = allVideos.length + allArticles.length + allCourses.length;
@@ -114,7 +135,9 @@ const summarizeVideo = (video: (typeof latestVideos)[number]) =>
 
 const summarizeArticle = (article: (typeof latestArticles)[number]) =>
 	compactCopy(
-		article.data.openGraph?.subtitle || article.data.subtitle || article.data.description,
+		article.data.openGraph?.subtitle ||
+			article.data.subtitle ||
+			article.data.description,
 		160,
 	);
 
@@ -236,6 +259,54 @@ const academyValues = [
 									</h4>
 									<p class="line-clamp-3 text-sm leading-7 text-secondary-content">
 										{item.data.description}
+									</p>
+								</div>
+							</a>
+						))}
+					</div>
+				</section>
+			)}
+
+			{latestLearningPaths.length > 0 && (
+				<section class="space-y-8">
+					<div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+						<div class="space-y-3">
+							<div class="eyebrow-label">Learn</div>
+							<h2 class="text-3xl font-bold tracking-tight text-primary-content md:text-4xl">
+								Learning Paths
+							</h2>
+							<p class="max-w-[40rem] text-base leading-7 text-secondary-content sm:text-lg sm:leading-8">
+								Curated, structured roadmaps for mastering Cloud Native — start here when you want a guided journey instead of a single tutorial.
+							</p>
+						</div>
+						<div class="md:pb-1">
+							<a
+								href="/learning-paths"
+								class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition-colors hover:text-primary-content"
+							>
+								All learning paths
+								<svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" /></svg>
+							</a>
+						</div>
+					</div>
+
+					<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+						{latestLearningPaths.map((path) => (
+							<a
+								href={`/learning-paths/${path.id}`}
+								class="soft-panel group block h-full p-4 sm:p-5"
+							>
+								<div class="space-y-3">
+									<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
+										<span>{difficultyDisplayLabel[path.data.difficulty] ?? path.data.difficulty}</span>
+										<span aria-hidden="true">·</span>
+										<span>{formatLearningPathDuration(path.data.estimatedDuration)}</span>
+									</div>
+									<h4 class="text-lg font-semibold leading-snug tracking-tight text-primary-content transition-colors group-hover:text-primary line-clamp-2">
+										{path.data.title}
+									</h4>
+									<p class="line-clamp-3 text-sm leading-7 text-secondary-content">
+										{path.data.description}
 									</p>
 								</div>
 							</a>


### PR DESCRIPTION
## Summary
- Fetch `learningPaths` collection on `/` and render up to four newest paths in a new "Learning Paths" section between News and Videos.
- Each card mirrors the existing News card treatment: difficulty + duration eyebrow, title, description, with the `soft-panel` hover style used elsewhere on the homepage.
- Section is gated on `latestLearningPaths.length > 0` so it disappears cleanly when no paths exist (e.g. very early in the catalogue's life).
- Two small helpers added: `formatLearningPathDuration` (matches the detail-page style) and a `difficultyDisplayLabel` map.

## Why
**Reach + retention.** The homepage already curated News, Videos, and Articles for new arrivals — but never Learning Paths, the most structured education surface the academy ships. A first-time visitor asking "how do I learn Kubernetes systematically?" had no signal that the answer existed on the site. Surfacing it on the home page promotes the highest-intent content type to where new audiences land.

Pairs with the rest of the learning-path investments:
- **#1064** — Course JSON-LD on detail pages (rich result eligibility)
- **#1073** — `NewsletterCTA` on detail (capture at the highest-intent moment)
- **#1077** — TopicHub now surfaces paths on every `/technology/{id}`
- **#1078** — Detail page tech chips link to `/technology/{id}`
- **This PR** — Homepage entry point so the loop has a discoverable starting point

## Test plan
- [ ] Build the site. Visit `/`. Confirm the new "Learning Paths" section renders between News and Videos with up to four cards.
- [ ] Each card shows difficulty + duration in the eyebrow, title links to `/learning-paths/<slug>`, description truncates at 3 lines.
- [ ] Visit `/` with `learning-paths` collection empty (rare) — confirm the section is hidden, no empty container.
- [ ] Toggle light/dark; hover state engages the brand primary colour on title.
- [ ] Cards' difficulty labels render "Beginner" / "Intermediate" / "Advanced" (proper case), not the raw enum.

## Human action required (post-merge / post-deploy)
- [ ] **Visual review on prod**. The section lands between News and Videos. If you'd rather lead with Learning Paths above News (since they're higher-intent for new audiences), say the word and I'll swap.
- [ ] **Watch PostHog homepage funnel** for the next 14 days. The `/ → /learning-paths/*` edge should appear; if it doesn't out-perform `/ → /watch/*` proportionally, consider promoting the section above News.
- [ ] **If the catalogue grows to ~10+ learning paths**, four cards on home become a small sample. Bump the limit to 6 or 8 in a follow-up. Currently four matches the News and Articles cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)