### PR TITLE
seo: Speakable JSON-LD + dynamic sitemap priorities

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/article-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/article-jsonld.astro
@@ -40,6 +40,10 @@ const jsonLd = {
 			url: new URL("/android-chrome-512x512.png", siteOrigin).href,
 		},
 	},
+	speakable: {
+		"@type": "SpeakableSpecification",
+		cssSelector: [".article-header h1"],
+	},
 };
 ---
 

--- a/projects/rawkode.academy/website/src/lib/news-jsonld.ts
+++ b/projects/rawkode.academy/website/src/lib/news-jsonld.ts
@@ -77,6 +77,10 @@ export function buildNewsArticleJsonLd(
 			},
 		},
 		articleSection: "News",
+		speakable: {
+			"@type": "SpeakableSpecification",
+			cssSelector: [".article-header h1"],
+		},
 	};
 
 	if (keywords.length > 0) {

--- a/projects/rawkode.academy/website/src/lib/sitemaps.ts
+++ b/projects/rawkode.academy/website/src/lib/sitemaps.ts
@@ -228,6 +228,7 @@ export async function getArticleSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			article.data.publishedAt,
 		),
 		changefreq: "daily" as const,
+		priority: 0.7,
 	}));
 
 	return sortByPath(entries);
@@ -275,6 +276,7 @@ export async function getTechnologySitemapEntries(): Promise<
 				(technology.data as Record<string, unknown>).publishedAt,
 			),
 			changefreq: "weekly" as const,
+			priority: 0.5,
 		}));
 
 	return sortByPath(entries);
@@ -291,6 +293,7 @@ export async function getVideoSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			video.data.publishedAt,
 		),
 		changefreq: "daily" as const,
+		priority: 0.7,
 	}));
 
 	return sortByPath(entries);
@@ -310,6 +313,7 @@ export async function getCourseSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			course.data.publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.7,
 	}));
 
 	const moduleEntries = modules.map((module) => ({
@@ -320,6 +324,7 @@ export async function getCourseSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			module.data.publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.6,
 	}));
 
 	return sortByPath([...courseEntries, ...moduleEntries]);
@@ -338,6 +343,7 @@ export async function getLearningPathSitemapEntries(): Promise<
 			learningPath.data.publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.7,
 	}));
 
 	return sortByPath(entries);
@@ -393,6 +399,7 @@ export async function getPeopleSitemapEntries(): Promise<SitemapUrlEntry[]> {
 				(person.data as Record<string, unknown>).publishedAt,
 			),
 			changefreq: "monthly" as const,
+			priority: 0.4,
 		}));
 
 	return sortByPath(entries);
@@ -409,6 +416,7 @@ export async function getShowSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			(show.data as Record<string, unknown>).publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.6,
 	}));
 
 	return sortByPath(entries);
@@ -425,6 +433,7 @@ export async function getSeriesSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			(seriesEntry.data as Record<string, unknown>).publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.5,
 	}));
 
 	return sortByPath(entries);
@@ -441,6 +450,7 @@ export async function getNewsSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			item.data.publishedAt,
 		),
 		changefreq: "weekly" as const,
+		priority: 0.7,
 	}));
 
 	return sortByPath(entries);
@@ -468,6 +478,7 @@ export async function getFreshNewsSitemapEntries(
 		path: `/news/${item.id}`,
 		lastmod: item.data.publishedAt,
 		changefreq: "hourly" as const,
+		priority: 0.7,
 	}));
 }
 
@@ -482,6 +493,7 @@ export async function getAdrSitemapEntries(): Promise<SitemapUrlEntry[]> {
 			(adr.data as Record<string, unknown>).updatedAt,
 		),
 		changefreq: "monthly" as const,
+		priority: 0.4,
 	}));
 
 	return sortByPath(entries);


### PR DESCRIPTION
## Summary

Two small technical-SEO additions on top of the recent validation pass (PR #1096):

- **`SpeakableSpecification`** on `/read/<slug>` (TechArticle) and `/news/<slug>` (NewsArticle) JSON-LD. CSS selector points to `.article-header h1`. Hints to Google Assistant which DOM chunks are speech-friendly, with no behavioural impact for sighted users.
- **`<priority>` field on dynamic sitemap entries.** Static-page priorities shipped in round 4; this closes the gap on `getArticleSitemapEntries`, `getVideoSitemapEntries`, `getNewsSitemapEntries`, `getCourseSitemapEntries`, `getLearningPathSitemapEntries`, `getShowSitemapEntries`, `getSeriesSitemapEntries`, `getTechnologySitemapEntries`, `getPeopleSitemapEntries`, `getAdrSitemapEntries`, and the Google News fresh-items mapper. Weights: high-value content 0.7, secondary listings 0.5–0.6, low-fan-out profile / decision-record pages 0.4. Most crawlers de-emphasise priority across domains but still use it as a within-site hint for crawl ordering.

## Test plan

- [ ] CI green (`bun run test`, `astro check`, `bun run knip`)
- [ ] After merge, view-source an article page and confirm the JSON-LD payload includes `speakable.cssSelector`
- [ ] Spot-check `/sitemaps/articles.xml` — each `<url>` should carry a `<priority>0.7</priority>` line

## Human action required

None. Cosmetic structured-data and sitemap weight additions; no UI change, no schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)