### PR TITLE
fix(rawkode.academy/website): capture $pageview so PostHog web analytics works

### DIFF
--- a/projects/rawkode.academy/website/src/components/posthog/index.astro
+++ b/projects/rawkode.academy/website/src/components/posthog/index.astro
@@ -11,8 +11,6 @@ const { userId } = Astro.props;
 	const PH_HOST = "https://eu.i.posthog.com";
 	let posthogInitialized = false;
 	let enableInFlight = false;
-	let pageExitHandlerAttached = false;
-	let pageStartTime = Date.now();
 
 	const getUtmParams = () => {
 		try {
@@ -114,7 +112,6 @@ const { userId } = Astro.props;
 			window.posthog.init(PH_KEY, {
 				api_host: PH_HOST,
 				autocapture: true,
-				capture_pageview: false,
 				respect_dnt: true,
 				session_recording: {
 					maskAllInputs: true,
@@ -129,27 +126,6 @@ const { userId } = Astro.props;
 
 			if (userId) {
 				window.posthog.identify(userId);
-			}
-
-			window.posthog.capture("page_view", {
-				path: location.pathname,
-				referrer: document.referrer || "",
-				title: document.title,
-			});
-
-			if (!pageExitHandlerAttached) {
-				pageStartTime = Date.now();
-				window.addEventListener("beforeunload", () => {
-					const seconds = Math.floor((Date.now() - pageStartTime) / 1000);
-					try {
-						window.posthog.capture("page_exit", {
-							path: location.pathname,
-							time_on_page: seconds,
-							referrer: document.referrer || "",
-						});
-					} catch {}
-				});
-				pageExitHandlerAttached = true;
 			}
 
 			posthogInitialized = true;


### PR DESCRIPTION
## Summary
- Removed `capture_pageview: false` and the manual `page_view` / `page_exit` captures.
- PostHog now fires `$pageview` on init and `$pageleave` on unload, which is what every web-analytics surface (Web Analytics, the weekly digest, source/path dashboards) actually reads.

## Why
Our PostHog project was sending a custom `page_view` event instead of `$pageview`. Result: the `web-analytics-weekly-digest` returned zeros, and the built-in Web Analytics view showed no data, even though traffic was healthy. The custom event carried no extra information that PostHog's defaults don't already populate (`$current_url`, `$pathname`, `$referrer`, `$host`, `$session_duration`).

## Test plan
- [ ] After deploy, hit a few pages and confirm `$pageview` events appear in PostHog (live events feed).
- [ ] Re-run the web analytics weekly digest (or open Web Analytics) and confirm non-zero visitors / pageviews / sessions.
- [ ] Spot check that `$current_url`, `$pathname`, `$referring_domain` properties are populated on the new events.

## Human action required
- **Deploy this to production** for the new events to start flowing.
- **Migrate any insights / dashboards / alerts built on `page_view` or `page_exit`** to `$pageview` / `$pageleave`. Historical data on the old event names is preserved but stops growing after this ships.
  - Specifically, the Grafana/Faro side at `projects/rawkode.academy/website/src/components/grafana/index.astro` still emits `page_view` / `page_exit` via Faro (unrelated to PostHog), so any InfluxDB/Grafana boards that read those names keep working untouched.
- **Backfill is not possible** for the PostHog gap, but going forward the Web Analytics product, the weekly digest, the SEO drop guardrail (if it keys off `$pageview`), and source attribution will all start working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)