### PR TITLE
News digest follow-on — May 15, 2026 (Microcks, CRI-O 1.36, Helm 4.2)

### DIFF
--- a/content/news/crio-1-36-spdystream-cve-2026-35469/index.mdx
+++ b/content/news/crio-1-36-spdystream-cve-2026-35469/index.mdx
@@ -1,0 +1,28 @@
+---
+title: "CRI-O 1.36 ships with CNI health monitoring; all supported branches patch a spdystream DoS"
+description: "CRI-O 1.36.0 and patch releases for 1.35, 1.34, and 1.33 landed on May 5 with CVE-2026-35469 (CVSS 8.7) fixed across the board, alongside new CNI status polling and GOMAXPROCS injection."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - crio
+  - kubernetes
+---
+
+CRI-O shipped [v1.36.0](https://github.com/cri-o/cri-o/releases/tag/v1.36.0) on May 5, 2026, the matching CRI for Kubernetes 1.36. Patch releases for the older supported branches — v1.35.3, v1.34.8, and v1.33.12 — went out the same day.
+
+## CVE-2026-35469 across every supported branch
+
+Every release in the May 5 batch updates `spdystream` from 0.5.0 to 0.5.1 to address [CVE-2026-35469](https://nvd.nist.gov/vuln/detail/CVE-2026-35469), a denial-of-service flaw in the Go SPDY library used by CRI streaming endpoints. The SPDY/3 frame parser allocates memory based on attacker-controlled counts and lengths without bounds checking, and because header blocks are zlib-compressed a small on-the-wire payload can decompress into very large allocations. CVSS 4.0 score is 8.7 (HIGH). The Red Hat advisory lists kubelet, CRI-O, and kube-apiserver as affected components.
+
+## What's new in 1.36 itself
+
+- **CNI plugin health monitoring.** CRI-O now continuously polls CNI plugins via the `STATUS` verb and reports `NetworkReady` accordingly, rather than discovering broken CNI only at pod-create time.
+- **`min_injected_gomaxprocs` config option.** Lets operators set a floor for `GOMAXPROCS` in every container CRI-O creates — useful when CPU limits don't match the thread-count assumptions of Go or Java workloads.
+- **Streaming container methods.** Implements `StreamContainers`, `StreamContainerStats`, and `StreamPodSandboxes`, matching the newer streaming CRI surface.
+- **systemd + `hostUsers: false` regression fixed.** A v1.35.0 regression that caused permission-denied failures for systemd containers with user namespaces is resolved.
+- **Fast-exit race.** A race that reported `exitCode 255` for containers that exited very quickly is fixed.
+
+If you run CRI-O — including on the older 1.33–1.35 branches — patch level matters here regardless of whether you've consumed the matching Kubernetes patches.
+
+**Sources:** [CRI-O v1.36.0 release notes](https://github.com/cri-o/cri-o/releases/tag/v1.36.0), [CVE-2026-35469 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2026-35469), [GHSA-pc3f-x583-g7j2](https://github.com/advisories/GHSA-pc3f-x583-g7j2) — May 5, 2026

--- a/content/news/helm-4-2-3-21-v3-eol-warning/index.mdx
+++ b/content/news/helm-4-2-3-21-v3-eol-warning/index.mdx
@@ -1,0 +1,32 @@
+---
+title: "Helm 4.2 lands; Helm 3.21 ships with an explicit end-of-life warning"
+description: "Helm v4.2.0 and v3.21.0 both released on May 14, with the v3 release notes now stating that the v3 line is approaching end-of-life — a planning trigger for the long tail of clusters still on v3 charts."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - helm
+---
+
+Helm shipped [v4.2.0](https://github.com/helm/helm/releases/tag/v4.2.0) and [v3.21.0](https://github.com/helm/helm/releases/tag/v3.21.0) on May 14, 2026. The notable change isn't in the changelog — it's the warning at the top of the v3.21.0 notes that Helm v3 is approaching end-of-life and that operators should plan their migration to v4.
+
+## What's in v4.2
+
+The release continues to track Kubernetes upstream tightly: client libraries are bumped to v1.36, Go is bumped to 1.26, and controller-runtime to v0.24. The headline functional changes:
+
+- A new `mustToToml` template function for charts that need TOML rendering without dropping back to raw strings.
+- `--dry-run=server` now honours `generateName:` instead of erroring on names that the apiserver would assign.
+- The build switches to goreleaser; binaries are now produced for `loong64` (LoongArch).
+- Multiple fixes for post-renderers — hooks no longer collide with templates, and YAML separator parsing and Windows line-ending handling are corrected.
+
+The `--hide-notes` and `--render-subchart-notes` flags are deprecated.
+
+## What's in v3.21
+
+The v3 line is in maintenance: this release upgrades `opentelemetry` packages to pick up patched CVEs and corrects a chart-path bug. No new functional surface.
+
+## Why this matters now
+
+Helm v4 has been GA since November 12, 2025, but most production clusters still distribute v3 charts. The explicit "approaching end-of-life" language in a release-notes header — rather than a separate deprecation announcement — is the planning trigger: vendors will start dropping v3-only charts, and chart authors will need to validate against v4's stricter template engine.
+
+**Sources:** [Helm v4.2.0](https://github.com/helm/helm/releases/tag/v4.2.0), [Helm v3.21.0](https://github.com/helm/helm/releases/tag/v3.21.0) — May 14, 2026

--- a/content/news/microcks-cncf-incubation/index.mdx
+++ b/content/news/microcks-cncf-incubation/index.mdx
@@ -1,0 +1,23 @@
+---
+title: "Microcks moves from CNCF Sandbox to Incubation"
+description: "The CNCF Technical Oversight Committee voted to promote Microcks — a multi-protocol API mocking and contract-testing platform — to Incubating status, three years after Sandbox acceptance."
+publishedAt: 2026-05-15
+authors:
+  - rawkode
+technologies:
+  - microcks
+---
+
+The CNCF Technical Oversight Committee has voted to promote Microcks from Sandbox to Incubating, according to the [CNCF announcement on May 7, 2026](https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/). Microcks entered the Sandbox on June 22, 2023.
+
+## What Microcks covers that other mocking tools don't
+
+Microcks generates live mock servers from contract documents — OpenAPI, AsyncAPI, gRPC/Protobuf, GraphQL SDL, Postman collections, and SOAP/WSDL — and runs the same artifacts as conformance tests against a real implementation. Its Async Minion component publishes and verifies messages on Kafka, MQTT, AMQP, NATS, WebSockets, Google Pub/Sub, and Amazon SQS/SNS, which is the part most other open-source mock servers don't do.
+
+## What the promotion actually means
+
+Incubation is the CNCF level that requires production adopters, documented governance, and a sustained contributor base — not just a maturity badge. The announcement lists 645 contributors, 2.5 million container image downloads in 2025, and 34 public adopters. Maintainers Laurent Broudoux (project creator, 2015) and Yacine Kheddache continue under formal CNCF vendor-neutral governance.
+
+If you've been hand-rolling Kafka or AsyncAPI mocks for integration tests, this is the boring-correct path the foundation is now backing.
+
+**Source:** [Microcks becomes a CNCF incubating project](https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/) — CNCF, May 7, 2026


### PR DESCRIPTION
## Summary

A follow-on to the May 15 digest already shipped in #1069. After scanning Tier 1/Tier 2 sources for the last 7 days, three items survived triage that weren't covered by the earlier batch: Microcks's CNCF Incubation promotion, the CRI-O 1.36 release wave (plus CVE-2026-35469 patches across all supported branches), and the Helm 4.2 / 3.21 dual release with an explicit v3 end-of-life warning. Each segment passes the substance, source, and "so what" gates without padding.

## Segments

- **Microcks moves from CNCF Sandbox to Incubation** — TOC vote confirmed on May 7; multi-protocol contract mocking (including AsyncAPI / Kafka / MQTT / Pub-Sub) is the differentiator the audience cares about.
- **CRI-O 1.36 + CVE-2026-35469 patches across 1.33–1.36** — CVSS 8.7 spdystream DoS fix shipped on every supported branch on May 5; CRI-O 1.36.0 also adds CNI STATUS polling and GOMAXPROCS injection. Worth standalone coverage because the earlier May patch wave article focused on the Kubernetes side.
- **Helm 4.2 + 3.21 with v3 EOL warning** — v3.21's release notes now carry "approaching end-of-life" language. v4.2 tracks Kubernetes 1.36 client libraries and adds `mustToToml`, `loong64` builds, and `generateName:` support under `--dry-run=server`.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Microcks → CNCF Incubating, announced May 7, 2026 | https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/ | ✅ |
| Microcks in Sandbox since June 22, 2023 | content/technologies/microcks/index.mdx + CNCF announcement | ✅ |
| Microcks protocol scope (OpenAPI, AsyncAPI, gRPC, GraphQL, Postman, SOAP; Kafka/MQTT/AMQP/NATS/WS/Pub-Sub/SQS-SNS) | https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/ | ✅ |
| Microcks adoption metrics (645 contributors, 2.5M downloads 2025, 34 adopters) | https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/ | ✅ |
| CRI-O v1.36.0 release date May 5, 2026 | https://github.com/cri-o/cri-o/releases/tag/v1.36.0 | ✅ |
| CRI-O patch releases v1.35.3 / v1.34.8 / v1.33.12 same day | https://github.com/cri-o/cri-o/releases | ✅ |
| CVE-2026-35469 CVSS 4.0 score 8.7 HIGH; affects spdystream ≤ 0.5.0; fixed in 0.5.1 | https://nvd.nist.gov/vuln/detail/CVE-2026-35469 | ✅ |
| CVE affects kubelet / CRI-O / kube-apiserver | Red Hat bugzilla #2457729 + GHSA-pc3f-x583-g7j2 | ✅ |
| CRI-O 1.36 features (CNI STATUS, `min_injected_gomaxprocs`, streaming methods, systemd `hostUsers: false` regression fix, fast-exit race fix) | https://github.com/cri-o/cri-o/releases/tag/v1.36.0 | ✅ |
| Helm v4.2.0 and v3.21.0 released May 14, 2026 | https://github.com/helm/helm/releases/tag/v4.2.0, https://github.com/helm/helm/releases/tag/v3.21.0 | ✅ |
| Helm v4.0.0 GA on Nov 12, 2025 | https://github.com/helm/helm-www/blob/main/blog/2025-11-17-helm-4-released/index.md | ✅ |
| Helm v3 "approaching end of life" wording in v3.21.0 release notes header | https://github.com/helm/helm/releases/tag/v3.21.0 | ✅ |
| Helm 4.2 changes (k8s client libs 1.36, Go 1.26, controller-runtime 0.24, `mustToToml`, `--dry-run=server` honours `generateName:`, goreleaser, loong64) | https://github.com/helm/helm/releases/tag/v4.2.0 | ✅ |
| Helm 4.2 deprecations (`--hide-notes`, `--render-subchart-notes`) | https://github.com/helm/helm/releases/tag/v4.2.0 | ✅ |
| Helm 3.21 upgrades opentelemetry packages for CVEs | https://github.com/helm/helm/releases/tag/v3.21.0 | ✅ |

## Items considered and dropped

- **CNCF KubeCon Japan 2026 schedule (May 13)** — conference programming announcement; fails substance axis.
- **Cilium 1.18.10 / 1.19.4 (May 13)** — already covered in `content/news/cilium-may-2026-patch-wave`.
- **Cloudflare Infire / Unweight** — InfoQ summary appeared May 3, but the primary blog posts are from August 2025; not fresh.
- **Lemonade adds vLLM ROCm backend (May 8)** — packaging story, thin on substance for the target audience.
- **Microsoft / NVIDIA DRA + vGPU on AKS (March 2026)** — out of the 7-day window and already widely covered.
- **runc 1.5** — expected end of April; couldn't verify a fresh post-May 1 ship.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial → Fact-check → Edit → Final.
- Total candidates considered: ~18 across CNCF, Kubernetes, eBPF, GitOps, observability, AI/HPC inference, platform engineering, and security.
- Segments shipped: 3.
- Time horizon: May 5–14, 2026.
- Format note: followed the existing repo convention of one `content/news/<slug>/index.mdx` per item (matching the 20 entries shipped in #1069), rather than a single combined digest file.

https://claude.ai/code/session_01Rd6W2f1obnotXdHTXyv9qd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rd6W2f1obnotXdHTXyv9qd)_