### PR TITLE
seo: drop trailing slash on prerendered assets

### DIFF
--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -796,6 +796,29 @@ describe("Crawlability and Sitemaps", () => {
 		);
 	});
 
+	it("configures the Workers assets binding to strip trailing slashes so canonical URLs serve directly", async () => {
+		// Astro's trailingSlash config is "never" and the canonical URL emitted
+		// in head.astro never carries a trailing slash. For prerendered routes
+		// (read, news, about, courses, …) Cloudflare's static-asset server
+		// would, by default, redirect /foo → /foo/ because Astro builds
+		// directory-format index.html files. Setting html_handling to
+		// "drop-trailing-slash" inverts that so /foo/ → /foo (301), matching
+		// the canonical URL and removing the unnecessary redirect hop.
+		const { readFile } = await import("node:fs/promises");
+		const { fileURLToPath } = await import("node:url");
+		const path = fileURLToPath(new URL("../../wrangler.jsonc", import.meta.url));
+		const raw = await readFile(path, "utf-8");
+		// wrangler.jsonc allows comments; strip them before JSON.parse.
+		const stripped = raw
+			.replace(/\/\/[^\n]*/g, "")
+			.replace(/\/\*[\s\S]*?\*\//g, "");
+		const config = JSON.parse(stripped) as {
+			assets?: { html_handling?: string };
+		};
+
+		expect(config.assets?.html_handling).toBe("drop-trailing-slash");
+	});
+
 	it("renders an OpenSearch description that points browsers at /search?q={searchTerms}", async () => {
 		const { renderOpenSearchDescription } = await import(
 			"../pages/opensearch.xml.ts"

--- a/projects/rawkode.academy/website/wrangler.jsonc
+++ b/projects/rawkode.academy/website/wrangler.jsonc
@@ -6,7 +6,8 @@
 	"compatibility_flags": ["nodejs_compat"],
 	"assets": {
 		"binding": "ASSETS",
-		"directory": "./dist"
+		"directory": "./dist",
+		"html_handling": "drop-trailing-slash"
 	},
 	"workers_dev": true,
 	"preview_urls": true,


### PR DESCRIPTION
## Summary

Audit-driven fix. Probed production trailing-slash behaviour across page types and found prerendered routes were taking a needless 307 hop on every visit because the canonical URL didn't match what Cloudflare's static-asset server served.

### Findings

Astro is configured with `trailingSlash: "never"` and `head.astro` emits canonical URLs without a trailing slash. SSR routes already honour that.

Prerendered routes did not:

| Path | Before |
|------|--------|
| `/read/<slug>`               | 307 → `/read/<slug>/` |
| `/news/<slug>`               | 307 → `/news/<slug>/` |
| `/courses`                   | 307 → `/courses/` |
| `/about`, `/people`, `/learning-paths`, `/technology`, `/technology/<id>` | 307 → `<path>/` |
| `/shows/<id>` (SSR)          | 200 (slash → 301 → no-slash) — already correct |
| `/watch/<slug>` (SSR)        | 200 (slash → 301 → no-slash) — already correct |

So every prerendered page was emitting a canonical that pointed at a URL that 307'd before serving. Google handles this fine, but it adds an unnecessary hop on first hit and creates a mismatch with what `head.astro` advertises.

### Fix

Set `html_handling: "drop-trailing-slash"` on the Workers static-assets binding in `wrangler.jsonc`. This makes `/foo/` → 301 → `/foo` and serves `/foo` directly from the existing `dist/client/foo/index.html`. Now every prerendered route matches its canonical URL on first hit.

Added an SEO test that reads `wrangler.jsonc` and asserts the field stays set so a future config refactor can't silently regress the canonical match.

## Test plan

- [ ] CI green
- [ ] After deploy, `curl -sI https://rawkode.academy/read/<slug>` returns 200 directly (no 307)
- [ ] After deploy, `curl -sI https://rawkode.academy/read/<slug>/` returns 301 → no-slash

## Human action required

None. Edge-config change; no UI or schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)