### PR TITLE
[codex] Import recent academy videos

### DIFF
--- a/content/technologies/hadron/index.mdx
+++ b/content/technologies/hadron/index.mdx
@@ -1,0 +1,17 @@
+---
+name: Hadron
+website: 'https://hadron-linux.io/'
+documentation: 'https://kairos.io/getting-started/what-is-kairos/'
+source: 'https://github.com/kairos-io/hadron'
+license: Apache-2.0
+status: stable
+category: Runtime
+subcategory: Container Runtime
+relatedTechnologies:
+  - kairos
+terms:
+  - Hadron Linux
+---
+Hadron is a minimal Linux distribution built from scratch for cloud and edge systems. It uses upstream components, including musl libc, systemd, and vanilla Linux kernels, while avoiding a traditional package manager in the base operating system.
+
+In the Kairos ecosystem, Hadron provides a lean base for immutable, image-based systems. Kairos handles the lifecycle model around installation, A/B upgrades, rollback, and Kubernetes distribution integration, while Hadron supplies the small, upstream-aligned Linux foundation underneath.

--- a/content/technologies/intar/index.mdx
+++ b/content/technologies/intar/index.mdx
@@ -1,0 +1,14 @@
+---
+name: Intar
+website: 'https://intar.dev'
+source: 'https://github.com/intar-dev/intar-cli'
+license: MIT
+status: alpha
+category: App Definition and Development
+subcategory: Developer Tools
+terms:
+  - intar-cli
+---
+Intar is a QEMU-based DevOps lab environment. It runs HCL-defined scenarios in local virtual machines, evaluates probes, and presents progress through a terminal UI.
+
+The project is built around reproducible infrastructure training and debugging exercises, where a scenario describes the VM image, probes, and target state that the user needs to repair.

--- a/content/technologies/jujutsu/index.mdx
+++ b/content/technologies/jujutsu/index.mdx
@@ -1,0 +1,18 @@
+---
+name: Jujutsu
+website: 'https://jj-vcs.dev/'
+documentation: 'https://jj-vcs.github.io/jj/latest/'
+source: 'https://github.com/jj-vcs/jj'
+license: Apache-2.0
+status: stable
+category: App Definition and Development
+subcategory: Developer Tools
+aliases:
+  - jj
+terms:
+  - jj
+  - Jujutsu
+---
+Jujutsu, commonly called `jj`, is a Git-compatible version control system with a different workflow model from Git. It treats the working copy as a change, keeps an operation log for undo and recovery, and can work with existing Git repositories and remotes.
+
+The project focuses on making history editing, rebasing, conflict handling, and day-to-day changes easier to reason about without cutting users off from Git hosting and collaboration workflows.

--- a/content/technologies/sympozium/index.mdx
+++ b/content/technologies/sympozium/index.mdx
@@ -1,0 +1,14 @@
+---
+name: Sympozium
+website: 'https://sympozium.ai/'
+documentation: 'https://deploy.sympozium.ai/docs/'
+source: 'https://github.com/sympozium-ai/sympozium'
+status: beta
+category: Orchestration & Management
+subcategory: Scheduling & Orchestration
+terms:
+  - Sympozium AI
+---
+Sympozium is a Kubernetes-native coordination layer for multi-agent AI systems. It models agents as pods and uses Kubernetes primitives such as CRDs and jobs to coordinate structured handoffs, shared context, and agent workflow execution.
+
+The project is aimed at teams building agent systems that need shared situational awareness rather than isolated prompt execution.

--- a/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
+++ b/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
@@ -1,0 +1,19 @@
+---
+id: p0ksv7fv60hxvhe7uo46cf29
+slug: chevron7-2026-01-23
+title: Friday, January 23rd, 2026 - Chevron7
+subtitle: Rawkode Academy Office Hours
+description: |
+  Rawkode Academy Office Hours
+
+  Intar: https://github.com/intar-dev/intar-cli
+publishedAt: 2026-01-24T00:46:23.000Z
+type: live
+category: editorial
+technologies:
+  - intar
+show: rawkode-live
+duration: 2666
+guests:
+  - icepuma
+---

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-jujutsu-jj.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-jujutsu-jj.md
@@ -1,0 +1,23 @@
+---
+id: m7az25q3ide58725jigj9a5m
+slug: hands-on-introduction-to-jujutsu-jj
+title: Hands-on Introduction to jujutsu (jj)
+subtitle: A hands-on look at Jujutsu with Steve Klabnik.
+description: |
+  Git has dominated the version control landscape for over a decade, but does that mean we've reached the end of history for VCS? Join us for a deep dive into Jujutsu (jj), a Git-compatible version control system that might change the way you think about source control.
+
+  In this live stream, Steve Klabnik guides us through the philosophy behind Jujutsu, why it exists, and how it solves some of Git's persistent UX hurdles while maintaining compatibility with existing Git repositories.
+
+  Resources:
+  - Jujutsu (jj) on GitHub: https://github.com/jj-vcs/jj
+  - Jujutsu documentation: https://docs.jj-vcs.dev/latest/
+publishedAt: 2026-01-22T06:37:57.000Z
+type: live
+category: tutorial
+technologies:
+  - jujutsu
+show: rawkode-live
+duration: 3715
+guests:
+  - steve-klabnik
+---

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
@@ -1,0 +1,23 @@
+---
+id: wurwxcxlodtw5pubcuip4sfw
+slug: hands-on-introduction-to-sympozium
+title: Hands-on Introduction to sympozium
+subtitle: "Diving into Sympozium AI: The Future of Collaborative Intelligence"
+description: |
+  Diving into Sympozium AI: The Future of Collaborative Intelligence
+
+  In this live stream, we explore Sympozium, an ambitious open-source project designed to bridge the gap between human collaboration and AI-driven insights.
+
+  Whether you're a developer, a data scientist, or someone tracking the next wave of autonomous agents, this session breaks down how Sympozium works and why it matters.
+
+  Repository: https://github.com/sympozium-ai/sympozium
+publishedAt: 2026-04-17T05:38:22.000Z
+type: live
+category: tutorial
+technologies:
+  - sympozium
+show: rawkode-live
+duration: 5510
+guests:
+  - alex-jones
+---

--- a/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
+++ b/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
@@ -1,0 +1,27 @@
+---
+id: hxjai2mhvplhc4rl3c7dq2eh
+slug: hadron-minimal-secure-linux-for-cloud-edge
+title: "Hadron: Minimal & Secure Linux for Cloud & Edge"
+subtitle: Is your Linux distribution too bloated for the cloud and edge?
+description: |
+  Is your Linux distribution too bloated for the cloud and edge?
+
+  For years, the Cloud Native world has compromised by forcing general-purpose, legacy-heavy desktop distributions into minimal, immutable molds. The Kairos team decided it was time to build something from scratch with a single purpose: to be the cleanest possible foundation for immutable infrastructure.
+
+  Meet Hadron. It is a minimal, secure Linux distribution designed specifically for the cloud and the edge.
+
+  In this video, we explore why Hadron was created and its unique technical approach, pairing the minimalism of musl libc with the compatibility of systemd. We also look at how Hadron uses Containerfiles to create auditable software bills of materials for better security posture.
+
+  Finally, we get a Kubernetes cluster running with k3s using Kairos on top of Hadron.
+
+  Resources:
+  - https://hadron-linux.io
+publishedAt: 2026-02-05T19:24:45.000Z
+type: recorded
+category: tutorial
+technologies:
+  - hadron
+  - kairos
+duration: 592
+guests: []
+---


### PR DESCRIPTION
## Summary

Adds four recent Rawkode Academy videos that were missing from the website content:

- Hadron: Minimal & Secure Linux for Cloud & Edge
- Hands-on Introduction to jujutsu (jj)
- Friday, January 23rd, 2026 - Chevron7
- Hands-on Introduction to sympozium

Also adds technology taxonomy entries for Hadron, Intar, Jujutsu, and Sympozium so the new video metadata resolves through Astro content references.

## Metadata Notes

- Hadron is tagged with Hadron and Kairos.
- Jujutsu uses Steve Klabnik as guest.
- Chevron7 uses icepuma as guest and Intar as the technology.
- Sympozium uses Alex Jones as guest.
- Intar website is set to https://intar.dev with GitHub as the source.

## Validation

- `bun run build` from `projects/rawkode.academy/website`
- `git diff --check`
- Verified uploaded thumbnails exist for all four video IDs.
- Verified streams are available for Hadron, Jujutsu, and Chevron7; Sympozium is still within the expected longer transcode window.