### PR TITLE
chore: microcopy sweep on 404, newsletter, and /people

### DIFF
--- a/projects/rawkode.academy/website/src/components/newsletter/NewsletterWidget.vue
+++ b/projects/rawkode.academy/website/src/components/newsletter/NewsletterWidget.vue
@@ -129,7 +129,7 @@ const subscribeAsLearner = async () => {
 		error.value =
 			err instanceof Error
 				? err.message
-				: "Failed to subscribe. Please try again.";
+				: "Couldn't subscribe right now. Try again in a moment.";
 	} finally {
 		isLoading.value = false;
 	}
@@ -163,7 +163,7 @@ const subscribeWithEmail = async () => {
 		error.value =
 			err instanceof Error
 				? err.message
-				: "Failed to subscribe. Please try again.";
+				: "Couldn't subscribe right now. Try again in a moment.";
 	} finally {
 		isLoading.value = false;
 	}
@@ -346,7 +346,7 @@ const trackSignInClick = () => {
 								@click="trackSignInClick"
 								class="inline-flex items-center justify-center w-full rounded-xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white bg-gradient-primary shadow-lg hover:shadow-xl border border-white/40 dark:border-white/10 hover:-translate-y-0.5 active:translate-y-0 transition-smooth"
 							>
-								Continue with Sign in
+								Sign in instead
 							</a>
 						</form>
 					</Transition>

--- a/projects/rawkode.academy/website/src/pages/404.astro
+++ b/projects/rawkode.academy/website/src/pages/404.astro
@@ -40,7 +40,7 @@ const supportLinks = [
 ];
 ---
 
-<MinimalLayout title="404 – Rawkode Academy" description="We couldn't find that page, but here are a few quick ways to get back on course.">
+<MinimalLayout title="Page not found | Rawkode Academy" description="That page doesn't exist (or doesn't exist any more). Search the catalogue, jump into a course, or browse the technology guides.">
 	<main class="relative isolate min-h-screen overflow-hidden bg-slate-950 text-slate-100">
 		<div class="pointer-events-none absolute inset-0">
 			<div class="absolute -top-32 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-primary/30 blur-3xl"></div>

--- a/projects/rawkode.academy/website/src/pages/people/index.astro
+++ b/projects/rawkode.academy/website/src/pages/people/index.astro
@@ -68,7 +68,7 @@ const peopleJsonLd = sortedPeople.map((person) => ({
 							<input
 								id="people-search"
 								type="search"
-								placeholder="e.g. Rawkode, Guests..."
+								placeholder="Type a name…"
 								class="w-full rounded-xl py-3 pl-12 pr-4 text-base text-primary-content placeholder-gray-400 dark:placeholder-gray-500 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/40 dark:border-gray-600/50 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/40 transition"
 								autocomplete="off"
 							/>


### PR DESCRIPTION
## Summary

Small copy fixes flagged during the SEO/copy/content hygiene audit:

- **404 `<title>`** was `404 - Rawkode Academy` with an en-dash; normalised to `Page not found | Rawkode Academy` to match the brand-suffix pattern in `head.astro`. Description rewritten so it actually describes what the page does (search the catalogue, jump into a course, browse technology guides).
- **NewsletterWidget error fallback**: generic `Failed to subscribe. Please try again.` (in both subscribe paths) → `Couldn't subscribe right now. Try again in a moment.` — reads less like a stack-trace label.
- **NewsletterWidget sign-in button**: `Continue with Sign in` parsed awkwardly; switched to `Sign in instead`.
- **`/people` search placeholder**: `e.g. Rawkode, Guests...` — "Guests" was a category label not a searchable name and led people to type it literally. Replaced with `Type a name...`.

## Test plan

- [ ] CI green (`astro check`, `bun run knip`, vitest)
- [ ] After merge, /people search shows the new placeholder
- [ ] After merge, /404 view-source shows the new title + description
- [ ] After merge, trigger the newsletter widget error path (or read the bundle) to confirm the new copy

## Human action required

None. Copy-only changes, no schema or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)