### PR TITLE
fix: drop broken Cloud Native Compass artworkUrl

### DIFF
--- a/content/shows/cloud-native-compass/index.md
+++ b/content/shows/cloud-native-compass/index.md
@@ -16,7 +16,6 @@ podcast:
   subcategory: Software How-To
   explicit: false
   copyright: Rawkode Academy
-  artworkUrl: https://content.rawkode.academy/shows/cloud-native-compass/artwork.jpg
 subscribeLinks:
   - platform: Apple Podcasts
     url: https://podcasts.apple.com/us/podcast/cloud-native-compass/id1685669024


### PR DESCRIPTION
## Summary

Audit-driven fix surfaced while checking per-show podcast feed Apple Podcasts compliance.

### Finding

The published Cloud Native Compass per-show RSS feed (`/api/feeds/shows/cloud-native-compass.xml`) has been emitting an `<image>` and `<itunes:image>` URL that **404s in production**:

```
$ curl -sSI 'https://rawkode.academy/cdn-cgi/image/width=1400,height=1400,fit=cover,format=jpeg,quality=90/https://content.rawkode.academy/shows/cloud-native-compass/artwork.jpg'
HTTP/2 404
cf-resized: err=9404
```

Source artwork doesn't exist:

```
$ curl -sSI 'https://content.rawkode.academy/shows/cloud-native-compass/artwork.jpg'
HTTP/2 404
```

Apple Podcasts validators reject feeds whose channel artwork 404s; aggregators show a broken-image placeholder.

The same broken URL is consumed by `/shows/cloud-native-compass`'s JSON-LD via `podcastImageUrl` in `src/pages/shows/[showId].astro:105`, so structured data was also pointing at the 404.

### Fix

Removed the configured `podcast.artworkUrl` from `content/shows/cloud-native-compass/index.md`. The existing fallback paths take over:

- **Feed**: uses the first episode's thumbnail (Cloudflare-resized to a 1400x1400 JPEG via `/cdn-cgi/image/`). Confirmed serving HTTP 200 from a representative episode.
- **Show page**: falls back to the bundled `cover.png` via Astro's image pipeline.

Both satisfy Apple's hard minimum until a real square 1400x1400+ piece of show artwork is uploaded.

### Audit notes (no code change needed)

- The current builder already crops to **1400x1400 JPEG quality=90 via Cloudflare Image Resizing** (`getSquaredArtworkUrl` in `src/pages/api/feeds/shows/[showId].xml.ts`). That's Apple's hard minimum. Could upgrade to 3000x3000 in a follow-up *if* show artwork is authored at that resolution.
- Per-episode `itunes:image` confirmed serving HTTP 200 through the resize pipeline.
- The empty-feed edge case (show with no published episodes + no `artworkUrl`) emits no `<image>` element; rare but worth a future defensive note.

## Human action required

- [ ] Upload a real square Cloud Native Compass podcast artwork (≥ 1400x1400, ideally 3000x3000) to a stable URL and add `podcast.artworkUrl` back. Without this, the feed art is a single-episode thumbnail rather than proper show art.

## Test plan

- [ ] CI green (`astro check`, vitest, knip)
- [ ] After merge, fetch `https://rawkode.academy/api/feeds/shows/cloud-native-compass.xml` and confirm `<image>` and `<itunes:image>` URLs HTTP 200
- [ ] Spot-check `/shows/cloud-native-compass` page JSON-LD `image` field renders the local cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)