### PR TITLE
feat(rawkode.academy/website): video resources schema + tab

### DIFF
--- a/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
+++ b/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
@@ -72,11 +72,61 @@
         role="tabpanel"
         aria-labelledby="video-tab-resources"
       >
-        <div class="prose prose-lg dark:prose-invert max-w-none">
-          <p class="text-muted">
-            Resources related to this video will be displayed here, including
-            links, downloads, and additional materials.
-          </p>
+        <div v-if="!resources || resources.length === 0" class="prose prose-lg dark:prose-invert max-w-none">
+          <p class="text-muted">No resources for this episode yet.</p>
+        </div>
+        <div v-else class="space-y-6">
+          <div v-for="group in groupedResources" :key="group.category">
+            <h3 class="text-sm font-semibold text-muted uppercase tracking-wider mb-3">
+              {{ categoryLabel(group.category) }}
+            </h3>
+            <div class="grid gap-3">
+              <a
+                v-for="(resource, idx) in group.items"
+                :key="resource.id || `${group.category}-${idx}`"
+                :href="resource.url || resource.filePath || '#'"
+                :target="resource.type === 'url' ? '_blank' : undefined"
+                :rel="resource.type === 'url' ? 'noopener noreferrer' : undefined"
+                class="flex items-start gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-smooth group"
+              >
+                <svg
+                  class="w-5 h-5 mt-0.5 text-muted group-hover:text-primary flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    :d="categoryIcon(group.category)"
+                  />
+                </svg>
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium text-primary-content group-hover:text-primary">
+                    {{ resource.title }}
+                  </div>
+                  <div v-if="resource.description" class="text-sm text-muted mt-0.5">
+                    {{ resource.description }}
+                  </div>
+                </div>
+                <svg
+                  v-if="resource.type === 'url'"
+                  class="w-4 h-4 mt-1 text-muted group-hover:text-primary flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -96,6 +146,27 @@ const trackEvent = (event, properties) => {
 	}
 };
 
+const CATEGORY_ORDER = ["documentation", "code", "slides", "demos", "other"];
+
+const CATEGORY_ICONS = {
+	documentation:
+		"M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z",
+	code: "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4",
+	slides: "M7 4v16M17 4v16M3 12h18M8 12h8",
+	demos:
+		"M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z",
+	other:
+		"M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1",
+};
+
+const CATEGORY_LABELS = {
+	documentation: "Documentation",
+	code: "Code",
+	slides: "Slides",
+	demos: "Demos",
+	other: "Additional Resources",
+};
+
 export default {
 	name: "VideoContentTabs",
 	components: {
@@ -106,6 +177,10 @@ export default {
 		videoId: {
 			type: String,
 			required: true,
+		},
+		resources: {
+			type: Array,
+			default: () => [],
 		},
 	},
 	data() {
@@ -118,6 +193,20 @@ export default {
 			],
 		};
 	},
+	computed: {
+		groupedResources() {
+			const groups = new Map();
+			for (const resource of this.resources || []) {
+				const category = resource.category || "other";
+				if (!groups.has(category)) groups.set(category, []);
+				groups.get(category).push(resource);
+			}
+			return CATEGORY_ORDER.filter((c) => groups.has(c)).map((category) => ({
+				category,
+				items: groups.get(category),
+			}));
+		},
+	},
 	methods: {
 		setActiveTab(tabId) {
 			const previousTab = this.activeTab;
@@ -128,6 +217,12 @@ export default {
 				previous_tab: previousTab,
 				video_id: this.videoId,
 			});
+		},
+		categoryIcon(category) {
+			return CATEGORY_ICONS[category] || CATEGORY_ICONS.other;
+		},
+		categoryLabel(category) {
+			return CATEGORY_LABELS[category] || CATEGORY_LABELS.other;
 		},
 	},
 };

--- a/projects/rawkode.academy/website/src/content.config.ts
+++ b/projects/rawkode.academy/website/src/content.config.ts
@@ -7,6 +7,34 @@ import { resolveContentDirSync } from "@rawkodeacademy/content/utils";
 // Local, file-based content collections for videos, shows, and technologies.
 // These are populated by scripts/sync-graphql-content.ts during build or on demand.
 
+// Shared resource schema. Used by videos, articles, courses, and course modules.
+const resourceSchema = z.object({
+	id: z.string().optional(),
+	title: z.string(),
+	description: z.string().optional(),
+	type: z.enum(["url", "file", "embed"]),
+	url: z.union([z.url(), z.string().startsWith("/")]).optional(),
+	filePath: z.string().optional(),
+	embedConfig: z
+		.object({
+			container: z.enum(["webcontainer", "iframe"]),
+			src: z.string(),
+			height: z.string().default("600px"),
+			width: z.string().default("100%"),
+			files: z.record(z.string(), z.string()).optional(), // For WebContainer file system
+			import: z
+				.object({
+					localDir: z.string(), // Path relative to the content file
+				})
+				.optional(),
+			startCommand: z.string().optional(), // Command to run in WebContainer
+		})
+		.optional(),
+	category: z
+		.enum(["slides", "code", "documentation", "demos", "other"])
+		.default("other"),
+});
+
 const videos = defineCollection({
 	loader: glob({
 		pattern: ["**/*.{md,mdx}"],
@@ -47,6 +75,7 @@ const videos = defineCollection({
 			)
 			.default([]),
 		guests: z.array(reference("people")).default([]),
+		resources: z.array(resourceSchema).optional(),
 	}),
 });
 
@@ -103,34 +132,6 @@ const shows = defineCollection({
 });
 
 // HINT: image() is described here -> https://docs.astro.build/en/guides/images/#images-in-content-collections
-
-// Shared resource schema for courses and course modules
-const resourceSchema = z.object({
-	id: z.string().optional(),
-	title: z.string(),
-	description: z.string().optional(),
-	type: z.enum(["url", "file", "embed"]),
-	url: z.union([z.url(), z.string().startsWith("/")]).optional(),
-	filePath: z.string().optional(),
-	embedConfig: z
-		.object({
-			container: z.enum(["webcontainer", "iframe"]),
-			src: z.string(),
-			height: z.string().default("600px"),
-			width: z.string().default("100%"),
-			files: z.record(z.string(), z.string()).optional(), // For WebContainer file system
-			import: z
-				.object({
-					localDir: z.string(), // Path relative to the content file
-				})
-				.optional(),
-			startCommand: z.string().optional(), // Command to run in WebContainer
-		})
-		.optional(),
-	category: z
-		.enum(["slides", "code", "documentation", "demos", "other"])
-		.default("other"),
-});
 
 const people = defineCollection({
 	loader: glob({

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -360,6 +360,7 @@ if (isAuthenticated && user?.id) {
 				<VideoContentTabs
 					client:idle
 					videoId={video.data.id}
+					resources={video.data.resources ?? []}
 				/>
 
 				{/* More Videos by Technology */}


### PR DESCRIPTION
## Summary
- Add `resources: z.array(resourceSchema).optional()` to the videos content collection.
- The shared `resourceSchema` (already used by articles, courses, course modules) is moved above the videos definition so videos can reference it; no shape change.
- Replace the placeholder paragraph in the watch-page Resources tab with a real list view that groups entries by category, renders an icon per category, and shows a graceful empty state when a video has no resources yet.

## Why
Phase 2 of the video description / resources project (`docs/superpowers/specs/2026-05-17-video-descriptions-and-resources-design.md`). Adds the schema and UI plumbing so phase 3's transcript-driven extraction has somewhere to land its output. Until phase 3 ships, every video shows the empty state.

## Test plan
- [ ] `astro check` is clean (0 errors).
- [ ] Build the site locally and visit a `/watch/<slug>` page; the Resources tab renders "No resources for this episode yet."
- [ ] Add a `resources:` block to one video's frontmatter locally; confirm the tab renders the entry with the correct category icon.

## Human action required
- **Deploy after phase 3 ships** — alone, this PR is benign (empty state everywhere). Coupled with phase 3, every video gains real entries.
- No content edits needed for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)