### PR TITLE
feat(rawkode.academy/website): add PodcastSeries JSON-LD on show pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/podcast-series-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/podcast-series-jsonld.astro
@@ -1,0 +1,44 @@
+---
+import type { CollectionEntry } from "astro:content";
+import { buildPodcastSeriesJsonLd } from "@/lib/podcast-series-jsonld";
+
+interface Props {
+	show: CollectionEntry<"shows">;
+	hosts: ReadonlyArray<CollectionEntry<"people">>;
+	episodeCount?: number;
+	imageUrl?: string;
+	slot?: string;
+}
+
+const { show, hosts, episodeCount, imageUrl } = Astro.props;
+
+const siteUrl = (Astro.site ?? Astro.url).origin;
+const homePageUrl = new URL(`/shows/${show.data.id}`, siteUrl).href;
+const feedUrl = new URL(`/api/feeds/shows/${show.data.id}.xml`, siteUrl).href;
+
+const jsonLd = buildPodcastSeriesJsonLd({
+	siteUrl,
+	source: {
+		id: show.data.id,
+		name: show.data.name,
+		...(show.data.description ? { description: show.data.description } : {}),
+		...(show.data.podcast?.category
+			? { category: show.data.podcast.category }
+			: {}),
+		...(show.data.podcast?.subcategory
+			? { subcategory: show.data.podcast.subcategory }
+			: {}),
+		...(imageUrl ? { imageUrl } : {}),
+		...(typeof episodeCount === "number" ? { episodeCount } : {}),
+	},
+	hosts: hosts.map((host) => ({ id: host.data.id, name: host.data.name })),
+	feedUrl,
+	homePageUrl,
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/podcast-series-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/podcast-series-jsonld.ts
@@ -1,0 +1,94 @@
+export interface PodcastSeriesHost {
+	id: string;
+	name: string;
+}
+
+export interface PodcastSeriesSource {
+	id: string;
+	name: string;
+	description?: string;
+	category?: string;
+	subcategory?: string;
+	imageUrl?: string;
+	episodeCount?: number;
+}
+
+export interface BuildPodcastSeriesJsonLdInput {
+	siteUrl: string;
+	source: PodcastSeriesSource;
+	hosts: ReadonlyArray<PodcastSeriesHost>;
+	feedUrl: string;
+	homePageUrl: string;
+}
+
+const PUBLISHER_NAME = "Rawkode Academy";
+const PUBLISHER_LOGO_PATH = "/android-chrome-512x512.png";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+/**
+ * Build a schema.org/PodcastSeries JSON-LD payload for a show page.
+ *
+ * PodcastSeries is the documented type for episodic audio/video shows;
+ * Google's podcast surfaces and Apple Podcasts' web crawler both honour it.
+ * Combined with the existing `subscribeLinks` UI, it makes a show
+ * machine-discoverable as a podcast wherever the user opens it.
+ */
+export function buildPodcastSeriesJsonLd(
+	input: BuildPodcastSeriesJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, source, hosts, feedUrl, homePageUrl } = input;
+
+	const jsonLd: Record<string, unknown> = {
+		"@context": "https://schema.org",
+		"@type": "PodcastSeries",
+		name: source.name,
+		url: homePageUrl,
+		webFeed: feedUrl,
+		inLanguage: "en",
+		publisher: {
+			"@type": "Organization",
+			name: PUBLISHER_NAME,
+			url: siteUrl,
+			logo: {
+				"@type": "ImageObject",
+				url: joinUrl(siteUrl, PUBLISHER_LOGO_PATH),
+			},
+		},
+	};
+
+	if (source.description) {
+		jsonLd.description = source.description;
+	}
+
+	if (source.imageUrl) {
+		jsonLd.image = source.imageUrl;
+	}
+
+	const genres = [source.category, source.subcategory].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	if (genres.length > 0) {
+		jsonLd.genre = genres.join(" / ");
+	}
+
+	if (
+		typeof source.episodeCount === "number" &&
+		Number.isFinite(source.episodeCount) &&
+		source.episodeCount >= 0
+	) {
+		jsonLd.numberOfEpisodes = Math.floor(source.episodeCount);
+	}
+
+	if (hosts.length > 0) {
+		jsonLd.author = hosts.map((host) => ({
+			"@type": "Person",
+			name: host.name,
+			url: joinUrl(siteUrl, `/people/${host.id}`),
+		}));
+	}
+
+	return jsonLd;
+}

--- a/projects/rawkode.academy/website/src/pages/shows/[showId].astro
+++ b/projects/rawkode.academy/website/src/pages/shows/[showId].astro
@@ -2,9 +2,11 @@
 export const prerender = false;
 
 import { getCollection, getEntries } from "astro:content";
+import { getImage } from "astro:assets";
 import { getPublishedVideos } from "@/lib/content";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb.astro";
 import VideoMetadata from "@/components/html/video-metadata.astro";
+import PodcastSeriesJsonLd from "@/components/html/podcast-series-jsonld.astro";
 import VideoFeed from "@/components/video/video-feed.astro";
 import SubscribeLinks from "@/components/show/SubscribeLinks.vue";
 import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
@@ -93,6 +95,18 @@ const latestEpisode = feedVideos[0];
 const totalDurationSeconds = feedVideos.reduce((sum, v) => sum + v.duration, 0);
 const totalHours = Math.floor(totalDurationSeconds / 3600);
 
+let podcastImageUrl: string | undefined;
+if (showEntry.data.podcast?.artworkUrl) {
+	podcastImageUrl = showEntry.data.podcast.artworkUrl;
+} else if (showEntry.data.cover) {
+	try {
+		const resolved = await getImage({ src: showEntry.data.cover.image });
+		podcastImageUrl = new URL(resolved.src, Astro.site ?? Astro.url).href;
+	} catch {
+		// Fall through with no image — JSON-LD `image` is optional.
+	}
+}
+
 function formatDate(dateString: string) {
 	return new Date(dateString).toLocaleDateString("en-US", {
 		year: "numeric",
@@ -114,6 +128,13 @@ function formatDuration(seconds: number) {
 ---
 
 <Page title={pageTitle} description={showDescription}>
+        <PodcastSeriesJsonLd
+                slot="extra-head"
+                show={showEntry}
+                hosts={hostEntries}
+                episodeCount={feedVideos.length}
+                {...(podcastImageUrl ? { imageUrl: podcastImageUrl } : {})}
+        />
         <VideoMetadata
                 slot="extra-head"
                 title={pageTitle}


### PR DESCRIPTION
## Summary
- New pure-TS builder `src/lib/podcast-series-jsonld.ts` producing a `schema.org/PodcastSeries` payload (name, description, url, image, `webFeed` pointing at the existing per-show RSS, `numberOfEpisodes`, genre derived from podcast category/subcategory, host authors → `/people/{id}`, publisher Organization).
- Astro wrapper resolves the show artwork: `podcast.artworkUrl` if present, otherwise the page cover image processed by `getImage` (so it works with both string and `Image` references).
- Wired into `/shows/[showId].astro` via `extra-head` slot, alongside the existing `VideoMetadata`.

## Why
**Reach.** Shows are podcasts — they have hosts, category/subcategory frontmatter, per-show RSS feeds, episode counts, and the existing `SubscribeLinks` UI for Apple Podcasts / Spotify / etc. But the rendered page had no structured data tying that together. `PodcastSeries` is the documented schema.org type for episodic audio/video shows and is honoured by:
- **Apple Podcasts** (via the iTunes crawler that follows the `webFeed` from JSON-LD)
- **Google's podcast surfaces** (deprecated Google Podcasts but still feeding YouTube Music's podcast directory)
- **Brave Goggles**, generic search engines, podcast aggregators

Combined with the existing `subscribeLinks`, this makes a show machine-discoverable as a podcast wherever the audience lives.

## Test plan
- [ ] Build and `view-source:` on `/shows/<id>` — confirm a `<script type="application/ld+json">` with `@type: "PodcastSeries"` is present.
- [ ] `webFeed` is `/api/feeds/shows/<id>.xml` (the existing per-show feed).
- [ ] `image` resolves: if the show defines `podcast.artworkUrl`, that's used; otherwise the cover image is processed via `getImage`.
- [ ] `numberOfEpisodes` matches `feedVideos.length` for that show.
- [ ] Paste the rendered JSON into `https://validator.schema.org/` — zero errors.
- [ ] No regression on `VideoMetadata` (the existing JSON-LD is still emitted alongside).

## Human action required (post-merge / post-deploy)
- [ ] **Validate one production URL** in [Google Rich Results Test](https://search.google.com/test/rich-results) — paste a show URL, confirm "PodcastSeries" detected.
- [ ] **Schema.org validator**: paste the same URL, confirm zero errors.
- [ ] **Confirm artwork in podcast directories**: if your shows aren't already in Apple Podcasts Connect, this PR doesn't auto-submit them — you still need to submit the feed URL there once. Apple Podcasts re-fetches metadata periodically; the JSON-LD doesn't bypass that flow but it helps generic search engines and aggregators.
- [ ] **Optional follow-up** — each individual episode is a `PodcastEpisode` (PodcastSeries' child type). Wiring it on `/watch/[slug]` for videos that belong to a show is a separate PR worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)