### PR TITLE
quality: SEO, copy, and content hygiene sweep (round 3)

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/head.astro
+++ b/projects/rawkode.academy/website/src/components/html/head.astro
@@ -94,7 +94,7 @@ const normalizedTitle =
 	<!-- Resource hints for performance -->
 	<link rel="preconnect" href="https://content.rawkode.academy" />
 	<link rel="preconnect" href="https://avatars.githubusercontent.com" />
-	<link rel="preconnect" href="https://unpkg.com" />
+	<link rel="dns-prefetch" href="https://image.rawkode.academy" />
 	<link rel="dns-prefetch" href="https://discord.gg" />
 
 	<!-- Preload critical fonts -->

--- a/projects/rawkode.academy/website/src/components/html/person-itemlist-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/person-itemlist-jsonld.astro
@@ -1,0 +1,32 @@
+---
+import { buildPersonItemListJsonLd } from "@/lib/person-itemlist-jsonld";
+
+interface PersonEntryInput {
+	id: string;
+	name: string;
+	avatarUrl?: string | undefined;
+	sameAs?: ReadonlyArray<string | undefined>;
+}
+
+interface Props {
+	people: ReadonlyArray<PersonEntryInput>;
+	listUrl: string;
+	listName?: string;
+	slot?: string;
+}
+
+const { people, listUrl, listName } = Astro.props;
+
+const jsonLd = buildPersonItemListJsonLd({
+	siteUrl: (Astro.site ?? Astro.url).origin,
+	listUrl,
+	listName: listName ?? "People",
+	people,
+});
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+/>

--- a/projects/rawkode.academy/website/src/lib/person-itemlist-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/person-itemlist-jsonld.ts
@@ -1,0 +1,61 @@
+export interface PersonListEntry {
+	id: string;
+	name: string;
+	avatarUrl?: string | undefined;
+	// Full URLs only — the content-config transform on people resolves
+	// the bare-handle frontmatter fields into URLs already.
+	sameAs?: ReadonlyArray<string | undefined>;
+}
+
+export interface BuildPersonItemListJsonLdInput {
+	siteUrl: string;
+	listUrl: string;
+	listName: string;
+	people: ReadonlyArray<PersonListEntry>;
+}
+
+function joinUrl(base: string, path: string): string {
+	return new URL(path, base).href;
+}
+
+/**
+ * Build a schema.org ItemList JSON-LD payload for the people index page.
+ *
+ * Each ListItem embeds a Person item with name, profile url, avatar, and
+ * sameAs links to external profiles. Same Person shape we emit on the
+ * individual /people/<id> pages, grouped at the listing level.
+ */
+export function buildPersonItemListJsonLd(
+	input: BuildPersonItemListJsonLdInput,
+): Record<string, unknown> {
+	const { siteUrl, listUrl, listName, people } = input;
+
+	const itemListElement = people.map((person, index) => {
+		const personUrl = joinUrl(siteUrl, `/people/${person.id}`);
+		const sameAs = (person.sameAs ?? []).filter(
+			(s): s is string => typeof s === "string" && s.length > 0,
+		);
+		const item: Record<string, unknown> = {
+			"@type": "Person",
+			name: person.name,
+			url: personUrl,
+		};
+		if (person.avatarUrl) item.image = person.avatarUrl;
+		if (sameAs.length > 0) item.sameAs = sameAs;
+		return {
+			"@type": "ListItem",
+			position: index + 1,
+			url: personUrl,
+			item,
+		};
+	});
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: listName,
+		url: listUrl,
+		numberOfItems: itemListElement.length,
+		itemListElement,
+	};
+}

--- a/projects/rawkode.academy/website/src/pages/about/index.astro
+++ b/projects/rawkode.academy/website/src/pages/about/index.astro
@@ -132,7 +132,7 @@ const signatureFormats = [
         }
 </style>
 
-<Page title="About Rawkode Academy" description="Get to know the story, mission, and formats behind Rawkode Academy.">
+<Page title="About Rawkode Academy" description="The story, mission, and formats behind Rawkode Academy — how we make hands-on cloud native and Kubernetes education for working engineers.">
         <Hero
                 background="gradient-hero"
                 pattern="dots"

--- a/projects/rawkode.academy/website/src/pages/people/index.astro
+++ b/projects/rawkode.academy/website/src/pages/people/index.astro
@@ -1,17 +1,39 @@
 ---
 export const prerender = true;
 
+import PersonItemListJsonLd from "@/components/html/person-itemlist-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 import { getCollection } from "astro:content";
 
 const people = await getCollection("people");
 const sortedPeople = people.sort((a, b) => a.data.name.localeCompare(b.data.name));
+
+const peopleJsonLd = sortedPeople.map((person) => ({
+	id: person.data.id,
+	name: person.data.name,
+	avatarUrl: person.data.avatarUrl,
+	sameAs: [
+		person.data.github,
+		person.data.twitter,
+		person.data.bluesky,
+		person.data.linkedin,
+		person.data.mastodon,
+		person.data.website,
+		person.data.youtube,
+	],
+}));
 ---
 
 <Page
 	title="People"
 	description="Meet the hosts, guests, contributors, and instructors behind Rawkode Academy — the people creating and curating our cloud native content."
 >
+	<PersonItemListJsonLd
+		slot="extra-head"
+		people={peopleJsonLd}
+		listUrl={new URL("/people", Astro.site ?? Astro.url).href}
+		listName="Rawkode Academy People"
+	/>
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->
 		<section class="w-full">

--- a/projects/rawkode.academy/website/src/pages/search.astro
+++ b/projects/rawkode.academy/website/src/pages/search.astro
@@ -57,8 +57,8 @@ const feedVideos = results
 <Page
 	title={searchQuery ? `Search results for "${searchQuery}"` : "Search"}
 	description={searchQuery
-		? `Search results for "${searchQuery}" across Rawkode Academy's cloud native videos, articles, and learning paths.`
-		: "Search Rawkode Academy's library of cloud native and Kubernetes videos, articles, and learning paths."}
+		? `Video search results for "${searchQuery}" on Rawkode Academy.`
+		: "Search Rawkode Academy's cloud native and Kubernetes video library."}
 	noindex
 >
 	{searchQuery.length === 0 ? (


### PR DESCRIPTION
## Summary

Round 3 of the self-paced SEO / copy / content-hygiene loop. Round 1 (PR #1089) and Round 2 (PR #1091) merged; this PR picks up where round 2 left off.

## Iterations

- **#26 (HEAD)** Emit Person ItemList JSON-LD on `/people`. Round 2 (#1091) added ItemList structured-data to `/courses` and `/shows` — `/people` was still missing one. Built `lib/person-itemlist-jsonld.ts` + wrapper component, wired into the people index. Each ListItem embeds a Person with name, url, avatar image, and sameAs links to GitHub / Twitter / Bluesky / LinkedIn / Mastodon / website / YouTube.

## Human action required

Carry-overs from round 1 + 2 (still open):
- **`image.rawkode.academy` is 403** site-wide. Static fallback is in place but the dynamic service needs investigating (lives outside this repo).
- **`/community-day`** dead route — footer link + signup action wired but no page. Product decision: build the page or rip out the references.
- **50+ `content/technologies/*/index.mdx`** files have `useCase: '>-'`. Website-side defensive filter shipped in round 1; the right fix is in the content package.

Per-PR:
- Review each iteration's structured-data changes and validate with https://search.google.com/test/rich-results.
- Final review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)