### PR TITLE
feat(rawkode.academy/website): advertise JSON Feed via <link rel="alternate">

### DIFF
--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -95,6 +95,12 @@ const readingTime = calculateReadingTime(article.body || "");
 			title="Rawkode Academy - News (Atom)"
 			href="/api/feeds/news.atom"
 		/>
+		<link
+			rel="alternate"
+			type="application/feed+json"
+			title="Rawkode Academy - News (JSON Feed)"
+			href="/api/feeds/news.json"
+		/>
 	</Fragment>
 	<div class="article-page">
 		<Breadcrumb elements={breadcrumbElements} />

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -67,6 +67,12 @@ function formatTechnologyLabel(value: string): string {
 			title="Rawkode Academy - News (Atom)"
 			href="/api/feeds/news.atom"
 		/>
+		<link
+			rel="alternate"
+			type="application/feed+json"
+			title="Rawkode Academy - News (JSON Feed)"
+			href="/api/feeds/news.json"
+		/>
 	</Fragment>
 	<section class="page-px section-py-tight">
 		<div class="mx-auto max-w-4xl">

--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -132,6 +132,13 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 		title="Rawkode Academy - Articles (Atom)"
 		href="/api/feeds/articles.atom"
 	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/feed+json"
+		title="Rawkode Academy - Articles (JSON Feed)"
+		href="/api/feeds/articles.json"
+	/>
 
 	<div class="article-page">
 		<!-- Breadcrumb -->

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -46,6 +46,12 @@ const pageDescription =
     />
     <link
       rel="alternate"
+      type="application/feed+json"
+      title="Rawkode Academy - Articles (JSON Feed)"
+      href="/api/feeds/articles.json"
+    />
+    <link
+      rel="alternate"
       type="application/atom+xml"
       title="Rawkode Academy - Articles (Atom)"
       href="/api/feeds/articles.atom"

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -256,6 +256,13 @@ if (isAuthenticated && user?.id) {
 		title="Rawkode Academy - Videos (Atom)"
 		href="/api/feeds/videos.atom"
 	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/feed+json"
+		title="Rawkode Academy - Videos (JSON Feed)"
+		href="/api/feeds/videos.json"
+	/>
 	<div class="min-h-screen">
 		<div class="container-content content-px py-4 sm:py-6 lg:py-8">
 			{/* Breadcrumb */}

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -151,6 +151,13 @@ const hasNextPage = end < allVideos.length;
 		title="Rawkode Academy - Videos (Atom)"
 		href="/api/feeds/videos.atom"
 	/>
+	<link
+		slot="extra-head"
+		rel="alternate"
+		type="application/feed+json"
+		title="Rawkode Academy - Videos (JSON Feed)"
+		href="/api/feeds/videos.json"
+	/>
 
 	<!-- Featured Content Section -->
 	{featuredVideo && (


### PR DESCRIPTION
## Summary
Add a third `<link rel="alternate" type="application/feed+json">` next to the existing RSS/Atom discovery tags on every news/read/watch surface (index + detail):
- `/news`, `/news/[slug]` → `/api/feeds/news.json`
- `/read`, `/read/[slug]` → `/api/feeds/articles.json`
- `/watch`, `/watch/[slug]` → `/api/feeds/videos.json`

## Why
**Reach.** #1060 wired the RSS/Atom discovery tags; #1072 + #1075 then shipped JSON Feed 1.1 endpoints (`all.json` + per-type variants). But the discovery tags weren't updated, so feed-reader extensions and apps that prefer JSON Feed (NetNewsWire, Feedbin, Reeder, FeedLand) had nothing to auto-detect on visit. Three formats are now equally discoverable.

Six-line completeness diff, no logic change.

## Test plan
- [ ] `view-source:` on each of `/news`, `/news/<slug>`, `/read`, `/read/<slug>`, `/watch`, `/watch/<slug>` — confirm three `<link rel="alternate">` tags (RSS, Atom, JSON Feed) for each collection.
- [ ] NetNewsWire on `/read` auto-detects the JSON Feed (it prefers JSON when available).
- [ ] A feed-reader extension on each surface lists all three formats.

## Human action required (post-merge / post-deploy)
- [ ] **Smoke-test in NetNewsWire**: visit `/read` and add subscription via the URL bar. It should default to the JSON Feed format (preferring `feed+json` MIME type per its docs). If it picks the wrong one, send me the URL.
- [ ] **Optional follow-up** — add the same three discovery tags on the homepage `/` pointing at `/api/feeds/all.{xml,atom,json}`. Currently the homepage doesn't advertise any feed format. Standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)