### PR TITLE
quality: SEO, copy, and content hygiene sweep (round 2)

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/course-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/course-itemlist-jsonld.astro
@@ -1,0 +1,38 @@
+---
+import { buildCourseItemListJsonLd } from "@/lib/course-itemlist-jsonld";
+
+interface CourseEntryInput {
+	id: string;
+	data: {
+		title: string;
+		description: string;
+		publishedAt: Date;
+		updatedAt?: Date | undefined;
+		difficulty: "beginner" | "intermediate" | "advanced";
+	};
+}
+
+interface Props {
+	courses: ReadonlyArray<CourseEntryInput>;
+	listUrl: string;
+	listName?: string;
+	limit?: number;
+	slot?: string;
+}
+
+const { courses, listUrl, listName, limit } = Astro.props;
+
+const jsonLd = buildCourseItemListJsonLd({
+	siteUrl: (Astro.site ?? Astro.url).origin,
+	listUrl,
+	listName: listName ?? "Courses",
+	courses,
+	...(typeof limit === "number" ? { limit } : {}),
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/components/html/show-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/show-itemlist-jsonld.astro
@@ -1,0 +1,33 @@
+---
+import { buildShowItemListJsonLd } from "@/lib/show-itemlist-jsonld";
+
+interface ShowEntryInput {
+	id: string;
+	name: string;
+	description?: string | undefined;
+	imageUrl?: string | undefined;
+	episodeCount?: number | undefined;
+}
+
+interface Props {
+	shows: ReadonlyArray<ShowEntryInput>;
+	listUrl: string;
+	listName?: string;
+	slot?: string;
+}
+
+const { shows, listUrl, listName } = Astro.props;
+
+const jsonLd = buildShowItemListJsonLd({
+	siteUrl: (Astro.site ?? Astro.url).origin,
+	listUrl,
+	listName: listName ?? "Shows",
+	shows,
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/layouts/minimal.astro
+++ b/projects/rawkode.academy/website/src/layouts/minimal.astro
@@ -5,9 +5,10 @@ import "@/styles/global.css";
 interface Props {
 	title: string;
 	description?: string;
+	noindex?: boolean;
 }
 
-const { title, description } = Astro.props;
+const { title, description, noindex } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -17,6 +18,7 @@ const { title, description } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description || title} />
+    {noindex && <meta name="robots" content="noindex,follow" />}
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />

--- a/projects/rawkode.academy/website/src/lib/course-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/course-itemlist-jsonld.ts
@@ -1,0 +1,88 @@
+export interface CourseListEntry {
+	id: string;
+	data: {
+		title: string;
+		description: string;
+		publishedAt: Date;
+		updatedAt?: Date | undefined;
+		difficulty: "beginner" | "intermediate" | "advanced";
+	};
+}
+
+export interface BuildCourseItemListJsonLdInput {
+	siteUrl: string;
+	listUrl: string;
+	listName: string;
+	courses: ReadonlyArray<CourseListEntry>;
+	limit?: number;
+}
+
+const DEFAULT_LIMIT = 20;
+const PUBLISHER_NAME = "Rawkode Academy";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+const difficultyEducationalLevel: Record<
+	CourseListEntry["data"]["difficulty"],
+	string
+> = {
+	beginner: "Beginner",
+	intermediate: "Intermediate",
+	advanced: "Advanced",
+};
+
+/**
+ * Build a schema.org ItemList JSON-LD payload for the courses index page.
+ *
+ * Each ListItem embeds a Course item — Google's documented shape for the
+ * Course rich result on list-type pages.
+ * See https://developers.google.com/search/docs/appearance/structured-data/course
+ */
+export function buildCourseItemListJsonLd(
+	input: BuildCourseItemListJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, listUrl, listName, courses, limit = DEFAULT_LIMIT } = input;
+
+	const ordered = [...courses]
+		.sort(
+			(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
+		)
+		.slice(0, Math.max(0, limit));
+
+	const provider = {
+		"@type": "Organization",
+		name: PUBLISHER_NAME,
+		url: siteUrl,
+		sameAs: siteUrl,
+	};
+
+	const itemListElement = ordered.map((course, index) => {
+		const courseUrl = joinUrl(siteUrl, `/courses/${course.id}`);
+		return {
+			"@type": "ListItem",
+			position: index + 1,
+			url: courseUrl,
+			item: {
+				"@type": "Course",
+				name: course.data.title,
+				description: course.data.description,
+				url: courseUrl,
+				provider,
+				educationalLevel:
+					difficultyEducationalLevel[course.data.difficulty] ?? undefined,
+			},
+		};
+	});
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: listName,
+		url: listUrl,
+		numberOfItems: itemListElement.length,
+		itemListOrder: "https://schema.org/ItemListOrderDescending",
+		itemListElement,
+	};
+}

--- a/projects/rawkode.academy/website/src/lib/show-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/show-itemlist-jsonld.ts
@@ -1,0 +1,69 @@
+export interface ShowListEntry {
+	id: string;
+	name: string;
+	description?: string | undefined;
+	imageUrl?: string | undefined;
+	episodeCount?: number | undefined;
+}
+
+export interface BuildShowItemListJsonLdInput {
+	siteUrl: string;
+	listUrl: string;
+	listName: string;
+	shows: ReadonlyArray<ShowListEntry>;
+}
+
+const PUBLISHER_NAME = "Rawkode Academy";
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+/**
+ * Build a schema.org ItemList JSON-LD payload for the shows index page.
+ *
+ * Each ListItem embeds a PodcastSeries item — the show pages individually
+ * emit PodcastSeries JSON-LD already; the listing's ItemList groups them
+ * so Google can surface the whole library.
+ */
+export function buildShowItemListJsonLd(
+	input: BuildShowItemListJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, listUrl, listName, shows } = input;
+
+	const publisher = {
+		"@type": "Organization",
+		name: PUBLISHER_NAME,
+		url: siteUrl,
+	};
+
+	const itemListElement = shows.map((show, index) => {
+		const showUrl = joinUrl(siteUrl, `/shows/${show.id}`);
+		const item: Record<string, unknown> = {
+			"@type": "PodcastSeries",
+			name: show.name,
+			url: showUrl,
+			publisher,
+		};
+		if (show.description) item.description = show.description;
+		if (show.imageUrl) item.image = show.imageUrl;
+		if (typeof show.episodeCount === "number" && show.episodeCount > 0) {
+			item.numberOfEpisodes = show.episodeCount;
+		}
+		return {
+			"@type": "ListItem",
+			position: index + 1,
+			url: showUrl,
+			item,
+		};
+	});
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: listName,
+		url: listUrl,
+		numberOfItems: itemListElement.length,
+		itemListElement,
+	};
+}

--- a/projects/rawkode.academy/website/src/pages/confirm-subscription.astro
+++ b/projects/rawkode.academy/website/src/pages/confirm-subscription.astro
@@ -20,7 +20,11 @@ await env.EMAIL_PREFERENCES.setPreference(prefixedUserId, {
 });
 ---
 
-<Page title="Subscription Confirmed" description="You are now subscribed to the Rawkode Academy newsletter.">
+<Page
+	title="Subscription Confirmed"
+	description="You are now subscribed to the Rawkode Academy newsletter."
+	noindex
+>
 	<div class="min-h-[60vh] flex flex-col items-center justify-center px-4 text-center">
 		<div class="w-24 h-24 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-8">
 			<svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/projects/rawkode.academy/website/src/pages/courses/index.astro
+++ b/projects/rawkode.academy/website/src/pages/courses/index.astro
@@ -49,7 +49,7 @@ if (featuredCourse) {
 	});
 }
 
-const pageTitle = "Cloud Native Courses | Rawkode Academy";
+const pageTitle = "Cloud Native Courses";
 const pageDescription =
 	"Hands-on cloud native courses, labs, and walkthroughs covering Kubernetes, identity, GraphQL, Rust, and the tooling behind real platform engineering.";
 ---

--- a/projects/rawkode.academy/website/src/pages/courses/index.astro
+++ b/projects/rawkode.academy/website/src/pages/courses/index.astro
@@ -2,6 +2,7 @@
 import { getCollection, getEntries } from "astro:content";
 import CourseCard from "@/components/courses/CourseCard.astro";
 import CoursesHero from "@/components/courses/CoursesHero.astro";
+import CourseItemListJsonLd from "@/components/html/course-itemlist-jsonld.astro";
 import { getCourseModuleSlug } from "@/utils/course-path";
 import Page from "@/wrappers/page.astro";
 
@@ -55,6 +56,12 @@ const pageDescription =
 ---
 
 <Page title={pageTitle} description={pageDescription}>
+	<CourseItemListJsonLd
+		slot="extra-head"
+		courses={allCourses}
+		listUrl={new URL("/courses", Astro.site ?? Astro.url).href}
+		listName="Cloud Native Courses"
+	/>
 	<section class="page-px section-py-tight">
 		<div class="mx-auto max-w-7xl">
 			{featuredCourse ? (

--- a/projects/rawkode.academy/website/src/pages/embed/webcontainer.astro
+++ b/projects/rawkode.academy/website/src/pages/embed/webcontainer.astro
@@ -32,7 +32,7 @@ if (!courseId || !demoId) {
 export const prerender = false;
 ---
 
-<MinimalLayout title={title}>
+<MinimalLayout title={title} noindex>
   <style>
     body {
       margin: 0;

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -77,7 +77,7 @@ const socialProofStats = [
 	{ icon: "👥", value: "30K+", label: "Learners" },
 ];
 
-const pageTitle = "Cloud Native & Kubernetes Education | Rawkode Academy";
+const pageTitle = "Cloud Native & Kubernetes Education";
 const pageDescription =
 	"Master Cloud Native technologies and Kubernetes with Rawkode Academy's expert-led courses, articles, and live streams. Stay ahead in a fast-evolving landscape.";
 

--- a/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
@@ -33,7 +33,7 @@ const itemListPaths = await Promise.all(
 	}),
 );
 
-const pageTitle = "Learning Paths | Rawkode Academy";
+const pageTitle = "Learning Paths";
 const pageDescription =
 	"Curated, video-driven journeys to help you level up your Kubernetes, platform engineering, and cloud native skills.";
 ---

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -24,7 +24,7 @@ for (const technology of allTechnologies) {
 
 const pageTitle = "Cloud Native News";
 const pageDescription =
-	"Cloud native, Kubernetes, and AI infrastructure news for engineers.";
+	"Cloud native, Kubernetes, and AI infrastructure news for engineers — release notes, security advisories, KEP updates, ecosystem moves, in plain language.";
 
 function formatDisplayDate(date: Date): string {
 	return new Intl.DateTimeFormat("en-US", {

--- a/projects/rawkode.academy/website/src/pages/news/index.astro
+++ b/projects/rawkode.academy/website/src/pages/news/index.astro
@@ -22,7 +22,7 @@ for (const technology of allTechnologies) {
 	technologyNameById.set(rawId, technology.data.name);
 }
 
-const pageTitle = "Cloud Native News | Rawkode Academy";
+const pageTitle = "Cloud Native News";
 const pageDescription =
 	"Cloud native, Kubernetes, and AI infrastructure news for engineers.";
 

--- a/projects/rawkode.academy/website/src/pages/organizations/branding/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/branding/index.astro
@@ -143,7 +143,7 @@ const defaultLogoGradient =
 	"linear-gradient(135deg, #5F5ED7 0%, #00CEFF 100%)";
 ---
 
-<Page title="Branding | Rawkode Academy" description="Official Rawkode Academy brand assets — logos, colors, and usage guidelines for partners.">
+<Page title="Branding" description="Official Rawkode Academy brand assets — logos, colors, and usage guidelines for partners.">
   <Hero title="Branding Guidelines" subtitle="Our brand assets, color system, and recommended usage for partners" badge="Partner Resources" background="blobs" pattern="grid" wave={true} client:load>
     <Fragment slot="actions">
       <Button variant="primary" href="#assets">View Assets</Button>

--- a/projects/rawkode.academy/website/src/pages/organizations/consulting/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/consulting/index.astro
@@ -63,7 +63,7 @@ const consultingFAQs = [
 </style>
 
 <Page
-	title="Technical Consulting Services | Rawkode Academy"
+	title="Technical Consulting Services"
 	description="Expert technical consulting for developer experience, cloud native technologies, and software architecture to accelerate your technical initiatives and upskill your teams."
 >
 	<FAQJsonLD questions={consultingFAQs} slot="head" />

--- a/projects/rawkode.academy/website/src/pages/organizations/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/index.astro
@@ -90,7 +90,7 @@ const services = [
 </style>
 
 <Page
-	title="Enterprise Solutions | Rawkode Academy"
+	title="Enterprise Solutions"
 	description="Partner with Rawkode Academy for strategic partnerships, expert consulting, and team training to accelerate your cloud native journey."
 >
 	<!-- Hero Section -->

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -66,7 +66,7 @@ const partnershipFAQs = [
 </style>
 
 <Page
-	title="Strategic Technology Partnerships | Rawkode Academy"
+	title="Strategic Technology Partnerships"
 	description="Partner with Rawkode Academy to accelerate developer adoption, improve product experience, and drive growth through expert technical content and strategic guidance."
 >
 	<FAQJsonLD questions={partnershipFAQs} slot="head" />

--- a/projects/rawkode.academy/website/src/pages/organizations/training/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/training/index.astro
@@ -62,7 +62,7 @@ const trainingFAQs = [
 </style>
 
 <Page
-	title="Technical Training Programs | Rawkode Academy"
+	title="Technical Training Programs"
 	description="Hands-on technical training programs for cloud native technologies, developer experience, and platform engineering to upskill your engineering teams."
 >
 	<FAQJsonLD questions={trainingFAQs} slot="head" />

--- a/projects/rawkode.academy/website/src/pages/people/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/people/[id].astro
@@ -146,12 +146,12 @@ const noindex =
 
 const pageTitle = (() => {
 	if (showCount > 0) {
-		return `${person.data.name} — Host of ${showNames[0]} | Rawkode Academy`;
+		return `${person.data.name} — Host of ${showNames[0]}`;
 	}
 	if (topTechNames.length > 0) {
-		return `${person.data.name} — Talks on ${topTechNames.slice(0, 2).join(" & ")} | Rawkode Academy`;
+		return `${person.data.name} — Talks on ${topTechNames.slice(0, 2).join(" & ")}`;
 	}
-	return `${person.data.name} | Rawkode Academy`;
+	return person.data.name;
 })();
 
 const pageDescription = (() => {

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -26,7 +26,7 @@ const latestPostAuthors = latestPost
 // Get remaining posts (skip the first one since it's featured)
 const remainingPosts = allArticles.slice(1);
 
-const pageTitle = "Cloud Native & Kubernetes Articles | Rawkode Academy";
+const pageTitle = "Cloud Native & Kubernetes Articles";
 const pageDescription =
 	"Deep dive into cloud native technologies, Kubernetes, observability, and more. Articles written by practitioners for practitioners at Rawkode Academy.";
 ---

--- a/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
+++ b/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
@@ -43,7 +43,7 @@ const hasAccess = hasNewsletterSubscription || hasCheatsheetCookie || Astro.url.
 
 const pageTitle = "Kubernetes 1.35 Cheat Sheet";
 const pageDescription =
-	"Your comprehensive guide to Kubernetes 1.35 - breaking changes, new GA features, AI/ML scheduler primitives, and migration checklist. Free for cloud native engineers.";
+	"A guide to Kubernetes 1.35 — breaking changes, new GA features, AI/ML scheduler primitives, and a migration checklist for cloud native engineers.";
 ---
 
 <Page title={pageTitle} description={pageDescription}>

--- a/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
+++ b/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
@@ -41,7 +41,7 @@ if (user) {
 // User has access if they've subscribed (via preferences, cookie, or query param)
 const hasAccess = hasNewsletterSubscription || hasCheatsheetCookie || Astro.url.searchParams.has("subscribed");
 
-const pageTitle = "Kubernetes 1.35 Cheat Sheet | Rawkode Academy";
+const pageTitle = "Kubernetes 1.35 Cheat Sheet";
 const pageDescription =
 	"Your comprehensive guide to Kubernetes 1.35 - breaking changes, new GA features, AI/ML scheduler primitives, and migration checklist. Free for cloud native engineers.";
 ---

--- a/projects/rawkode.academy/website/src/pages/shows/index.astro
+++ b/projects/rawkode.academy/website/src/pages/shows/index.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 
 import { getCollection, getEntries } from "astro:content";
 import ShowCard from "@/components/show/ShowCard.astro";
+import ShowItemListJsonLd from "@/components/html/show-itemlist-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 import type { ShowSummary } from "@/types/show";
 
@@ -63,12 +64,30 @@ const showsToRender: ShowSummary[] = await (async () => {
 })();
 
 const hasShows = showsToRender.length > 0;
+
+const showsJsonLd = showEntries.map((s) => {
+	const episodeCount = videos.filter(
+		(v) => getShowId(v.data.show) === s.data.id,
+	).length;
+	return {
+		id: s.data.id,
+		name: s.data.name,
+		...(s.data.description ? { description: s.data.description } : {}),
+		...(episodeCount > 0 ? { episodeCount } : {}),
+	};
+});
 ---
 
 <Page
 	title="Shows"
 	description="Browse the live and recurring shows from Rawkode Academy — interviews, deep dives, and hands-on streams covering the cloud native ecosystem."
 >
+	<ShowItemListJsonLd
+		slot="extra-head"
+		shows={showsJsonLd}
+		listUrl={new URL("/shows", Astro.site ?? Astro.url).href}
+		listName="Rawkode Academy Shows"
+	/>
         <section class="relative overflow-hidden py-16 sm:py-20">
                 <!-- Background gradient -->
                 <div class="absolute inset-0 bg-gradient-to-b from-primary/5 via-transparent to-transparent dark:from-primary/10" aria-hidden="true"></div>

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -231,8 +231,8 @@ const categoryLabel =
 const seoTitle =
 	technology.seo?.title ??
 	(videoCount > 0
-		? `${technology.name} Tutorials, Videos & Guides | Rawkode Academy`
-		: `${technology.name} — ${categoryLabel} | Rawkode Academy`);
+		? `${technology.name} Tutorials, Videos & Guides`
+		: `${technology.name} — ${categoryLabel}`);
 
 const seoDescription = (() => {
 	if (technology.seo?.description) return technology.seo.description;

--- a/projects/rawkode.academy/website/src/pages/technology/index.astro
+++ b/projects/rawkode.academy/website/src/pages/technology/index.astro
@@ -39,7 +39,7 @@ try {
 
 <Page
 	title="Cloud Native Technologies"
-	description="Browse 300+ cloud native technologies — Kubernetes, GitOps, service mesh, observability, security, identity, and more — with tutorials, deep dives, and references."
+	description="300+ cloud native technologies — Kubernetes, GitOps, service mesh, observability, security, identity, and more — with tutorials, deep dives, and references."
 >
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->

--- a/projects/rawkode.academy/website/src/pages/technology/index.astro
+++ b/projects/rawkode.academy/website/src/pages/technology/index.astro
@@ -38,8 +38,8 @@ try {
 ---
 
 <Page
-	title="Technologies"
-	description="Explore the various technologies covered on Rawkode Academy."
+	title="Cloud Native Technologies"
+	description="Browse 300+ cloud native technologies covered on Rawkode Academy — Kubernetes, GitOps, service mesh, observability, security, identity, and more, each with tutorials, deep dives, and references."
 >
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->

--- a/projects/rawkode.academy/website/src/pages/technology/index.astro
+++ b/projects/rawkode.academy/website/src/pages/technology/index.astro
@@ -39,7 +39,7 @@ try {
 
 <Page
 	title="Cloud Native Technologies"
-	description="Browse 300+ cloud native technologies covered on Rawkode Academy — Kubernetes, GitOps, service mesh, observability, security, identity, and more, each with tutorials, deep dives, and references."
+	description="Browse 300+ cloud native technologies — Kubernetes, GitOps, service mesh, observability, security, identity, and more — with tutorials, deep dives, and references."
 >
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->

--- a/projects/rawkode.academy/website/src/pages/unsubscribe.astro
+++ b/projects/rawkode.academy/website/src/pages/unsubscribe.astro
@@ -85,7 +85,11 @@ if (Astro.request.method === "POST" && user) {
 }
 ---
 
-<Page title="Unsubscribe - Rawkode Academy" description="Unsubscribe from the Rawkode Academy newsletter.">
+<Page
+	title="Unsubscribe"
+	description="Unsubscribe from the Rawkode Academy newsletter."
+	noindex
+>
 	<div class="min-h-[60vh] flex flex-col items-center justify-center px-4 text-center">
 		{success === "true" ? (
 			<>


### PR DESCRIPTION
## Summary

Round 2 of the self-paced SEO / copy / content-hygiene loop. Round 1 shipped 17 iterations on PR #1089 and was merged; this PR picks up where that left off. Pushed to every iteration of the loop.

## Iterations

- **#18 (ce8bc6d2)** Consolidated brand-suffix handling. 13 page templates hardcoded ` | Rawkode Academy` directly into their `<Page title=...>` value, bypassing the length-aware suffix logic from round 1. That meant `/people/<slug>` titles ("David Flanagan — Host of Cloud Native Compass | Rawkode Academy" — 63 chars) blew past Google's 60-char SERP cap exactly when the central rule was designed to drop the suffix. Dropped the hardcoded suffix everywhere; head.astro now appends (or skips for length) consistently.

## Human action required

- Two findings from round 1 still need a product decision:
  - **`image.rawkode.academy` is 403** site-wide. Round 1 added a static fallback in opengraph.astro, but the upstream service repo is separate and needs investigating. Every page without an explicit cover currently has a non-dynamic OG card.
  - **`/community-day`** route is dead — footer link + Astro action still wired, no page renders. Either ship the landing page or rip out the references.
- One content-package follow-up: 50+ `content/technologies/*/index.mdx` files have `useCase: '>-'` (a yaml-folded scalar indicator that was authored as a quoted string and never interpreted). Round 1 filtered the broken value at the template; the right fix is in the content package — `grep -rl "useCase: '>-'" content/technologies/`.
- Review each iteration's copy / structured-data changes for tone and accuracy.
- Validate any new JSON-LD with https://search.google.com/test/rich-results.
- Final review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)