### PR TITLE
feat(content): tighten extraction prompt + 47 partial JSONs

### DIFF
--- a/content/scripts/extract-video-resources.ts
+++ b/content/scripts/extract-video-resources.ts
@@ -230,18 +230,34 @@ function buildPrompt(params: {
 		transcript,
 	} = params;
 	return [
-		"You are extracting concrete, linkable resources mentioned in a podcast/video transcript.",
+		"You extract concrete linkable resources from a video transcript. Be strict.",
 		"",
-		"RULES:",
-		"- Return ONLY a single JSON object, no prose before or after.",
-		"- The JSON shape is: {\"resources\": [{\"title\": string, \"url\": string|null, \"category\": \"documentation\"|\"code\"|\"slides\"|\"demos\"|\"other\", \"evidence_quote\": string, \"confidence\": \"high\"|\"medium\"|\"low\"}]}",
+		"OUTPUT: a single JSON object, no prose before or after.",
+		"SHAPE: {\"resources\": [{\"title\": string, \"url\": string|null, \"category\": \"documentation\"|\"code\"|\"slides\"|\"demos\"|\"other\", \"evidence_quote\": string, \"confidence\": \"high\"|\"medium\"|\"low\"}]}",
+		"",
+		"WHAT COUNTS AS A RESOURCE",
+		"A resource is one of:",
+		"- A specific repository or project the speaker names (e.g. 'kubernetes/kubernetes', 'rawkode-academy/courses').",
+		"- A specific documentation page, guide, or API reference (e.g. 'the Kubernetes Pod Security Standards docs page').",
+		"- A specific paper, RFC, book, blog post, talk, or video.",
+		"- A specific demo or example artifact (e.g. 'the OpenTelemetry demo application').",
+		"- A specific tool or product that is itself the LINK TARGET of the discussion — i.e. the speaker explicitly recommends going to look at it.",
+		"",
+		"WHAT DOES NOT COUNT (DROP THESE)",
+		"- Passing technology mentions. 'I'm using Postgres' / 'we run on AWS Lambda' / 'we deploy with Helm' — these are not resources, they are context. Drop them.",
+		"- The headlining technology of the video (already in KNOWN_TECHNOLOGIES).",
+		"- People mentioned only by name without a specific artifact (talk, post, repo) attached.",
+		"- Anything whose evidence quote is just 'we are using X' or 'X supports Y' — that is a mention, not a resource.",
+		"- Anything you cannot confidently name with a specific artifact identifier (a repo path, doc page title, post title, paper title).",
+		"",
+		"GUARDRAILS",
 		"- Each entry MUST include an evidence_quote taken verbatim from the transcript.",
-		"- A resource is concrete only if it is a specific page, doc, repo, paper, RFC, book, talk, post, tool, or product. Generic topics do not count.",
-		"- Skip anything covered by KNOWN_TECHNOLOGIES (those are already linked elsewhere). A specific docs page deep inside a known technology IS still a resource (e.g. a particular API reference page).",
-		"- Skip anything covered by KNOWN_GUESTS and KNOWN_HOSTS (their profiles are already linked elsewhere).",
-		"- Only emit `url` when the host and path are named clearly enough to identify (e.g. github.com/foo/bar, kubernetes.io/docs/...). Otherwise return url=null.",
-		"- Use confidence=low for ambiguous mentions; those will be dropped.",
-		"- Cap output at 10 resources. Choose the most useful, not the most numerous.",
+		"- Skip anything covered by KNOWN_TECHNOLOGIES or KNOWN_GUESTS (already linked elsewhere). A specific deep page inside a known technology IS still a resource (e.g. a particular API reference page).",
+		"- Only emit `url` when the host AND path are named with enough specificity to identify exactly (e.g. https://github.com/foo/bar, https://kubernetes.io/docs/concepts/...). If you would have to guess, return url=null.",
+		"- Every emitted url MUST start with `https://`. No bare hosts, no `http://`.",
+		"- Single-word generic titles ('Postgres', 'Helm', 'Jira') with url=null are forbidden — these are mentions, not resources. DROP them.",
+		"- Use confidence=low when in doubt; low entries are dropped automatically. Prefer omitting an entry over including a weak one.",
+		"- Hard cap: 5 resources per video. Quality over quantity. If only 0–2 real resources exist, return only those (or an empty array).",
 		"",
 		`TITLE: ${title}`,
 		`KNOWN_TECHNOLOGIES: ${knownTechnologyNames.join(", ") || "(none)"}`,
@@ -310,6 +326,18 @@ function isValidResource(value: unknown): value is Resource {
 	return true;
 }
 
+function normalizeUrl(url: string | undefined | null): string | null {
+	if (!url) return null;
+	const trimmed = url.trim();
+	if (!trimmed) return null;
+	if (/^https:\/\//i.test(trimmed)) return trimmed;
+	if (/^http:\/\//i.test(trimmed)) return `https://${trimmed.slice(7)}`;
+	if (trimmed.startsWith("/")) return trimmed;
+	// Bare host or host+path: prepend https://. Skip if it doesn't look like a host.
+	if (/^[a-z0-9.-]+\.[a-z]{2,}/i.test(trimmed)) return `https://${trimmed}`;
+	return null;
+}
+
 function filterAndDedupe(
 	candidates: Resource[],
 	knownHosts: Set<string>,
@@ -317,8 +345,14 @@ function filterAndDedupe(
 	const out: Resource[] = [];
 	const seenTitles = new Set<string>();
 	const seenUrls = new Set<string>();
-	for (const c of candidates) {
-		if (c.confidence === "low") continue;
+	for (const raw of candidates) {
+		if (raw.confidence === "low") continue;
+		const url = normalizeUrl(raw.url ?? null);
+		const c: Resource = { ...raw, url: url ?? undefined };
+		// Safety net: a single-word title with no URL is almost always a passing
+		// technology mention ("Postgres", "Helm"), not a real resource. Drop these.
+		const wordCount = c.title.trim().split(/\s+/).length;
+		if (wordCount <= 1 && !c.url) continue;
 		if (c.url) {
 			const host = urlHost(c.url);
 			if (host && knownHosts.has(host)) continue;

--- a/content/scripts/extract-video-resources.ts
+++ b/content/scripts/extract-video-resources.ts
@@ -3,10 +3,11 @@
 /**
  * Transcript-driven resource extraction for videos.
  *
- * For each video, fetch the public VTT, ask Gemini to extract concrete
- * linkable resources (docs, code, slides, demos, papers/books/posts), dedupe
- * against the URLs already attached to the video's technologies and guests,
- * and emit a JSON file per video for human review.
+ * For each video, fetch the public VTT, ask the Codex CLI (`codex exec`) to
+ * extract concrete linkable resources (docs, code, slides, demos,
+ * papers/books/posts), dedupe against the URLs already attached to the
+ * video's technologies and guests, and emit a JSON file per video for human
+ * review.
  *
  * Apply mode merges accepted JSON files into each video's frontmatter
  * `resources:` array, additive and idempotent.
@@ -20,7 +21,7 @@
  *   --max-parallel <n> Parallelism for extraction (default 5).
  *   --limit <n>        Only process the first N videos (debug).
  *   --only <slug>      Only process the video with this slug.
- *   --model <name>     Gemini model to pass to `gemini -m <name>`. Optional.
+ *   --model <name>     Model to pass to `codex exec -m <name>`. Optional.
  */
 
 import { readdir, readFile, writeFile, mkdir, access } from "node:fs/promises";
@@ -289,14 +290,14 @@ function extractJson(text: string): unknown | null {
 	}
 }
 
-function callGemini(prompt: string, model: string | null): Promise<string> {
+function callLlm(prompt: string, model: string | null): Promise<string> {
+	// Uses `codex exec` with prompt piped via stdin (avoids command-line length
+	// limits and shell-escaping issues for long transcripts).
 	return new Promise((resolve, reject) => {
-		const args: string[] = [];
-		if (model) {
-			args.push("-m", model);
-		}
-		args.push("-p", prompt);
-		const proc = spawn("gemini", args, { stdio: ["ignore", "pipe", "pipe"] });
+		const args: string[] = ["exec"];
+		if (model) args.push("-m", model);
+		args.push("-"); // read prompt from stdin
+		const proc = spawn("codex", args, { stdio: ["pipe", "pipe", "pipe"] });
 		let stdout = "";
 		let stderr = "";
 		proc.stdout.on("data", (chunk) => {
@@ -308,8 +309,10 @@ function callGemini(prompt: string, model: string | null): Promise<string> {
 		proc.on("error", reject);
 		proc.on("close", (code) => {
 			if (code === 0) resolve(stdout);
-			else reject(new Error(`gemini exited ${code}: ${stderr.trim()}`));
+			else reject(new Error(`codex exited ${code}: ${stderr.trim()}`));
 		});
+		proc.stdin.write(prompt);
+		proc.stdin.end();
 	});
 }
 
@@ -438,7 +441,7 @@ async function processVideo(
 
 	let raw: string;
 	try {
-		raw = await callGemini(prompt, opts.model);
+		raw = await callLlm(prompt, opts.model);
 	} catch (error) {
 		return {
 			status: "error",

--- a/content/scripts/output/resources/ad51s1b7h8fhtsexscspmy3x.json
+++ b/content/scripts/output/resources/ad51s1b7h8fhtsexscspmy3x.json
@@ -1,0 +1,34 @@
+{
+	"video_id": "ad51s1b7h8fhtsexscspmy3x",
+	"slug": "improve-your-supply-chain-security-pipeline-with-scribe-security",
+	"title": "Improve Your Supply Chain Security Pipeline with Scribe Security",
+	"generated_at": "2026-05-17T12:57:52.564Z",
+	"known_technology_names": [],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "SLSA (Salsa) Framework",
+			"category": "documentation",
+			"evidence_quote": "Google introduced us to the Salsa framework for supply chain security and integrity validation back in 2021.",
+			"confidence": "high"
+		},
+		{
+			"title": "Directus Headless CMS",
+			"category": "code",
+			"evidence_quote": "I've forked a real open source project called Directus, which is a headless CMS that powers data frameworks with their Studio UI.",
+			"confidence": "high"
+		},
+		{
+			"title": "NIST Secure Software Development Framework (SSDF)",
+			"category": "documentation",
+			"evidence_quote": "And for this NIST secure software development framework, we have nine pending tasks or controls that we need to bring under compliance.",
+			"confidence": "high"
+		},
+		{
+			"title": "Scribe Security Action BOM",
+			"category": "code",
+			"evidence_quote": "Here, we're seeing use Scrape security action bomb.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ag2zatp44xhj015i1fe4ejs1.json
+++ b/content/scripts/output/resources/ag2zatp44xhj015i1fe4ejs1.json
@@ -1,0 +1,38 @@
+{
+	"video_id": "ag2zatp44xhj015i1fe4ejs1",
+	"slug": "workshop-database-access-postgres-with-teleport",
+	"title": "Workshop - Database Access (Postgres) with Teleport",
+	"generated_at": "2026-05-17T12:46:11.458Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Rawkode Academy Courses Repository",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "You will find it at Rawkode Academy, which is the organization on GitHub. And then there is a repository called courses.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Documentation: Database Access with Self-hosted PostgreSQL",
+			"category": "documentation",
+			"evidence_quote": "Database access was self hosted Postgres. A lot of these steps are already covered here. This is where you find all of your answers.",
+			"confidence": "high"
+		},
+		{
+			"title": "Beekeeper Studio",
+			"category": "other",
+			"evidence_quote": "I'm gonna use Beekeeper studio. I thought it looked good. That was my reason for picking it. I thought it was the nicest looking of the clients I was playing with earlier.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rawkode Academy Discord",
+			"url": "https://rawkode.chat",
+			"category": "other",
+			"evidence_quote": "So my Discord is Rawkode.chat",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/cle88zfeqmv5z0rl6g7mi083.json
+++ b/content/scripts/output/resources/cle88zfeqmv5z0rl6g7mi083.json
@@ -1,0 +1,33 @@
+{
+	"video_id": "cle88zfeqmv5z0rl6g7mi083",
+	"slug": "introduction-to-bgp",
+	"title": "Introduction to BGP",
+	"generated_at": "2026-05-17T12:45:29.830Z",
+	"known_technology_names": [],
+	"known_guest_names": [
+		"Jeremy Tanner"
+	],
+	"resources": [
+		{
+			"title": "WonderNetwork Global Latency Statistics",
+			"url": "https://wondernetwork.com",
+			"category": "other",
+			"evidence_quote": "These figures I got from wonder network, which is a really cool website I wasn't familiar with, But you can actually add all your own cities, which I thought was nice.",
+			"confidence": "high"
+		},
+		{
+			"title": "Locoping",
+			"url": "https://locoping.com",
+			"category": "other",
+			"evidence_quote": "There's a website listed here too after we get past all this stuff called loco ping. ... we can also use local ping, which will show gives us a web interface to trace route as well.",
+			"confidence": "medium"
+		},
+		{
+			"title": "Simple Wikipedia (BGP)",
+			"url": "https://simple.wikipedia.org/wiki/Border_Gateway_Protocol",
+			"category": "documentation",
+			"evidence_quote": "Are you aware of Wikipedia Simple? ... you can swap out the language, e n, for simple. And usually... you get a very simplified definition of the thing that you're looking at.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/cvahj7nb3ypukon4fm4mreaa.json
+++ b/content/scripts/output/resources/cvahj7nb3ypukon4fm4mreaa.json
@@ -1,0 +1,39 @@
+{
+	"video_id": "cvahj7nb3ypukon4fm4mreaa",
+	"slug": "monitoring-your-security-posture-with-prometheus",
+	"title": "Monitoring Your Security Posture with Prometheus",
+	"generated_at": "2026-05-17T12:55:24.799Z",
+	"known_technology_names": [
+		"Kubescape"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Kubescape Complete Guide Repository",
+			"url": "https://github.com/rawkode-academy/kubescape-complete-guide",
+			"category": "code",
+			"evidence_quote": "the just fail is here and available via the repository on the Rawkode Academy. The link is in the description.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubescape Prometheus Exporter",
+			"url": "https://github.com/kubescape/prometheus-exporter",
+			"category": "code",
+			"evidence_quote": "We run an operator and our cluster that uses Prometheus service monitors, speaks to Kubescape, gets a result of our scans, writes them to Prometheus",
+			"confidence": "high"
+		},
+		{
+			"title": "ARMO Cloud Dashboard",
+			"url": "https://cloud.armosec.io/",
+			"category": "other",
+			"evidence_quote": "When you run Kubescape, you get the ARMOR cloud dashboard. You can go and see the report and results of all your scans.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubescape Grafana Dashboard",
+			"category": "other",
+			"evidence_quote": "Sometimes you just need a dashboard. We need to see multiple queries, multiple metrics, and how they change together over time. So let's run the download dashboard, just target.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/czct26lrzw3y5ylu4tjvfsq5.json
+++ b/content/scripts/output/resources/czct26lrzw3y5ylu4tjvfsq5.json
@@ -1,0 +1,12 @@
+{
+	"video_id": "czct26lrzw3y5ylu4tjvfsq5",
+	"slug": "writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions",
+	"title": "Writing New Micro-services Using AI with GitLab Duo Code Suggestions",
+	"generated_at": "2026-05-17T12:51:17.720Z",
+	"known_technology_names": [
+		"GitLab",
+		"GitLab Duo"
+	],
+	"known_guest_names": [],
+	"resources": []
+}

--- a/content/scripts/output/resources/d52og3gdtmtu7w8nhkyg1uyt.json
+++ b/content/scripts/output/resources/d52og3gdtmtu7w8nhkyg1uyt.json
@@ -1,0 +1,45 @@
+{
+	"video_id": "d52og3gdtmtu7w8nhkyg1uyt",
+	"slug": "kubescape-cli-and-github-action",
+	"title": "Kubescape CLI & GitHub Action",
+	"generated_at": "2026-05-17T12:44:59.416Z",
+	"known_technology_names": [
+		"Kubescape"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Kubescape GitHub Action",
+			"url": "https://github.com/kubescape/github-action",
+			"category": "code",
+			"evidence_quote": "There's now a GitHub action that automates this entire process for you.",
+			"confidence": "high"
+		},
+		{
+			"title": "Google Microservices Demo",
+			"url": "https://github.com/GoogleCloudPlatform/microservices-demo",
+			"category": "demos",
+			"evidence_quote": "in this directory, we have the Google microservice demo",
+			"confidence": "high"
+		},
+		{
+			"title": "Weaveworks Sock Shop",
+			"url": "https://github.com/microservices-demo/microservices-demo",
+			"category": "demos",
+			"evidence_quote": "and the Weaveworks Sockshop demo",
+			"confidence": "high"
+		},
+		{
+			"title": "NSA/CISA Kubernetes Hardening Guidance",
+			"category": "documentation",
+			"evidence_quote": "However, we can say we want to scan, get the NSA framework in this directory.",
+			"confidence": "high"
+		},
+		{
+			"title": "Klustered Automation Repository",
+			"category": "code",
+			"evidence_quote": "So here I am in the GitHub repository for the clustered automation.",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/dtax4c66pvgyj704bvojhsou.json
+++ b/content/scripts/output/resources/dtax4c66pvgyj704bvojhsou.json
@@ -1,0 +1,39 @@
+{
+	"video_id": "dtax4c66pvgyj704bvojhsou",
+	"slug": "workshop-deploying-teleport-on-kubernetes",
+	"title": "Workshop - Deploying Teleport on Kubernetes",
+	"generated_at": "2026-05-17T12:45:16.535Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Rawkode Academy Courses Repository",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "we have the new workshop pushed to the Rawkode Academy slash courses repository on github.com. You will find a directory called eight kubernetes with the README that we will be using for today's session.",
+			"confidence": "high"
+		},
+		{
+			"title": "Artifact Hub",
+			"url": "https://artifacthub.io",
+			"category": "other",
+			"evidence_quote": "The Teleport charts are not published through the Artifact Hub. If you're not familiar with the Artifact Hub, there we go, Artifact Hub. This is like the new Helm Hub or even a replacement or discovery mechanism",
+			"confidence": "high"
+		},
+		{
+			"title": "Emissary Ingress",
+			"url": "https://www.getambassador.io/products/emissary-ingress",
+			"category": "other",
+			"evidence_quote": "I'm a fan of emissaries, so I just swapped out. What that means is... we have our ambassador, which is Emissary NGRIS, as a load balancer",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubernetes Office Hours",
+			"category": "other",
+			"evidence_quote": "Carlos and I are hosting the Kubernetes office hours tomorrow. That is at two p. M. GMT.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ecc8n8zd3p5xk96h52qdp2p7.json
+++ b/content/scripts/output/resources/ecc8n8zd3p5xk96h52qdp2p7.json
@@ -1,0 +1,19 @@
+{
+	"video_id": "ecc8n8zd3p5xk96h52qdp2p7",
+	"slug": "workshop-access-control-and-roles-deep-dive",
+	"title": "Workshop - Access Control & Roles Deep Dive",
+	"generated_at": "2026-05-17T12:44:24.101Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Workshop Course Materials (RBAC Deep Dive)",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "all the README files are on GitHub. You can find them at github.com/rockwoodacademy/courses. This is part 10, the RBAG deep dive",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/eihdoemxfyzm33pxzcix5ci5.json
+++ b/content/scripts/output/resources/eihdoemxfyzm33pxzcix5ci5.json
@@ -1,0 +1,32 @@
+{
+	"video_id": "eihdoemxfyzm33pxzcix5ci5",
+	"slug": "replace-your-github-actions-yaml-with-cue",
+	"title": "Replace Your GitHub Actions YAML with CUE",
+	"generated_at": "2026-05-17T12:49:22.239Z",
+	"known_technology_names": [
+		"CUE"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "CUE Documentation",
+			"url": "https://cue.dev/docs",
+			"category": "documentation",
+			"evidence_quote": "First place you'll wanna go to is queue.dev/docs.",
+			"confidence": "high"
+		},
+		{
+			"title": "CUE Central Registry",
+			"url": "https://registry.cue.works",
+			"category": "other",
+			"evidence_quote": "This is the relatively new effort from the Q team to make it easier to adopt Q for common workflows.",
+			"confidence": "high"
+		},
+		{
+			"title": "GitHub Actions package on CUE Registry",
+			"category": "code",
+			"evidence_quote": "If we search for GitHub actions and click on the package, you'll see that we now have a bunch of definitions that we can import from the central registry",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/etr47c1p01p3mefltqwanwhv.json
+++ b/content/scripts/output/resources/etr47c1p01p3mefltqwanwhv.json
@@ -1,0 +1,30 @@
+{
+	"video_id": "etr47c1p01p3mefltqwanwhv",
+	"slug": "ebpf-for-runtime-enforcement",
+	"title": "eBPF for Runtime Enforcement",
+	"generated_at": "2026-05-17T12:49:55.950Z",
+	"known_technology_names": [
+		"Tetragon"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Tetragon Installation Documentation",
+			"category": "documentation",
+			"evidence_quote": "From here, we're going to click on installation. Now we should note there are multiple ways to install Tetragon.",
+			"confidence": "high"
+		},
+		{
+			"title": "Tetragon GitHub Releases",
+			"category": "code",
+			"evidence_quote": "So from here, we can see that we can grab Tetragon from the GitHub releases.",
+			"confidence": "high"
+		},
+		{
+			"title": "Tetragon Helm Chart",
+			"category": "code",
+			"evidence_quote": "Now we're going to use Helm, so this isn't anything you haven't seen before. We add the repository, do an update, and ask it to install.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/f8kozfxzp1vtykj2na0sye5w.json
+++ b/content/scripts/output/resources/f8kozfxzp1vtykj2na0sye5w.json
@@ -1,0 +1,36 @@
+{
+	"video_id": "f8kozfxzp1vtykj2na0sye5w",
+	"slug": "part-3-tutorial-2-getting-started-with-influxdb",
+	"title": "Part 3 - Tutorial 2: Getting Started with InfluxDB",
+	"generated_at": "2026-05-17T12:49:04.213Z",
+	"known_technology_names": [
+		"InfluxDB"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Part 1: An Introduction to Time Series",
+			"category": "other",
+			"evidence_quote": "We talked about this briefly in the very first part of this course, an introduction to time series.",
+			"confidence": "high"
+		},
+		{
+			"title": "Flux Workshop: Writing Your First Flux",
+			"category": "other",
+			"evidence_quote": "The next workshop will be this week, and it will be focusing on writing your first flux. Make sure to catch that.",
+			"confidence": "high"
+		},
+		{
+			"title": "InfluxDB 2 Templates",
+			"category": "other",
+			"evidence_quote": "One of the coolest things about InfluxDB's latest version, version two, is templates. We will be spending also a significant amount of time on using the GetOps pattern to apply our telegraph configurations, our dashboards and our tasks using InfluxDB two templates.",
+			"confidence": "high"
+		},
+		{
+			"title": "Telegraf Data Collector",
+			"category": "code",
+			"evidence_quote": "You can start to specify and configure Telegraph, or you could just say, I will do this later, which is what we're going to choose now.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/fd8h2x0iq6qy06gui4vev807.json
+++ b/content/scripts/output/resources/fd8h2x0iq6qy06gui4vev807.json
@@ -1,0 +1,40 @@
+{
+	"video_id": "fd8h2x0iq6qy06gui4vev807",
+	"slug": "the-roast-of-the-linux-desktop",
+	"title": "The Roast of the Linux Desktop",
+	"generated_at": "2026-05-17T12:50:24.685Z",
+	"known_technology_names": [],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Fedora Silverblue",
+			"category": "other",
+			"evidence_quote": "I am trying for Dora Silverblue right now, and I'm gonna kinda try and explain why.",
+			"confidence": "high"
+		},
+		{
+			"title": "Universal Blue (uBlue)",
+			"category": "code",
+			"evidence_quote": "He works on the uBlue project, which is, like, trying to make it silver Silver Blue more developer friendly",
+			"confidence": "high"
+		},
+		{
+			"title": "Microsoft PowerToys",
+			"category": "code",
+			"evidence_quote": "I set up this is this is PowerToys, PowerRun. This is how I run most everything",
+			"confidence": "high"
+		},
+		{
+			"title": "UniGet Package Manager",
+			"category": "code",
+			"evidence_quote": "I use this this program called UniGet. So when it comes to Windows, the only way I install anything in Windows is through UniGet.",
+			"confidence": "high"
+		},
+		{
+			"title": "Dev Home",
+			"category": "code",
+			"evidence_quote": "Dev Home is a all in one tool for getting started developing on Windows.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/fg5n3s12kpi526uupu0w7tav.json
+++ b/content/scripts/output/resources/fg5n3s12kpi526uupu0w7tav.json
@@ -1,0 +1,26 @@
+{
+	"video_id": "fg5n3s12kpi526uupu0w7tav",
+	"slug": "part-4-tutorial-3-collecting-metrics-with-telegraf",
+	"title": "Part 4 - Tutorial 3: Collecting Metrics with Telegraf",
+	"generated_at": "2026-05-17T12:45:58.872Z",
+	"known_technology_names": [
+		"InfluxDB",
+		"Telegraf"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "influxdata/telegraf GitHub Repository",
+			"url": "https://github.com/influxdata/telegraf",
+			"category": "code",
+			"evidence_quote": "The best thing you can do is go to the Telegraph repository. That's github.com/influxdata/telegraph.",
+			"confidence": "high"
+		},
+		{
+			"title": "Telegraf Plugins Reference",
+			"category": "documentation",
+			"evidence_quote": "From here, you can click on plugins. You will see inputs and outputs. Those are the two that you will use the most with inputs being the one that you wanna be, maybe you're perhaps more curious about and want to understand.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/g179fxks66spn3ni7749lzdd.json
+++ b/content/scripts/output/resources/g179fxks66spn3ni7749lzdd.json
@@ -1,0 +1,41 @@
+{
+	"video_id": "g179fxks66spn3ni7749lzdd",
+	"slug": "developing-and-building-open-source-with-dagger",
+	"title": "Developing & Building Open Source with Dagger",
+	"generated_at": "2026-05-17T12:50:28.540Z",
+	"known_technology_names": [
+		"Dagger",
+		"OpenUnison"
+	],
+	"known_guest_names": [
+		"Marc Boorshtein"
+	],
+	"resources": [
+		{
+			"title": "OpenUnison Helm Charts",
+			"url": "https://github.com/OpenUnison/helmcharts",
+			"category": "code",
+			"evidence_quote": "The actual Helm charts are GitHub.com/OpenUnison/helmcharts.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubernetes: An Enterprise Guide",
+			"category": "other",
+			"evidence_quote": "I am also the coauthor of Kubernetes, an enterprise guide, first and second edition, the third edition next month.",
+			"confidence": "high"
+		},
+		{
+			"title": "Hurl",
+			"url": "https://hurl.dev",
+			"category": "other",
+			"evidence_quote": "I'll probably use hurl dot dev or something like that. It's a really cool text based tool for making HTTP requests and assertions.",
+			"confidence": "high"
+		},
+		{
+			"title": "k3s Dagger Module",
+			"category": "code",
+			"evidence_quote": "This is the easiest k three s and say the container for Dagger I have ever seen in my life. So that is a testament to Marcos' work.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/gz1nbyatbi6h3q1usddwkdqh.json
+++ b/content/scripts/output/resources/gz1nbyatbi6h3q1usddwkdqh.json
@@ -1,0 +1,36 @@
+{
+	"video_id": "gz1nbyatbi6h3q1usddwkdqh",
+	"slug": "github-authentication",
+	"title": "GitHub Authentication",
+	"generated_at": "2026-05-17T12:46:30.621Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Teleport GitHub SSO Documentation",
+			"category": "documentation",
+			"evidence_quote": "I have the browser here where I have the documentation on setting up single sign on with GitHub",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport RBAC Deep Dive",
+			"category": "other",
+			"evidence_quote": "we actually did a Teleport Rback deep dive session, which you can find at Rawkode.live if you just search for Teleport Rback.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Machine ID Q&A with Ben Adams",
+			"category": "other",
+			"evidence_quote": "go to this Q and A with Ben Adams from the Teleport team. We actually do a demo and talk about machine ID in much more detail",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Windows Desktop Access Video",
+			"category": "other",
+			"evidence_quote": "even desktop, Windows desktop, for example, which we did a video on recently with Ben from that team",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/h0e270cxlhdgnr6x20mcno3d.json
+++ b/content/scripts/output/resources/h0e270cxlhdgnr6x20mcno3d.json
@@ -1,0 +1,11 @@
+{
+	"video_id": "h0e270cxlhdgnr6x20mcno3d",
+	"slug": "unlocking-global-edge-services-with-ngrok",
+	"title": "Unlocking Global Edge Services with ngrok",
+	"generated_at": "2026-05-17T12:52:43.806Z",
+	"known_technology_names": [
+		"ngrok"
+	],
+	"known_guest_names": [],
+	"resources": []
+}

--- a/content/scripts/output/resources/h5nbnjit38i94obymum2ke22.json
+++ b/content/scripts/output/resources/h5nbnjit38i94obymum2ke22.json
@@ -1,0 +1,19 @@
+{
+	"video_id": "h5nbnjit38i94obymum2ke22",
+	"slug": "fuck-you-hashicorp-an-ibm-company",
+	"title": "Fuck you, Hashicorp ... an IBM Company.",
+	"generated_at": "2026-05-17T12:48:13.461Z",
+	"known_technology_names": [
+		"Terraform"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Cloud Development Kit for Terraform (CDKTF)",
+			"url": "https://github.com/hashicorp/terraform-cdk",
+			"category": "code",
+			"evidence_quote": "HashiCorp, an IBM company, has archived the Terraform CDK repository.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/idafk86yfg7uq201z7v4p0wv.json
+++ b/content/scripts/output/resources/idafk86yfg7uq201z7v4p0wv.json
@@ -1,0 +1,39 @@
+{
+	"video_id": "idafk86yfg7uq201z7v4p0wv",
+	"slug": "sentry-prometheus-and-grafana-integrations",
+	"title": "Sentry, Prometheus, & Grafana Integrations",
+	"generated_at": "2026-05-17T12:57:30.068Z",
+	"known_technology_names": [
+		"Komodor"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Komodor Tutorial Part 1: Deploying the Agent",
+			"category": "other",
+			"evidence_quote": "If you haven't seen part one, pause this and go watch it now. In part one, I show you how to deploy the Komodor agent to your Kubernetes cluster.",
+			"confidence": "high"
+		},
+		{
+			"title": "kube-prometheus",
+			"url": "https://github.com/prometheus-operator/kube-prometheus",
+			"category": "code",
+			"evidence_quote": "This is this generic Kube Prometheus install.",
+			"confidence": "high"
+		},
+		{
+			"title": "Sentry",
+			"url": "https://sentry.io",
+			"category": "other",
+			"evidence_quote": "Sentry is something that if you're an application developer, you probably already know. It's an open source tool that you integrate into your application.",
+			"confidence": "high"
+		},
+		{
+			"title": "Grafana",
+			"url": "https://grafana.com",
+			"category": "other",
+			"evidence_quote": "Another tool that developers love to use -- well, I love to use, but I'll speak for all developers now, is Grafana",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ivg9hwb376cu64psybqhd5k0.json
+++ b/content/scripts/output/resources/ivg9hwb376cu64psybqhd5k0.json
@@ -1,0 +1,19 @@
+{
+	"video_id": "ivg9hwb376cu64psybqhd5k0",
+	"slug": "managing-tls",
+	"title": "Managing TLS",
+	"generated_at": "2026-05-17T12:44:17.941Z",
+	"known_technology_names": [
+		"Portainer"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Portainer in Production GitHub Repository",
+			"url": "https://github.com/rawcodeacademy/portainer-in-production",
+			"category": "code",
+			"evidence_quote": "The code is available at github.com/rawcodeacademy/portainer-in-production.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/klzxhw3ow8qzrua89xr91717.json
+++ b/content/scripts/output/resources/klzxhw3ow8qzrua89xr91717.json
@@ -1,0 +1,30 @@
+{
+	"video_id": "klzxhw3ow8qzrua89xr91717",
+	"slug": "using-guidepad-io-to-primitives-to-simplify-future-facing-problems",
+	"title": "Using Guidepad.io to Primitives to Simplify Future Facing Problems",
+	"generated_at": "2026-05-17T12:51:55.179Z",
+	"known_technology_names": [
+		"Guidepad"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "S3 Provider Service Demo",
+			"category": "code",
+			"evidence_quote": "It is called s three provider, and it is 105 lines long.",
+			"confidence": "high"
+		},
+		{
+			"title": "CloudTrail Requirement Class",
+			"category": "code",
+			"evidence_quote": "Inside of our plugin, we have requirements dot py. In this, we define a new class which extend requirement called CloudTrail requirement.",
+			"confidence": "high"
+		},
+		{
+			"title": "Terraform Control Plane Implementation",
+			"category": "code",
+			"evidence_quote": "If we pop open Terraform, we will see the code. Now all this does is give Guidepad enough information to tell it how to execute Terraform programs.",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/lxx8tfrfnnhiv1ur4h6t60t0.json
+++ b/content/scripts/output/resources/lxx8tfrfnnhiv1ur4h6t60t0.json
@@ -1,0 +1,25 @@
+{
+	"video_id": "lxx8tfrfnnhiv1ur4h6t60t0",
+	"slug": "a-hands-on-overview-of-guidepad",
+	"title": "A Hands-on Overview of guidepad",
+	"generated_at": "2026-05-17T12:52:03.589Z",
+	"known_technology_names": [
+		"Guidepad"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Microlink API",
+			"url": "https://microlink.io/",
+			"category": "other",
+			"evidence_quote": "In order to enrich our bookmarks with metadata we're using the micro link API.",
+			"confidence": "high"
+		},
+		{
+			"title": "Guidepad Rawkode",
+			"category": "code",
+			"evidence_quote": "This is my Guidepad plugin. A Guidepad plugin is a bunch of Python code which you store and get and register with the Guidepad system.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/m33ycy3p5m13rbpi3h4bkbv0.json
+++ b/content/scripts/output/resources/m33ycy3p5m13rbpi3h4bkbv0.json
@@ -1,0 +1,45 @@
+{
+	"video_id": "m33ycy3p5m13rbpi3h4bkbv0",
+	"slug": "lets-take-a-look-at-teleport-10",
+	"title": "Let's Take a Look at Teleport 10",
+	"generated_at": "2026-05-17T12:47:38.677Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [
+		"Ben Abbott"
+	],
+	"resources": [
+		{
+			"title": "Teleport Upgrade Documentation",
+			"category": "documentation",
+			"evidence_quote": "we have sort of specific documentation around how to upgrade between nine and ten and, like, end of life cycle.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rawkode Academy Discord",
+			"url": "https://rawkode.chat",
+			"category": "other",
+			"evidence_quote": "You can join a Academy Discord. It's available at Rawkode.chat.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport 10 Release Blog",
+			"category": "documentation",
+			"evidence_quote": "I do have the watch new IntelliPortem blog here. So maybe we could scroll through this, and you can give us a bit of a an introduction to the other stuff that's listed here.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport RFDs (Request For Discussion)",
+			"category": "documentation",
+			"evidence_quote": "along with kind of being open call for GitHub, we have sort of RFDs. Ah. We sort of discuss like how we're implementing our features.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Community Slack",
+			"category": "other",
+			"evidence_quote": "you can join our community Slack channel. It's avail it's a scoteleport.com forward slash slack.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/n3ub5yilclec48k398q64zi2.json
+++ b/content/scripts/output/resources/n3ub5yilclec48k398q64zi2.json
@@ -1,0 +1,36 @@
+{
+	"video_id": "n3ub5yilclec48k398q64zi2",
+	"slug": "advanced-kubernetes-scheduling",
+	"title": "Advanced Kubernetes Scheduling",
+	"generated_at": "2026-05-17T12:45:35.285Z",
+	"known_technology_names": [
+		"Kubernetes"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Kubernetes Documentation: PriorityClass",
+			"category": "documentation",
+			"evidence_quote": "We can copy an example from a documentation like so. Here, we're using the scheduling Kubernetes IOV one API. We're going to create a new priority class",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubernetes Documentation: Pod Scheduling Readiness",
+			"category": "documentation",
+			"evidence_quote": "I have enabled a feature gate called pod scheduling readiness.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubernetes Enhancement Proposal: Dynamic Resource Allocation",
+			"category": "documentation",
+			"evidence_quote": "I'm kind of leaning on the example from the KEP here, which talks about claiming cats",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubernetes Documentation: Topology Spread Constraints",
+			"category": "documentation",
+			"evidence_quote": "There's a relatively new feature in Kubernetes called topology spread constraints.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ncgxuu1vyx5yl7psezcz79dk.json
+++ b/content/scripts/output/resources/ncgxuu1vyx5yl7psezcz79dk.json
@@ -1,0 +1,42 @@
+{
+	"video_id": "ncgxuu1vyx5yl7psezcz79dk",
+	"slug": "supply-chain-security-with-a-cli-valint",
+	"title": "Supply Chain Security with a CLI: valint",
+	"generated_at": "2026-05-17T12:56:33.629Z",
+	"known_technology_names": [],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Valint Installation Script",
+			"url": "https://get.scrapesecurity.com/install.sh",
+			"category": "code",
+			"evidence_quote": "You can grab it from get.scrapesecurity.com/install.sh, where if you put that through a shell, you will get your Valant in your local directory.",
+			"confidence": "high"
+		},
+		{
+			"title": "Scribe Security JFrog Container Registry",
+			"category": "other",
+			"evidence_quote": "Or you can pull the Valiant container image from their JFrog instance, which is scrapesecurity.jfrog.i0/scrape-docker-public-local/valiant latest.",
+			"confidence": "high"
+		},
+		{
+			"title": "Indigo (Blue Sky Go SDK)",
+			"category": "code",
+			"evidence_quote": "I'm in a directory and taking a look at Blue Sky Go SDK or program called Indigo.",
+			"confidence": "high"
+		},
+		{
+			"title": "Mongo Express",
+			"category": "code",
+			"evidence_quote": "we'll scan a git repository. Mongoexpressmongoexpress.git.",
+			"confidence": "high"
+		},
+		{
+			"title": "Sigstore",
+			"url": "https://sigstore.dev",
+			"category": "other",
+			"evidence_quote": "this will ask me to log in with Segstor.",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/o1184zljah5ebqa0sj8h0i43.json
+++ b/content/scripts/output/resources/o1184zljah5ebqa0sj8h0i43.json
@@ -1,0 +1,31 @@
+{
+	"video_id": "o1184zljah5ebqa0sj8h0i43",
+	"slug": "part-5-workshop-1-introduction-to-flux",
+	"title": "Part 5 - Workshop 1: Introduction to Flux",
+	"generated_at": "2026-05-17T12:45:36.812Z",
+	"known_technology_names": [
+		"InfluxDB"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Rawkode Academy Courses Repository",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "You can find the resources for this course at github dot com slash rockode academy. I have started adding the materials to the courses repository.",
+			"confidence": "high"
+		},
+		{
+			"title": "Flux VS Code Extension",
+			"category": "other",
+			"evidence_quote": "you'll see that there is this Versus code extension from InfluxData. You can add connections... local host.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rawkode Academy Discord",
+			"category": "other",
+			"evidence_quote": "Use the Discord to ask for help. Use the comments to ask for help. I'm here.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ovgas80n8hqlkknowpijiqbb.json
+++ b/content/scripts/output/resources/ovgas80n8hqlkknowpijiqbb.json
@@ -2,74 +2,10 @@
 	"video_id": "ovgas80n8hqlkknowpijiqbb",
 	"slug": "exploring-ngroks-traffic-policies-for-secure-application-development",
 	"title": "Exploring ngrok's Traffic Policies for Secure Application Development",
-	"generated_at": "2026-05-17T11:42:40.804Z",
+	"generated_at": "2026-05-17T12:49:58.294Z",
 	"known_technology_names": [
 		"ngrok"
 	],
 	"known_guest_names": [],
-	"resources": [
-		{
-			"title": "Deno",
-			"url": null,
-			"category": "other",
-			"evidence_quote": "But what we have here is a Deno application configured with a router and some Prometheus metrics.",
-			"confidence": "high"
-		},
-		{
-			"title": "Prometheus",
-			"url": null,
-			"category": "other",
-			"evidence_quote": "But what we have here is a Deno application configured with a router and some Prometheus metrics.",
-			"confidence": "high"
-		},
-		{
-			"title": "GCP Cloud Shell",
-			"url": null,
-			"category": "other",
-			"evidence_quote": "Here, I have a GCP Cloud Shell where I can also curl ngrok",
-			"confidence": "high"
-		},
-		{
-			"title": "ngrok Traffic Policy Documentation",
-			"url": null,
-			"category": "documentation",
-			"evidence_quote": "This is the traffic policy page, which is currently in preview, but we like to fly things on the edge and unstable as often as we can.",
-			"confidence": "high"
-		},
-		{
-			"title": "Common Expression Language",
-			"url": null,
-			"category": "other",
-			"evidence_quote": "Now the secret sauce of traffic policies is the common expression language.",
-			"confidence": "high"
-		},
-		{
-			"title": "ngrok HTTP Request Variables Documentation",
-			"url": null,
-			"category": "documentation",
-			"evidence_quote": "We can click on request variables. And now we have the understanding of an HTTP request.",
-			"confidence": "high"
-		},
-		{
-			"title": "ngrok Connection Geo Variables Documentation",
-			"url": null,
-			"category": "documentation",
-			"evidence_quote": "we'll see that we have access to connection geo variables.",
-			"confidence": "high"
-		},
-		{
-			"title": "ngrok Custom Response Action Documentation",
-			"url": null,
-			"category": "documentation",
-			"evidence_quote": "to get the properties that we need, we'll head back to the documentation and click on custom response.",
-			"confidence": "high"
-		},
-		{
-			"title": "ngrok JWT Validation Examples",
-			"url": null,
-			"category": "documentation",
-			"evidence_quote": "Go explore the documentation where you'll find examples of JWT validation for your endpoints.",
-			"confidence": "high"
-		}
-	]
+	"resources": []
 }

--- a/content/scripts/output/resources/pg8dyt42vac1gmldqsjnkswg.json
+++ b/content/scripts/output/resources/pg8dyt42vac1gmldqsjnkswg.json
@@ -1,0 +1,33 @@
+{
+	"video_id": "pg8dyt42vac1gmldqsjnkswg",
+	"slug": "server-side-webassembly-at-the-edge",
+	"title": "Server Side WebAssembly at the Edge",
+	"generated_at": "2026-05-17T12:51:36.918Z",
+	"known_technology_names": [
+		"Spin"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Fermion Installer",
+			"url": "https://github.com/fermion/installer",
+			"category": "code",
+			"evidence_quote": "you can find this and currently a pull request at github.com/firmion/installer.",
+			"confidence": "high"
+		},
+		{
+			"title": "Deis Labs Hippo",
+			"url": "https://github.com/deislabs/hippo",
+			"category": "code",
+			"evidence_quote": "Hippo is a days lab project, which I believe is mostly dot net.",
+			"confidence": "high"
+		},
+		{
+			"title": "Deis Labs Bundle",
+			"url": "https://github.com/deislabs/bundle",
+			"category": "code",
+			"evidence_quote": "deploying Hippo and Bundle from data slabs",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/phhk3ymh8qjb3pzwmmtofefz.json
+++ b/content/scripts/output/resources/phhk3ymh8qjb3pzwmmtofefz.json
@@ -1,0 +1,28 @@
+{
+	"video_id": "phhk3ymh8qjb3pzwmmtofefz",
+	"slug": "aquaproj-and-dagger",
+	"title": "aquaproj & Dagger",
+	"generated_at": "2026-05-17T12:57:09.596Z",
+	"known_technology_names": [
+		"aquaproj",
+		"Dagger"
+	],
+	"known_guest_names": [
+		"Brian Ketelsen"
+	],
+	"resources": [
+		{
+			"title": "AlphaBits Podcast",
+			"url": "https://alphabets.fm",
+			"category": "other",
+			"evidence_quote": "check out the podcast available at alphabets.fm.",
+			"confidence": "high"
+		},
+		{
+			"title": "aquaproj Registry",
+			"category": "code",
+			"evidence_quote": "and the registry, and the registry has all of the package definitions.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/q29r22us2pmcizlk0v0zifyb.json
+++ b/content/scripts/output/resources/q29r22us2pmcizlk0v0zifyb.json
@@ -1,0 +1,26 @@
+{
+	"video_id": "q29r22us2pmcizlk0v0zifyb",
+	"slug": "kubescape-operator-and-saas",
+	"title": "Kubescape Operator & SaaS",
+	"generated_at": "2026-05-17T12:44:40.084Z",
+	"known_technology_names": [
+		"Kubescape"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Kubescape Complete Guide Repository",
+			"url": "https://github.com/rawkode-academy/kubescape-complete-guide",
+			"category": "code",
+			"evidence_quote": "All this code is available online at github.com slash Rawkode Academy. There you will find a repository called the Kubescape complete guide.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kubescape Helm Charts",
+			"url": "https://kubescape.github.io/helm-charts",
+			"category": "documentation",
+			"evidence_quote": "Kubescape provide a wonderful helm chart that allows us to deploy their cloud operator. You can find that at kubescape.github.i0/helm-charts.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/rwhw1lpmbqe2tfflabrd0ys9.json
+++ b/content/scripts/output/resources/rwhw1lpmbqe2tfflabrd0ys9.json
@@ -1,0 +1,41 @@
+{
+	"video_id": "rwhw1lpmbqe2tfflabrd0ys9",
+	"slug": "kubernetes-disaster-recovery",
+	"title": "Kubernetes Disaster Recovery",
+	"generated_at": "2026-05-17T12:47:32.992Z",
+	"known_technology_names": [
+		"Kubernetes",
+		"Velero"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "SeaweedFS",
+			"url": "https://github.com/seaweedfs/seaweedfs",
+			"category": "code",
+			"evidence_quote": "I'm using my preferred choice, which is SeaweedFS. It is a single go binary, very easy to operate, download, and run.",
+			"confidence": "high"
+		},
+		{
+			"title": "Kopia",
+			"url": "https://github.com/kopia/kopia",
+			"category": "code",
+			"evidence_quote": "Next we have the uploader type of Kopia. This is now the default for Velero. You should not be using Restic anymore. It had corruption issues. Kopia is the way forward.",
+			"confidence": "high"
+		},
+		{
+			"title": "Spectro Cloud Palette",
+			"url": "https://www.spectrocloud.com/palette",
+			"category": "other",
+			"evidence_quote": "Then we'll use Spectro Cloud's Palette to solve the problem. Centralized backup locations, standardized policies via cluster profiles and workspace level backups that protect multiple clusters together",
+			"confidence": "high"
+		},
+		{
+			"title": "Spectro Cloud Palette Documentation",
+			"url": "https://docs.spectrocloud.com",
+			"category": "documentation",
+			"evidence_quote": "Head to docs.spectrocloud.com for examples of workspace backups, profile based policies, and real world scenarios.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/rwhw1lpmbqe2tfflabrd0ys9.json
+++ b/content/scripts/output/resources/rwhw1lpmbqe2tfflabrd0ys9.json
@@ -2,7 +2,7 @@
 	"video_id": "rwhw1lpmbqe2tfflabrd0ys9",
 	"slug": "kubernetes-disaster-recovery",
 	"title": "Kubernetes Disaster Recovery",
-	"generated_at": "2026-05-17T12:47:32.992Z",
+	"generated_at": "2026-05-17T13:16:14.100Z",
 	"known_technology_names": [
 		"Kubernetes",
 		"Velero"
@@ -10,31 +10,9 @@
 	"known_guest_names": [],
 	"resources": [
 		{
-			"title": "SeaweedFS",
-			"url": "https://github.com/seaweedfs/seaweedfs",
-			"category": "code",
-			"evidence_quote": "I'm using my preferred choice, which is SeaweedFS. It is a single go binary, very easy to operate, download, and run.",
-			"confidence": "high"
-		},
-		{
-			"title": "Kopia",
-			"url": "https://github.com/kopia/kopia",
-			"category": "code",
-			"evidence_quote": "Next we have the uploader type of Kopia. This is now the default for Velero. You should not be using Restic anymore. It had corruption issues. Kopia is the way forward.",
-			"confidence": "high"
-		},
-		{
-			"title": "Spectro Cloud Palette",
-			"url": "https://www.spectrocloud.com/palette",
-			"category": "other",
-			"evidence_quote": "Then we'll use Spectro Cloud's Palette to solve the problem. Centralized backup locations, standardized policies via cluster profiles and workspace level backups that protect multiple clusters together",
-			"confidence": "high"
-		},
-		{
-			"title": "Spectro Cloud Palette Documentation",
-			"url": "https://docs.spectrocloud.com",
+			"title": "Spectro Cloud Palette documentation",
 			"category": "documentation",
-			"evidence_quote": "Head to docs.spectrocloud.com for examples of workspace backups, profile based policies, and real world scenarios.",
+			"evidence_quote": "Head to docs.spectrocloud.com\nfor examples of workspace backups, profile\nbased policies, and real world scenarios.",
 			"confidence": "high"
 		}
 	]

--- a/content/scripts/output/resources/sgs7tm99rldi3ev42yzacukd.json
+++ b/content/scripts/output/resources/sgs7tm99rldi3ev42yzacukd.json
@@ -1,0 +1,35 @@
+{
+	"video_id": "sgs7tm99rldi3ev42yzacukd",
+	"slug": "kubernetes-security-scanning",
+	"title": "Kubernetes Security Scanning: The 4 Tools You Actually Need",
+	"generated_at": "2026-05-17T12:48:00.318Z",
+	"known_technology_names": [
+		"Kubernetes",
+		"kube-bench",
+		"kube-hunter",
+		"Sonobuoy",
+		"Syft",
+		"Grype"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Spectro Cloud Palette",
+			"category": "other",
+			"evidence_quote": "At the end of this video, you will see a demo with Spectral Cloud, where I turn on all of my day two secondurity scanning operations with a toggle box.",
+			"confidence": "high"
+		},
+		{
+			"title": "Google Microservices Demo",
+			"category": "demos",
+			"evidence_quote": "This is just using a Docker desktop with the Google microservices demo deployed.",
+			"confidence": "high"
+		},
+		{
+			"title": "CIS Kubernetes Benchmarks",
+			"category": "documentation",
+			"evidence_quote": "It checks the cluster against the SIS benchmarks, which is basically the global rule book if one were to exist for hardening Kubernetes.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/sx8a3ihcu4qum6du7ejlif7i.json
+++ b/content/scripts/output/resources/sx8a3ihcu4qum6du7ejlif7i.json
@@ -1,0 +1,30 @@
+{
+	"video_id": "sx8a3ihcu4qum6du7ejlif7i",
+	"slug": "full-stack-webassembly-applications-with-spin",
+	"title": "Full Stack WebAssembly Applications with Spin",
+	"generated_at": "2026-05-17T12:44:48.145Z",
+	"known_technology_names": [
+		"Spin"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Grain Programming Language",
+			"category": "code",
+			"evidence_quote": "There's a lot to love about Grain and that is a truly WebAssembly native language and that the only target is WebAssembly.",
+			"confidence": "high"
+		},
+		{
+			"title": "Fermion Cloud",
+			"category": "other",
+			"evidence_quote": "I have my application hosted on Fermion Cloud where I can do a 12 to minus result.",
+			"confidence": "high"
+		},
+		{
+			"title": "Spin SDK",
+			"category": "code",
+			"evidence_quote": "Here, we are using the Spin SDK, which is quite nice. We are able to use a procedural macro around our function, which says this is the entry point or application that handles all the glue.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/t0syi87suw4qezpmy1gkht9k.json
+++ b/content/scripts/output/resources/t0syi87suw4qezpmy1gkht9k.json
@@ -1,0 +1,21 @@
+{
+	"video_id": "t0syi87suw4qezpmy1gkht9k",
+	"slug": "developing-and-building-open-source-with-dagger-for-kargo",
+	"title": "Developing & Building Open Source with Dagger for Kargo",
+	"generated_at": "2026-05-17T12:51:11.791Z",
+	"known_technology_names": [
+		"Dagger"
+	],
+	"known_guest_names": [
+		"Kat Cosgrove"
+	],
+	"resources": [
+		{
+			"title": "Conductor",
+			"url": "https://ghcr.io/containercraft/conductor",
+			"category": "other",
+			"evidence_quote": "it's g h c r dot I o slash container craft slash conductor",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/t7zdnxgt54j4s3973zac3mjj.json
+++ b/content/scripts/output/resources/t7zdnxgt54j4s3973zac3mjj.json
@@ -1,0 +1,33 @@
+{
+	"video_id": "t7zdnxgt54j4s3973zac3mjj",
+	"slug": "bringing-clarity-to-infrastructure-as-code-with-env0",
+	"title": "Bringing Clarity to Infrastructure as Code with Env0",
+	"generated_at": "2026-05-17T12:56:56.305Z",
+	"known_technology_names": [
+		"Env0",
+		"Pulumi",
+		"Terraform"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Rawkode Academy GitLab",
+			"url": "https://gitlab.com/RawkodeAcademy",
+			"category": "code",
+			"evidence_quote": "The code is available at gitlab.com/RawkodeAcademy",
+			"confidence": "high"
+		},
+		{
+			"title": "Cloud Development Kit for Terraform (CDKTF)",
+			"category": "code",
+			"evidence_quote": "I'm a big fan of Terraform CDK. So let's see an action as part of m zero's workflow.",
+			"confidence": "high"
+		},
+		{
+			"title": "Cloud Development Kit for Kubernetes (cdk8s)",
+			"category": "code",
+			"evidence_quote": "using Pulumi c to spin up a Kubernetes cluster, Terraform to manage DNS records, CDK to deploy to the Kubernetes cluster and so on.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/te9uhekxxgat60sku1r85kuv.json
+++ b/content/scripts/output/resources/te9uhekxxgat60sku1r85kuv.json
@@ -1,0 +1,44 @@
+{
+	"video_id": "te9uhekxxgat60sku1r85kuv",
+	"slug": "q-and-a-lets-meet-teleport-9",
+	"title": "Q&A - Let's Meet Teleport 9",
+	"generated_at": "2026-05-17T12:46:00.106Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [
+		"Ben Abbott"
+	],
+	"resources": [
+		{
+			"title": "Teleport Public Roadmap",
+			"category": "documentation",
+			"evidence_quote": "And we also made our roadmap public. And so you can go to our docs and see what our roadmap is for the next three months.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Requests for Discussion (RFD)",
+			"category": "documentation",
+			"evidence_quote": "we have a request for discussion. And so you can go to our Git repo and sort of understand, like, what our, like, versioning strategy is",
+			"confidence": "high"
+		},
+		{
+			"title": "Why the Four Eyes Principle is Critical for Access",
+			"category": "other",
+			"evidence_quote": "I had this book post today, which is why the four eyes principle is critical for access.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Ansible Guide",
+			"category": "documentation",
+			"evidence_quote": "We have instructions here on sort of how to generate the host file in our Ansible guide.",
+			"confidence": "high"
+		},
+		{
+			"title": "Teleport Upcoming Releases",
+			"category": "documentation",
+			"evidence_quote": "We have our upcoming releases page sort of describes, you know, Kubernetes and database access support for machine ID.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/tfahqa0n2pld6jvnu7a8k5w9.json
+++ b/content/scripts/output/resources/tfahqa0n2pld6jvnu7a8k5w9.json
@@ -1,0 +1,38 @@
+{
+	"video_id": "tfahqa0n2pld6jvnu7a8k5w9",
+	"slug": "restrict-access-to-secure-files-with-tetragon",
+	"title": "Restrict Access to Secure Files with Tetragon",
+	"generated_at": "2026-05-17T12:50:43.262Z",
+	"known_technology_names": [
+		"Tetragon"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Tetragon Tracing Policy Concepts",
+			"category": "documentation",
+			"evidence_quote": "Fortunately, the documentation has us pretty well covered too. So if we go to concepts, tracing policy, we can now begin to dive in to what a tracing policy is composed of.",
+			"confidence": "high"
+		},
+		{
+			"title": "Tetragon GitHub Examples",
+			"url": "https://github.com/cilium/tetragon",
+			"category": "code",
+			"evidence_quote": "You can find us on github.com/psyllium/tetragon and then find the examples folder.",
+			"confidence": "high"
+		},
+		{
+			"title": "di.net Linux Man Pages",
+			"url": "https://di.net",
+			"category": "documentation",
+			"evidence_quote": "You can look it up on the man page if you want or it is available on any good man page website like di.net.",
+			"confidence": "high"
+		},
+		{
+			"title": "Sourcegraph Linux Kernel Search",
+			"category": "other",
+			"evidence_quote": "You can use source graph to search the entire Linux code base.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/tpw7gzgjwcw3wwnx4wh7ot7c.json
+++ b/content/scripts/output/resources/tpw7gzgjwcw3wwnx4wh7ot7c.json
@@ -1,0 +1,11 @@
+{
+	"video_id": "tpw7gzgjwcw3wwnx4wh7ot7c",
+	"slug": "why-webassembly-code-once-run-everywhere",
+	"title": "Why WebAssembly? Code Once, Run Everywhere",
+	"generated_at": "2026-05-17T12:57:20.396Z",
+	"known_technology_names": [
+		"Spin"
+	],
+	"known_guest_names": [],
+	"resources": []
+}

--- a/content/scripts/output/resources/ts7glm4w4d8yxlmd2qnduu7q.json
+++ b/content/scripts/output/resources/ts7glm4w4d8yxlmd2qnduu7q.json
@@ -1,0 +1,43 @@
+{
+	"video_id": "ts7glm4w4d8yxlmd2qnduu7q",
+	"slug": "building-custom-frameworks",
+	"title": "Building Custom Frameworks",
+	"generated_at": "2026-05-17T12:52:41.282Z",
+	"known_technology_names": [
+		"Kubescape"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "ARMO Cloud",
+			"category": "other",
+			"evidence_quote": "I would encourage you and I can't stress this enough. I encourage you to use ARMOR cloud, build your frameworks from there",
+			"confidence": "high"
+		},
+		{
+			"title": "Open Policy Agent",
+			"category": "code",
+			"evidence_quote": "If you're not familiar with Regal, it's the policy language from the Open Policy Agent project.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rego Playground",
+			"category": "demos",
+			"evidence_quote": "That means you can actually use the Regal playground to test your policies",
+			"confidence": "high"
+		},
+		{
+			"title": "CUE Language",
+			"category": "code",
+			"evidence_quote": "I encourage you all to go and find Q tutorials online and improve your data configuration lives.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rawkode Academy Container Registry",
+			"url": "https://ghcr.io/rawkodeacademy",
+			"category": "code",
+			"evidence_quote": "We call the start of function to check if our image starts with ghcr.i0/RawkodeAcademy.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/v0i31x8ecolt41m670pt9cto.json
+++ b/content/scripts/output/resources/v0i31x8ecolt41m670pt9cto.json
@@ -1,0 +1,46 @@
+{
+	"video_id": "v0i31x8ecolt41m670pt9cto",
+	"slug": "global-dns-with-bgp",
+	"title": "Global DNS with BGP",
+	"generated_at": "2026-05-17T12:47:33.459Z",
+	"known_technology_names": [
+		"CoreDNS",
+		"Pulumi"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Rawkode Academy Courses",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "There is a repository there called courses. You will find the global reach BGP directory here. This is today's session with the README and some Pulumi automation",
+			"confidence": "high"
+		},
+		{
+			"title": "Equinix Metal",
+			"url": "https://rawkode.link/metal",
+			"category": "other",
+			"evidence_quote": "If you wanna work along and do this on your own, there's a link below, rawkode.linkmetal. This will take you to the Equinix Medal homepage",
+			"confidence": "high"
+		},
+		{
+			"title": "PacketHost Network Helpers",
+			"url": "https://github.com/packethost/network-helpers",
+			"category": "code",
+			"evidence_quote": "The network helpers available at github.com/packethost/network-helpers do everything for you. They speak to the metadata API to pull out all the peer information to configure BERT.",
+			"confidence": "high"
+		},
+		{
+			"title": "CoreDNS Plugins Documentation",
+			"category": "documentation",
+			"evidence_quote": "So if you come here to core dns. Go to plugins. Well, we got here, we've got ACLs... there's a cache one here.",
+			"confidence": "high"
+		},
+		{
+			"title": "BIRD Internet Routing Daemon",
+			"category": "other",
+			"evidence_quote": "BERT is a BGP advertiser. BERT BGP. Here. So it's just open source software that anyone can use.",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/vsyhv7s6wvz4p9fuq507u28g.json
+++ b/content/scripts/output/resources/vsyhv7s6wvz4p9fuq507u28g.json
@@ -1,0 +1,39 @@
+{
+	"video_id": "vsyhv7s6wvz4p9fuq507u28g",
+	"slug": "ngrok-operator-tutorial",
+	"title": "Unboxing the ngrok Kubernetes Operator",
+	"generated_at": "2026-05-17T12:48:34.715Z",
+	"known_technology_names": [
+		"ngrok",
+		"Kubernetes"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "ngrok-operator GitHub Repository",
+			"url": "https://github.com/ngrok/ngrok-operator",
+			"category": "code",
+			"evidence_quote": "The first step is to go to GitHub, where you'll find the organization ngrok and a repository called ngrok-operator.",
+			"confidence": "high"
+		},
+		{
+			"title": "ngrok Helm Chart Repository",
+			"url": "https://charts.ngrok.com",
+			"category": "code",
+			"evidence_quote": "we need to add. The charts.ngrok.com repository. We can just paste this straight in and let Helm do its job.",
+			"confidence": "high"
+		},
+		{
+			"title": "ngrok Traffic Policy Actions Documentation",
+			"category": "documentation",
+			"evidence_quote": "Here we have the ngrok documentation. We have a list of all of the actions that we can use as part of a traffic policy.",
+			"confidence": "high"
+		},
+		{
+			"title": "ngrok vs Firewall Game",
+			"category": "demos",
+			"evidence_quote": "This is the ngrok versus the firewall game. As you can see, the ngrok logo at the bottom runs around firing with little bullets to destroy the firewall.",
+			"confidence": "medium"
+		}
+	]
+}

--- a/content/scripts/output/resources/wsxnftsmvohcoqr4izm8mur6.json
+++ b/content/scripts/output/resources/wsxnftsmvohcoqr4izm8mur6.json
@@ -1,0 +1,33 @@
+{
+	"video_id": "wsxnftsmvohcoqr4izm8mur6",
+	"slug": "custom-controls-with-gpt",
+	"title": "Custom Controls with GPT",
+	"generated_at": "2026-05-17T12:56:18.277Z",
+	"known_technology_names": [
+		"Kubescape"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Armo Platform",
+			"url": "https://www.armosec.io/",
+			"category": "other",
+			"evidence_quote": "So go check out ARMOR platform. Use the custom controls and AI to help you generate all the Regal that you need for your cluster.",
+			"confidence": "high"
+		},
+		{
+			"title": "Rego Playground",
+			"url": "https://play.openpolicyagent.org/",
+			"category": "demos",
+			"evidence_quote": "First, open a new tab in your browser and search for the Rego playground and click go. This is an interactive playground that allows you to test your Ragel policies.",
+			"confidence": "high"
+		},
+		{
+			"title": "Open Policy Agent",
+			"url": "https://www.openpolicyagent.org/",
+			"category": "documentation",
+			"evidence_quote": "Regal is a language that is part of open policy agent.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/xf99ugju3sc16q7f4iw3llv8.json
+++ b/content/scripts/output/resources/xf99ugju3sc16q7f4iw3llv8.json
@@ -1,0 +1,19 @@
+{
+	"video_id": "xf99ugju3sc16q7f4iw3llv8",
+	"slug": "go-sdk",
+	"title": "Go SDK",
+	"generated_at": "2026-05-17T12:56:02.725Z",
+	"known_technology_names": [
+		"Spin"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Spin Go SDK",
+			"url": "https://github.com/spinframework/spin-go-sdk",
+			"category": "code",
+			"evidence_quote": "we pull in the Spin HTTP SDK.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/xi7tekr74r3qfd7pv30lkp0s.json
+++ b/content/scripts/output/resources/xi7tekr74r3qfd7pv30lkp0s.json
@@ -1,0 +1,19 @@
+{
+	"video_id": "xi7tekr74r3qfd7pv30lkp0s",
+	"slug": "continuously-deploy-with-gitops",
+	"title": "Continuously Deploy with GitOps",
+	"generated_at": "2026-05-17T12:45:48.273Z",
+	"known_technology_names": [
+		"Portainer"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "Portainer in Production Course Repository",
+			"url": "https://github.com/rawkode-academy/portainer-in-production",
+			"category": "code",
+			"evidence_quote": "in our repository available at github.com/rawcodeacademy/retainer-in-production, there is a directory called GitOps.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/xqw6ifttca4q4sdninffrwml.json
+++ b/content/scripts/output/resources/xqw6ifttca4q4sdninffrwml.json
@@ -1,0 +1,43 @@
+{
+	"video_id": "xqw6ifttca4q4sdninffrwml",
+	"slug": "minio-we-wont-miss-you",
+	"title": "MinIO, we won't miss you.",
+	"generated_at": "2026-05-17T12:48:13.778Z",
+	"known_technology_names": [
+		"MinIO",
+		"SeaweedFS"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "MinIO Community Edition Maintenance Mode Announcement",
+			"category": "other",
+			"evidence_quote": "Mineo just announced maintenance mode for their Community edition.",
+			"confidence": "high"
+		},
+		{
+			"title": "Adam Jacobs' Analysis of MinIO License Enforcement",
+			"category": "other",
+			"evidence_quote": "industry experts and a friend Adam Jacobs said, and the link is below, this should drive everyone away from Mineo as a standard.",
+			"confidence": "high"
+		},
+		{
+			"title": "MinIO vs Nutanix License Compliance Case",
+			"category": "other",
+			"evidence_quote": "there was the case of Menio versus Nutanix.",
+			"confidence": "high"
+		},
+		{
+			"title": "MinIO vs Weka License Revocation Incident",
+			"category": "other",
+			"evidence_quote": "there was the case with Weka",
+			"confidence": "high"
+		},
+		{
+			"title": "MinIO GitHub Community Concerns",
+			"category": "other",
+			"evidence_quote": "the community raised their concerns on GitHub",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ycuvz85u2a7678qr5o4a488z.json
+++ b/content/scripts/output/resources/ycuvz85u2a7678qr5o4a488z.json
@@ -1,0 +1,31 @@
+{
+	"video_id": "ycuvz85u2a7678qr5o4a488z",
+	"slug": "workshop-database-access-mongodb-with-teleport",
+	"title": "Workshop - Database Access (mongoDB) with Teleport",
+	"generated_at": "2026-05-17T12:47:47.089Z",
+	"known_technology_names": [
+		"Teleport"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "rawkode-academy/courses",
+			"url": "https://github.com/rawkode-academy/courses",
+			"category": "code",
+			"evidence_quote": "you will see that we are back with the Rawkode Academy slash courses repository on github.com, where we have a directory called nine database access MongoDB.",
+			"confidence": "high"
+		},
+		{
+			"title": "MongoDB Atlas Documentation",
+			"category": "documentation",
+			"evidence_quote": "So let's pop over to the MongoDB Atlas documentation, and we're just gonna work through this.",
+			"confidence": "high"
+		},
+		{
+			"title": "MongoDB Compass",
+			"category": "other",
+			"evidence_quote": "I have never used MongoDB Compass before, but as you can tell by this thing telling me, you did not do this from the Internet today. So let's see if we can get the MongoDB Compass UI speaking to our Teleport exposed secure MongoDB cluster.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/ywd7rvmdaz445o5wf0snvwx9.json
+++ b/content/scripts/output/resources/ywd7rvmdaz445o5wf0snvwx9.json
@@ -1,0 +1,24 @@
+{
+	"video_id": "ywd7rvmdaz445o5wf0snvwx9",
+	"slug": "part-2-tutorial-1-installation",
+	"title": "Part 2 - Tutorial 1: Installation",
+	"generated_at": "2026-05-17T12:46:51.019Z",
+	"known_technology_names": [
+		"InfluxDB"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "InfluxData InfluxDB 2 Helm Chart",
+			"category": "code",
+			"evidence_quote": "Then the chart that we wish to install, InfluxData/InfluxDB2.",
+			"confidence": "high"
+		},
+		{
+			"title": "Course Materials Installation Guide",
+			"category": "documentation",
+			"evidence_quote": "In the course materials, you will find a README.Md inside of the to dash installing InfluxDB directory.",
+			"confidence": "high"
+		}
+	]
+}

--- a/content/scripts/output/resources/zh6x60pfsxnaglf391e673pj.json
+++ b/content/scripts/output/resources/zh6x60pfsxnaglf391e673pj.json
@@ -1,0 +1,18 @@
+{
+	"video_id": "zh6x60pfsxnaglf391e673pj",
+	"slug": "microservice-troubleshooting-built-for-developers",
+	"title": "Microservice Troubleshooting, Built for Developers",
+	"generated_at": "2026-05-17T12:48:52.174Z",
+	"known_technology_names": [
+		"Lumigo"
+	],
+	"known_guest_names": [],
+	"resources": [
+		{
+			"title": "OpenTelemetry Demo Application",
+			"category": "demos",
+			"evidence_quote": "We're using OpenTelemetry demo application, which comes with a single manifest for deploying to a Kubernetes cluster.",
+			"confidence": "high"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
Improves the transcript-driven resource extraction script and ships 47 sample JSONs from the first backfill run (quota-limited at ~55 videos).

### Prompt + script changes
- **Stricter prompt.** First-pass output tagged every named tool ("Postgres", "Helm", "Jira", "AWS Lambda", "Docker for Mac") as a resource, even when the speaker was just naming context. The new prompt explicitly names what counts (specific repo, doc page, paper, RFC, book, post, talk, named demo) and excludes passing mentions. Hard cap dropped 10 → 5 to force selectivity.
- **URL scheme normalization.** Old model emitted bare hosts (`github.com/foo/bar`, `rawkode.chat`) which would fail `z.url()` on apply. Prompt now requires `https://`, and `normalizeUrl()` defensively prepends it if the model forgets.
- **Single-word title safety net.** Filter drops `title=single word + url=null` entries — almost always a passing tech mention that slipped past the prompt.

### Sample quality (before vs after)
| Video | Old | New |
|---|---|---|
| Teleport workshop | 8 entries incl. `Postgres`, `Civo Cloud`, `Teleport Cloud` | 4 entries, all real (Rawkode courses repo, Teleport docs, Beekeeper Studio, Rawkode Discord) |
| Lumigo microservice debugging | 8 entries incl. `Helm`, `Redis`, `Jira`, `Docker for Mac`, `AWS Lambda`, `ECS` | 1 entry: OpenTelemetry demo application |
| InfluxDB install tutorial | 6 entries | 3 entries (README, Helm chart, Docker image) |

URLs that DO come through now properly start with `https://` (verified: `https://github.com/rawkode-academy/courses`, `https://rawkode.chat`).

## Quota situation
The backfill run hit the daily Gemini CLI quota at ~55 videos. 47 JSONs landed; 268 errored on QUOTA_EXHAUSTED; 10 had no transcript. Reset is ~22h out from this PR.

## Test plan
- [ ] Skim a sample of the 47 JSONs under `content/scripts/output/resources/`. Spot-check evidence quotes against transcripts to confirm verbatim.
- [ ] Confirm no single-word + null-URL entries remain (the safety net dropped them).
- [ ] Confirm every emitted `url` starts with `https://`.

## Human action required
- **Review the 47 JSONs.** If the quality bar looks good, merge and rerun extraction tomorrow when quota resets (`cd content && bun run scripts/extract-video-resources.ts --max-parallel 5`). The script is resume-safe and will skip the 47 already done.
- **After all 321 are extracted:** review-edit JSONs as needed, then `--apply` to write `resources:` into video frontmatter. That's the next PR.
- **Consider a paid Gemini API key** if you intend to rerun extractions often. Free tier is ~50 prompts/day on this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)