### PR TITLE
feat(rawkode.academy/website): emit ItemList JSON-LD on the /learning-paths index

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/learning-path-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/learning-path-itemlist-jsonld.astro
@@ -1,0 +1,46 @@
+---
+import type { CollectionEntry } from "astro:content";
+import { buildLearningPathItemListJsonLd } from "@/lib/learning-path-itemlist-jsonld";
+
+interface PathInput {
+	path: CollectionEntry<"learningPaths">;
+	authors: ReadonlyArray<{ id: string; name: string }>;
+	technologyLabels: ReadonlyArray<string>;
+}
+
+interface Props {
+	paths: ReadonlyArray<PathInput>;
+	listUrl: string;
+	listName?: string;
+	limit?: number;
+	slot?: string;
+}
+
+const { paths, listUrl, listName, limit } = Astro.props;
+
+const jsonLd = buildLearningPathItemListJsonLd({
+	siteUrl: (Astro.site ?? Astro.url).origin,
+	listUrl,
+	listName: listName ?? "Learning Paths",
+	paths: paths.map(({ path, authors, technologyLabels }) => ({
+		id: path.id,
+		source: {
+			title: path.data.title,
+			description: path.data.description,
+			difficulty: path.data.difficulty,
+			estimatedDuration: path.data.estimatedDuration,
+			prerequisites: path.data.prerequisites ?? [],
+			technologyLabels,
+			publishedAt: path.data.publishedAt,
+		},
+		authors,
+	})),
+	...(typeof limit === "number" ? { limit } : {}),
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/learning-path-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/learning-path-itemlist-jsonld.ts
@@ -1,0 +1,73 @@
+import {
+	buildLearningPathJsonLd,
+	type LearningPathSource,
+	type LearningPathAuthor,
+} from "@/lib/learning-path-jsonld";
+
+export interface LearningPathListEntry {
+	id: string;
+	source: LearningPathSource;
+	authors: ReadonlyArray<LearningPathAuthor>;
+}
+
+export interface BuildLearningPathItemListJsonLdInput {
+	siteUrl: string;
+	listUrl: string;
+	listName: string;
+	paths: ReadonlyArray<LearningPathListEntry>;
+	limit?: number;
+}
+
+const DEFAULT_LIMIT = 20;
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+/**
+ * Build a schema.org ItemList JSON-LD payload for /learning-paths.
+ *
+ * Each ListItem embeds the full Course payload from
+ * buildLearningPathJsonLd so the index inherits all the difficulty,
+ * duration, free-offer, and prerequisite metadata that powers the
+ * Course rich-result carousel on list-type pages.
+ */
+export function buildLearningPathItemListJsonLd(
+	input: BuildLearningPathItemListJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, listUrl, listName, paths, limit = DEFAULT_LIMIT } = input;
+	const ordered = [...paths]
+		.sort(
+			(a, b) => b.source.publishedAt.getTime() - a.source.publishedAt.getTime(),
+		)
+		.slice(0, Math.max(0, limit));
+
+	const itemListElement = ordered.map((entry, index) => {
+		const pathUrl = joinUrl(siteUrl, `/learning-paths/${entry.id}`);
+		const item = buildLearningPathJsonLd({
+			siteUrl,
+			pathUrl,
+			source: entry.source,
+			authors: entry.authors,
+		});
+		// schema.org/ListItem.item expects the embedded payload to omit @context
+		// (the @context belongs to the top-level document).
+		const { "@context": _context, ...itemWithoutContext } = item;
+		return {
+			"@type": "ListItem",
+			position: index + 1,
+			url: pathUrl,
+			item: itemWithoutContext,
+		};
+	});
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: listName,
+		url: listUrl,
+		numberOfItems: itemListElement.length,
+		itemListOrder: "https://schema.org/ItemListOrderDescending",
+		itemListElement,
+	};
+}

--- a/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
@@ -1,6 +1,7 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, getEntries } from "astro:content";
 import LearningPathCard from "@/components/learning-paths/LearningPathCard.astro";
+import LearningPathItemListJsonLd from "@/components/html/learning-path-itemlist-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
@@ -9,12 +10,41 @@ const learningPaths = (await getCollection("learningPaths")).sort(
 	(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
 );
 
+const allTechnologies = await getCollection("technologies");
+const technologyNameById = new Map<string, string>();
+for (const technology of allTechnologies) {
+	const rawId = technology.id.replace(/\/index$/, "");
+	technologyNameById.set(rawId, technology.data.name);
+}
+
+const itemListPaths = await Promise.all(
+	learningPaths.map(async (path) => {
+		const authorEntries = await getEntries(path.data.authors);
+		return {
+			path,
+			authors: authorEntries.map((author) => ({
+				id: author.data.id,
+				name: author.data.name,
+			})),
+			technologyLabels: (path.data.technologies ?? []).map(
+				(technologyId) => technologyNameById.get(technologyId) ?? technologyId,
+			),
+		};
+	}),
+);
+
 const pageTitle = "Learning Paths | Rawkode Academy";
 const pageDescription =
 	"Curated, video-driven journeys to help you level up your Kubernetes, platform engineering, and cloud native skills.";
 ---
 
 <Page title={pageTitle} description={pageDescription}>
+	<LearningPathItemListJsonLd
+		slot="extra-head"
+		paths={itemListPaths}
+		listUrl={new URL("/learning-paths", Astro.site ?? Astro.url).href}
+		listName="Rawkode Academy Learning Paths"
+	/>
 	<section class="relative overflow-hidden rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
 		<div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/20 dark:from-primary/20 dark:to-secondary/30"></div>
 		<div class="relative z-10 px-6 py-16 md:px-10 lg:px-16">


### PR DESCRIPTION
## Summary
- New pure-TS builder `src/lib/learning-path-itemlist-jsonld.ts` that produces a `schema.org/ItemList` whose `itemListElement` entries embed the **full Course payload** from `buildLearningPathJsonLd` (#1064) — same difficulty, ISO duration, free offer, prerequisites, internal author links.
- Thin Astro wrapper resolves the site origin and looks up canonical technology display names from the technologies collection (so the embedded Course's `teaches` reads "Kubernetes" not "kubernetes").
- Wired into `/learning-paths/index.astro` via `extra-head` slot.
- Embedded items strip `@context` (belongs at top-level only per schema.org guidance).

## Why
**Reach.** Completes the index-`ItemList` pattern across the long-form content types:

| Surface | PR |
|---|---|
| `/news` | #1056 |
| `/read` | #1061 |
| `/watch` | #1071 |
| **`/learning-paths`** | **this** |

Each ListItem carrying the full Course payload (not just a minimal stub) means the rich-result carousel can display difficulty + duration tiles, which is the whole point for educational content. Pairs with #1064 (detail-page Course JSON-LD) and #1079 (homepage entry) to give learning paths complete SEO + discoverability coverage.

## Test plan
- [ ] Build the site. `view-source:` on `/learning-paths` and confirm a `<script type="application/ld+json">` with `@type: "ItemList"` is present.
- [ ] Each `itemListElement[].item` has `@type: "Course"`, `educationalLevel`, `timeRequired` (ISO), `offers`, `hasCourseInstance`, `coursePrerequisites`.
- [ ] Paste the rendered JSON into `https://validator.schema.org/` — zero errors.
- [ ] `numberOfItems` matches the actual rendered list (capped at 20 even if more paths exist).

## Human action required (post-merge / post-deploy)
- [ ] **Validate the production URL** in [Google Rich Results Test](https://search.google.com/test/rich-results?url=https://rawkode.academy/learning-paths). Expect both "Course" and "ItemList" detected, no errors.
- [ ] **Same in Schema.org validator**: paste the URL, confirm zero errors.
- [ ] **Watch GSC Enhancements → Course / ItemList** for the next 1–2 weeks. Both should appear under "Valid items".
- [ ] **Optional follow-up** — add ItemList JSON-LD to `/courses`, `/shows`, `/people`, `/adrs` to complete the index structured-data coverage across every collection. Each gets list-rich-result eligibility for its respective `@type`. The pattern is now well-established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)