### PR TITLE
seo: OG article:section + article:tag on /read and /news

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/opengraph.astro
+++ b/projects/rawkode.academy/website/src/components/html/opengraph.astro
@@ -13,6 +13,8 @@ const {
 	updatedAt,
 	authors,
 	pageType = "WebPage",
+	articleSection,
+	articleTags,
 } = Astro.props;
 
 const openGraphUrl = new URL(Astro.url.pathname, Astro.site);
@@ -124,6 +126,12 @@ const firstAuthorMastodon = shouldShowArticleMeta
 	shouldShowArticleMeta && (
 		<>
 			<meta property="article:publisher" content="https://rawkode.academy" />
+			{articleSection && (
+				<meta property="article:section" content={articleSection} />
+			)}
+			{articleTags?.map((tag: string) => (
+				<meta property="article:tag" content={tag} />
+			))}
 			{authors && authors.map((author: CollectionEntry<"people">) => (
 				author.data.github && <meta property="article:author" content={author.data.github} />
 			))}

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -80,6 +80,8 @@ const readingTime = calculateReadingTime(article.body || "");
 	isArticle={true}
 	publishedAt={article.data.publishedAt}
 	authors={authors}
+	articleSection="News"
+	articleTags={tags.map((tag) => tag.label)}
 >
 	<Fragment slot="extra-head">
 		<NewsJsonLd article={article} authors={authors} />

--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -129,6 +129,8 @@ const publishDate = new Intl.DateTimeFormat("en-US", {
 	publishedAt={article.data.publishedAt}
 	updatedAt={article.data.updatedAt}
 	authors={authors}
+	articleSection={badgeConfig.label}
+	articleTags={tags.map((tag) => tag.label)}
 	{...(howToJsonLd ? { jsonLd: howToJsonLd } : {})}
 >
 	{imageUrl ? (

--- a/projects/rawkode.academy/website/src/types/opengraph.ts
+++ b/projects/rawkode.academy/website/src/types/opengraph.ts
@@ -34,4 +34,11 @@ export interface OpenGraphProps {
 	 * on tutorial articles.
 	 */
 	jsonLd?: Record<string, unknown> | undefined;
+	/**
+	 * Open Graph article-namespace section + tags. Only emitted when
+	 * `isArticle` is true. LinkedIn and Facebook use these to categorise
+	 * shares so they group with related posts in feed recommendations.
+	 */
+	articleSection?: string | undefined;
+	articleTags?: ReadonlyArray<string> | undefined;
 }


### PR DESCRIPTION
## Summary

Emit `<meta property=\"article:section\">` and one `<meta property=\"article:tag\">` per technology on article-flagged pages (i.e. when `isArticle={true}` on `<Page>`).

- LinkedIn and Facebook use these to categorise shares so they group with related posts in feed recommendations.
- `/read/<slug>`: section = the article-type label (Tutorial / Article / Guide / News), tags = the formatted technology names.
- `/news/<slug>`: section = `News`, tags = the formatted technology names.

All emissions are gated by `shouldShowArticleMeta` (the same guard that controls the existing `article:author` / `article:published_time` / `article:modified_time` meta), so non-article pages stay untouched.

## Test plan

- [ ] CI green (`astro check`, vitest, knip)
- [ ] After merge, view-source on `/read/<some-slug>` shows one `article:section` and one `article:tag` per declared technology
- [ ] After merge, view-source on `/news/<some-slug>` shows `article:section=News` plus tags
- [ ] View-source on a non-article page (e.g. `/about`, `/people`) shows neither

## Human action required

None. Additive Open Graph metadata; no UI change, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)