### PR TITLE
content(videos): per-video subagent review for all 325 videos

### DIFF
--- a/content/scripts/quote-bad-descriptions.ts
+++ b/content/scripts/quote-bad-descriptions.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+// Quote any frontmatter `description:` value that contains an unquoted ": "
+// (colon-space) sequence — YAML treats that as a mapping key separator and
+// the file fails to parse.
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const VIDEOS_DIR = join(__dirname, "..", "videos");
+
+async function walk(dir: string): Promise<string[]> {
+	const out: string[] = [];
+	for (const entry of await readdir(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...(await walk(full)));
+		else if (entry.isFile() && /\.md$/.test(entry.name)) out.push(full);
+	}
+	return out;
+}
+
+let fixed = 0;
+for (const path of await walk(VIDEOS_DIR)) {
+	const raw = await readFile(path, "utf8");
+	// Look for the description line in the frontmatter
+	const m = raw.match(/^(description: )([^'>|"].*: .*)$/m);
+	if (!m) continue;
+	const value = m[2];
+	// Don't double-escape single quotes inside the value
+	const escaped = value.replace(/'/g, "''");
+	const newDesc = `description: '${escaped}'`;
+	const out = raw.replace(/^description: [^'>|"].*: .*$/m, newDesc);
+	if (out !== raw) {
+		await writeFile(path, out, "utf8");
+		fixed++;
+		console.log(`fixed ${path}`);
+	}
+}
+console.log(`\nDone. fixed=${fixed}`);

--- a/content/scripts/quote-descriptions.ts
+++ b/content/scripts/quote-descriptions.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+// One-off cleanup: some video frontmatters have `description:` lines that
+// contain a bare colon (e.g. "UI: Data") followed by a space. YAML treats that
+// as a key-value separator and the file fails to parse. Re-emit any such
+// description through gray-matter so it gets quoted/folded properly.
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const VIDEOS_DIR = join(__dirname, "..", "videos");
+
+async function walk(dir: string): Promise<string[]> {
+	const out: string[] = [];
+	for (const entry of await readdir(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...(await walk(full)));
+		else if (entry.isFile() && /\.md$/.test(entry.name)) out.push(full);
+	}
+	return out;
+}
+
+let fixed = 0;
+for (const path of await walk(VIDEOS_DIR)) {
+	const raw = await readFile(path, "utf8");
+	let parsed;
+	try {
+		parsed = matter(raw);
+	} catch (error) {
+		console.log(`UNPARSEABLE: ${path} — ${(error as Error).message}`);
+		continue;
+	}
+	const desc = (parsed.data as { description?: unknown }).description;
+	if (typeof desc !== "string") continue;
+	// gray-matter.stringify always emits a YAML-safe representation; if the
+	// current on-disk file already has a safely-quoted form, the rewrite
+	// is a no-op except for the description line.
+	const out = matter.stringify(parsed.content, parsed.data);
+	if (out !== raw) {
+		await writeFile(path, out, "utf8");
+		fixed++;
+		console.log(`fixed ${path}`);
+	}
+}
+console.log(`\nDone. fixed=${fixed}`);

--- a/content/videos/shows/cloud-native-compass/2023/ambient-mesh-with-marino-wijay-and-matt-turner.md
+++ b/content/videos/shows/cloud-native-compass/2023/ambient-mesh-with-marino-wijay-and-matt-turner.md
@@ -2,12 +2,16 @@
 id: u4zql5xiqn4tc11jnb7ith6t
 slug: ambient-mesh-with-marino-wijay-and-matt-turner
 title: Ambient Mesh with Marino Wijay & Matt Turner
-description: 'Curious about Istio''s new deployment mechanism, Ambient Mesh?'
+description: Marino Wijay and Matt Turner unpack Istio Ambient Mesh, walking through ztunnel, HBONE, and waypoint proxies, the trade-offs against sidecars, and how eBPF, CNI plugins, and the Gateway API fit into Istio's post-graduation future.
 publishedAt: 2023-08-04T17:00:00.000Z
 type: recorded
 category: interview
 technologies:
   - istio
+  - envoy
+  - cilium
+  - ebpf
+  - kubernetes
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -84,9 +88,11 @@ guests:
 resources:
   - title: Network Foundations workshop
     type: url
+    url: https://www.solo.io/academy
     category: documentation
   - title: Envoy Gateway
     type: url
+    url: https://gateway.envoyproxy.io/
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/ambient-mesh-with-marino-wijay-and-matt-turner.md
+++ b/content/videos/shows/cloud-native-compass/2023/ambient-mesh-with-marino-wijay-and-matt-turner.md
@@ -2,7 +2,11 @@
 id: u4zql5xiqn4tc11jnb7ith6t
 slug: ambient-mesh-with-marino-wijay-and-matt-turner
 title: Ambient Mesh with Marino Wijay & Matt Turner
-description: Marino Wijay and Matt Turner unpack Istio Ambient Mesh, walking through ztunnel, HBONE, and waypoint proxies, the trade-offs against sidecars, and how eBPF, CNI plugins, and the Gateway API fit into Istio's post-graduation future.
+description: >-
+  Marino Wijay and Matt Turner unpack Istio Ambient Mesh, walking through
+  ztunnel, HBONE, and waypoint proxies, the trade-offs against sidecars, and how
+  eBPF, CNI plugins, and the Gateway API fit into Istio's post-graduation
+  future.
 publishedAt: 2023-08-04T17:00:00.000Z
 type: recorded
 category: interview
@@ -88,11 +92,11 @@ guests:
 resources:
   - title: Network Foundations workshop
     type: url
-    url: https://www.solo.io/academy
+    url: 'https://www.solo.io/academy'
     category: documentation
   - title: Envoy Gateway
     type: url
-    url: https://gateway.envoyproxy.io/
+    url: 'https://gateway.envoyproxy.io/'
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/cloud-containers-and-kubernetes.md
+++ b/content/videos/shows/cloud-native-compass/2023/cloud-containers-and-kubernetes.md
@@ -4,9 +4,9 @@ slug: cloud-containers-and-kubernetes
 title: 'Cloud, Containers, & Kubernetes'
 description: >-
   Eli (Scaleway), Neil (Portainer), and Abdel (Google) join the inaugural Cloud
-  Native Compass to debate cloud pricing beyond the big three, whether Docker
-  is still trustworthy, WebAssembly's role alongside containers, and the rise
-  of internal developer portals like Backstage.
+  Native Compass to debate cloud pricing beyond the big three, whether Docker is
+  still trustworthy, WebAssembly's role alongside containers, and the rise of
+  internal developer portals like Backstage.
 publishedAt: 2023-05-21T17:00:00.000Z
 type: recorded
 category: interview

--- a/content/videos/shows/cloud-native-compass/2023/cloud-containers-and-kubernetes.md
+++ b/content/videos/shows/cloud-native-compass/2023/cloud-containers-and-kubernetes.md
@@ -3,12 +3,21 @@ id: b3oefzhoncogvr5cyijfckcj
 slug: cloud-containers-and-kubernetes
 title: 'Cloud, Containers, & Kubernetes'
 description: >-
-  Joined by Eli (Scaleway), Neil (Portainer), and Abdel (Google), we discuss all
-  things cloud computing, containers, and Kubernetes.
+  Eli (Scaleway), Neil (Portainer), and Abdel (Google) join the inaugural Cloud
+  Native Compass to debate cloud pricing beyond the big three, whether Docker
+  is still trustworthy, WebAssembly's role alongside containers, and the rise
+  of internal developer portals like Backstage.
 publishedAt: 2023-05-21T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
+  - docker
+  - webassembly
+  - docker-compose
+  - backstage
+  - portainer
+  - envoy
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -33,9 +42,11 @@ guests:
   - abdellfetah-sghiouar
 resources:
   - title: Kubernetes Podcast
+    url: 'https://kubernetespodcast.com/'
     type: url
     category: other
-  - title: Docker Compose for Kubernetes
+  - title: Kompose (Docker Compose for Kubernetes)
+    url: 'https://github.com/kubernetes/kompose'
     type: url
     category: code
 ---

--- a/content/videos/shows/cloud-native-compass/2023/event-driven-architectures-at-wix.md
+++ b/content/videos/shows/cloud-native-compass/2023/event-driven-architectures-at-wix.md
@@ -69,18 +69,18 @@ resources:
   - title: Wix Engineering Blog
     type: url
     category: other
-    url: https://www.wix.engineering/
+    url: 'https://www.wix.engineering/'
   - title: Confluent Schema Registry
     type: url
     category: documentation
-    url: https://docs.confluent.io/platform/current/schema-registry/index.html
+    url: 'https://docs.confluent.io/platform/current/schema-registry/index.html'
   - title: Natan Silnitsky website
     type: url
     category: other
-    url: https://www.natansil.com/
+    url: 'https://www.natansil.com/'
   - title: ZIO Scala library
     type: url
     category: code
-    url: https://zio.dev/
+    url: 'https://zio.dev/'
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/event-driven-architectures-at-wix.md
+++ b/content/videos/shows/cloud-native-compass/2023/event-driven-architectures-at-wix.md
@@ -3,12 +3,16 @@ id: rzoehfxdwc2ldk4xbxgmcdb9
 slug: event-driven-architectures-at-wix
 title: Event-Driven Architectures at Wix
 description: >-
-  In this episode of the Cloud Native Compass, host David Flanagan interviews
-  Natan from Wix Engineering about event-driven architectures.
+  Natan Silnitsky shares how Wix operates 2,500+ microservices and 70 billion
+  Kafka events per day. We cover when to choose event-driven over RPC, schema
+  evolution with Confluent Schema Registry and protobuf, Kafka cost
+  optimisation, polyglot services, and ZIO on the JVM.
 publishedAt: 2023-06-19T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
+  - grpc
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -65,14 +69,18 @@ resources:
   - title: Wix Engineering Blog
     type: url
     category: other
+    url: https://www.wix.engineering/
   - title: Confluent Schema Registry
     type: url
     category: documentation
+    url: https://docs.confluent.io/platform/current/schema-registry/index.html
   - title: Natan Silnitsky website
     type: url
     category: other
+    url: https://www.natansil.com/
   - title: ZIO Scala library
     type: url
     category: code
+    url: https://zio.dev/
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/influxdb-3-and-rust.md
+++ b/content/videos/shows/cloud-native-compass/2023/influxdb-3-and-rust.md
@@ -71,15 +71,19 @@ guests:
 resources:
   - title: Apache Arrow project
     type: url
+    url: 'https://arrow.apache.org/'
     category: code
   - title: Apache DataFusion project
     type: url
+    url: 'https://datafusion.apache.org/'
     category: code
   - title: Flux community fork
     type: url
+    url: 'https://github.com/InfluxCommunity/flux'
     category: code
   - title: HashiCorp license change to BSL
     type: url
+    url: 'https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/is-webassembly-the-future-of-cloud-native.md
+++ b/content/videos/shows/cloud-native-compass/2023/is-webassembly-the-future-of-cloud-native.md
@@ -11,6 +11,13 @@ type: recorded
 category: interview
 technologies:
   - webassembly
+  - kwasm
+  - spin
+  - wasm-edge-runtime
+  - wasmcloud
+  - docker
+  - kubernetes
+  - gimlet
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -52,7 +59,15 @@ guests:
 resources:
   - title: kwasm
     type: url
-    url: 'https://kwasm.sh'
+    url: 'https://kwasm.sh/'
     category: code
+  - title: WebAssembly
+    type: url
+    url: 'https://webassembly.org/'
+    category: documentation
+  - title: Gimlet
+    type: url
+    url: 'https://gimlet.io/'
+    category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/kubernetes-security-with-identity-and-oidc.md
+++ b/content/videos/shows/cloud-native-compass/2023/kubernetes-security-with-identity-and-oidc.md
@@ -4,9 +4,9 @@ slug: kubernetes-security-with-identity-and-oidc
 title: Kubernetes Security with Identity & OIDC
 description: >-
   Marc Boorshtein, CTO of Tremolo Security, explains why long-lived kubeconfig
-  certificates are an anti-pattern, how OIDC and impersonation deliver
-  revocable cluster access, and how workflow identity via OIDC JWTs replaces
-  static service account tokens in CI/CD pipelines.
+  certificates are an anti-pattern, how OIDC and impersonation deliver revocable
+  cluster access, and how workflow identity via OIDC JWTs replaces static
+  service account tokens in CI/CD pipelines.
 publishedAt: 2023-05-29T17:00:00.000Z
 type: recorded
 category: interview

--- a/content/videos/shows/cloud-native-compass/2023/kubernetes-security-with-identity-and-oidc.md
+++ b/content/videos/shows/cloud-native-compass/2023/kubernetes-security-with-identity-and-oidc.md
@@ -3,14 +3,16 @@ id: ratw2atcqa376ktfpvj2joo4
 slug: kubernetes-security-with-identity-and-oidc
 title: Kubernetes Security with Identity & OIDC
 description: >-
-  I interview Mark Boorshtein, the CTO of Tremolo Security, an open-source
-  identity management company that focuses on authentication, authorization,
-  identity, and automation.
+  Marc Boorshtein, CTO of Tremolo Security, explains why long-lived kubeconfig
+  certificates are an anti-pattern, how OIDC and impersonation deliver
+  revocable cluster access, and how workflow identity via OIDC JWTs replaces
+  static service account tokens in CI/CD pipelines.
 publishedAt: 2023-05-29T17:00:00.000Z
 type: recorded
 category: interview
 technologies:
   - kubernetes
+  - openunison
 show: cloud-native-compass
 chapters:
   - startTime: 0

--- a/content/videos/shows/cloud-native-compass/2023/migrating-to-kubernetes.md
+++ b/content/videos/shows/cloud-native-compass/2023/migrating-to-kubernetes.md
@@ -69,31 +69,31 @@ guests:
 resources:
   - title: Argo CD
     type: url
-    url: https://argoproj.github.io/cd/
+    url: 'https://argoproj.github.io/cd/'
     category: code
   - title: DevSpace
     type: url
-    url: https://devspace.sh/
+    url: 'https://devspace.sh/'
     category: code
   - title: Flux
     type: url
-    url: https://fluxcd.io/
+    url: 'https://fluxcd.io/'
     category: code
   - title: Helm
     type: url
-    url: https://helm.sh/
+    url: 'https://helm.sh/'
     category: code
   - title: Kustomize
     type: url
-    url: https://kustomize.io/
+    url: 'https://kustomize.io/'
     category: code
   - title: KEDA
     type: url
-    url: https://keda.sh/
+    url: 'https://keda.sh/'
     category: code
   - title: Crossplane
     type: url
-    url: https://www.crossplane.io/
+    url: 'https://www.crossplane.io/'
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/migrating-to-kubernetes.md
+++ b/content/videos/shows/cloud-native-compass/2023/migrating-to-kubernetes.md
@@ -3,14 +3,21 @@ id: st3tvvzjqscd51gam6o0h5jv
 slug: migrating-to-kubernetes
 title: Migrating to Kubernetes
 description: >-
-  In this episode, Rachel shares her journey into tech and how she ended up in
-  the Kubernetes space. She did not have a traditional IT background, but she
-  was always interested in computers and programming.
+  Rachel Sweeney shares Built Technologies' migration to Kubernetes: when (and
+  when not) to adopt it, taming developer experience with DevSpace, and the
+  ecosystem of Argo CD, Flux, Helm, Kustomize, KEDA, and Crossplane that powers
+  their platform.
 publishedAt: 2023-05-22T17:00:00.000Z
 type: recorded
 category: interview
 technologies:
   - kubernetes
+  - argo
+  - devspace
+  - fluxcd
+  - helm
+  - keda
+  - crossplane
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -62,6 +69,31 @@ guests:
 resources:
   - title: Argo CD
     type: url
+    url: https://argoproj.github.io/cd/
+    category: code
+  - title: DevSpace
+    type: url
+    url: https://devspace.sh/
+    category: code
+  - title: Flux
+    type: url
+    url: https://fluxcd.io/
+    category: code
+  - title: Helm
+    type: url
+    url: https://helm.sh/
+    category: code
+  - title: Kustomize
+    type: url
+    url: https://kustomize.io/
+    category: code
+  - title: KEDA
+    type: url
+    url: https://keda.sh/
+    category: code
+  - title: Crossplane
+    type: url
+    url: https://www.crossplane.io/
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/server-side-webassembly.md
+++ b/content/videos/shows/cloud-native-compass/2023/server-side-webassembly.md
@@ -3,12 +3,22 @@ id: ypthw3fx8bmyo8cdfywuewog
 slug: server-side-webassembly
 title: Server-Side WebAssembly
 description: >-
-  In this episode of the Cloud Native Compass podcast, the guests discuss
-  WebAssembly and server-side WebAssembly.
+  Kate Goldenring (Fermyon), Connor Hicks (Suborbital), and Kevin Hoffman
+  (Cosmonic/wasmCloud) explore server-side WebAssembly: WASI, the component
+  model, runtimes, and how Wasm sits alongside containers and Kubernetes.
 publishedAt: 2023-05-08T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - webassembly
+  - wasmcloud
+  - suborbital
+  - spin
+  - akri
+  - kubernetes
+  - docker
+  - containerd
+  - rust
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -62,19 +72,25 @@ guests:
   - connor-hicks
   - kevin-hoffman
 resources:
-  - title: WasmCloud open source project
+  - title: wasmCloud open source project
     type: url
+    url: 'https://wasmcloud.com'
     category: code
   - title: Programming WebAssembly with Rust
     type: url
+    url: 'https://pragprog.com/titles/khrust/programming-webassembly-with-rust/'
     category: other
-  - title: Fermion
+  - title: Fermyon
     type: url
-    url: 'https://fermion.com'
+    url: 'https://www.fermyon.com/'
     category: other
   - title: Suborbital
     type: url
     url: 'https://suborbital.dev'
+    category: other
+  - title: Cosmonic
+    type: url
+    url: 'https://cosmonic.com'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/the-magic-of-ebpf.md
+++ b/content/videos/shows/cloud-native-compass/2023/the-magic-of-ebpf.md
@@ -3,13 +3,16 @@ id: cxwpwr732hsc2olh2072h59i
 slug: the-magic-of-ebpf
 title: The Magic of eBPF
 description: >-
-  We're back with an exciting new episode of Cloud Native Compass, and this time
-  we're diving deep into the captivating world of eBPF.
+  Liz Rice explains how eBPF lets you safely run programs inside the Linux
+  kernel, why the verifier makes it safer than kernel modules, and how projects
+  like Cilium, Falco, and Pixie are using it for networking, security, and
+  observability.
 publishedAt: 2023-08-25T17:00:00.000Z
 type: recorded
 category: interview
 technologies:
   - ebpf
+  - cilium
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -83,15 +86,19 @@ guests:
 resources:
   - title: Learning eBPF
     type: url
+    url: 'https://www.oreilly.com/library/view/learning-ebpf/9781098135119/'
     category: other
-  - title: eBPF Summit
+  - title: eBPF Summit 2023
     type: url
+    url: 'https://ebpf.io/summit-2023/'
     category: other
   - title: Iovisor BCC tools
     type: url
+    url: 'https://github.com/iovisor/bcc'
     category: code
   - title: OpenSnoop and ExecSnoop
     type: url
+    url: 'https://github.com/iovisor/bcc/blob/master/tools/opensnoop_example.txt'
     category: demos
 ---
 

--- a/content/videos/shows/cloud-native-compass/2023/trust-and-validation-in-ai.md
+++ b/content/videos/shows/cloud-native-compass/2023/trust-and-validation-in-ai.md
@@ -5,8 +5,8 @@ title: Trust and Validation in AI
 description: >-
   JJ Asgar joins to discuss IBM watsonx.ai and why enterprises distrust today's
   black-box AI. The conversation covers training data provenance, The Pile,
-  Hugging Face, hallucinations, copyright, and the human problem of verifying
-  AI outputs.
+  Hugging Face, hallucinations, copyright, and the human problem of verifying AI
+  outputs.
 publishedAt: 2023-11-01T17:00:00.000Z
 type: recorded
 category: interview

--- a/content/videos/shows/cloud-native-compass/2023/trust-and-validation-in-ai.md
+++ b/content/videos/shows/cloud-native-compass/2023/trust-and-validation-in-ai.md
@@ -3,9 +3,10 @@ id: ce0y3h3wgv2vt9m4rcux1s7x
 slug: trust-and-validation-in-ai
 title: Trust and Validation in AI
 description: >-
-  1️⃣ The People Problem: Laura Santamaria raises an important concern about
-  verifying AI-generated outputs and tackling the challenge of the "people
-  problem" in AI development.
+  JJ Asgar joins to discuss IBM watsonx.ai and why enterprises distrust today's
+  black-box AI. The conversation covers training data provenance, The Pile,
+  Hugging Face, hallucinations, copyright, and the human problem of verifying
+  AI outputs.
 publishedAt: 2023-11-01T17:00:00.000Z
 type: recorded
 category: interview
@@ -87,12 +88,14 @@ resources:
     category: documentation
   - title: The Pile AI dataset
     type: url
+    url: 'https://pile.eleuther.ai/'
     category: other
   - title: FOSSY working session Etherpad notes on AI data provenance
     type: url
     category: other
   - title: Hugging Face
     type: url
+    url: 'https://huggingface.co/'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/ai-augmented-programming.md
+++ b/content/videos/shows/cloud-native-compass/2025/ai-augmented-programming.md
@@ -19,11 +19,11 @@ guests: []
 resources:
   - title: Rawkode Academy mono repository
     type: url
-    url: https://github.com/rawkode-academy/rawkode-academy
+    url: 'https://github.com/rawkode-academy/rawkode-academy'
     category: code
   - title: Comtrya dotfile management tool
     type: url
-    url: https://comtrya.dev
+    url: 'https://comtrya.dev'
     category: code
   - title: IBM Granite episode
     type: url

--- a/content/videos/shows/cloud-native-compass/2025/ai-augmented-programming.md
+++ b/content/videos/shows/cloud-native-compass/2025/ai-augmented-programming.md
@@ -3,14 +3,15 @@ id: xy48jlregckbk64dc6gqbq1l
 slug: ai-augmented-programming
 title: AI-Augmented Programming
 description: >-
-  Ever wondered how AI is changing the way we code? Laura and David break it
-  down in this episode of Smart Coding. From real-world examples to the
-  surprising environmental impact of AI tools, they cover it all—with a few
-  personal stories thrown in.
+  Laura quizzes David on how he uses Claude as a CLI coding partner across the
+  Rawkode Academy monorepo, why he calls it smart coding rather than vibe
+  coding, and the trade-offs around productivity, skill atrophy, and the
+  environmental cost of AI tools.
 publishedAt: 2025-06-26T10:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - comtrya
 show: cloud-native-compass
 duration: 2518
 audioFileSize: 60425030
@@ -18,9 +19,11 @@ guests: []
 resources:
   - title: Rawkode Academy mono repository
     type: url
+    url: https://github.com/rawkode-academy/rawkode-academy
     category: code
   - title: Comtrya dotfile management tool
     type: url
+    url: https://comtrya.dev
     category: code
   - title: IBM Granite episode
     type: url

--- a/content/videos/shows/cloud-native-compass/2025/atlantis-the-terraform-automation-powerhouse.md
+++ b/content/videos/shows/cloud-native-compass/2025/atlantis-the-terraform-automation-powerhouse.md
@@ -3,13 +3,17 @@ id: xz8t49tipn0ol7mjxdexva0r
 slug: atlantis-the-terraform-automation-powerhouse
 title: 'Atlantis: The Terraform Automation Powerhouse'
 description: >-
-  In this episode David and Laura explore the world of Atlantis, the Terraform
-  automation tool, with special guest Jose (PePe) Amengual, a core contributor
-  and maintainer of the Atlantis project.
+  Pepe Amengual, a core maintainer of Atlantis, joins David and Laura to walk
+  through the Terraform pull request automation server: how it runs plan and
+  apply from PR comments, OpenTofu support, the path to 1.0, and the security
+  model around credentials.
 publishedAt: 2025-04-03T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - atlantis
+  - terraform
+  - opentofu
 show: cloud-native-compass
 duration: 2371
 audioFileSize: 56911135
@@ -19,11 +23,14 @@ resources:
   - title: Project Atlantis
     type: url
     category: code
+    url: https://github.com/runatlantis/atlantis
   - title: Atlantis OpenTofu support blog post
     type: url
     category: other
+    url: https://www.runatlantis.io/blog/2024/integrating-atlantis-with-opentofu
   - title: Atlantis Helm chart
     type: url
     category: code
+    url: https://github.com/runatlantis/helm-charts
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/atlantis-the-terraform-automation-powerhouse.md
+++ b/content/videos/shows/cloud-native-compass/2025/atlantis-the-terraform-automation-powerhouse.md
@@ -23,14 +23,14 @@ resources:
   - title: Project Atlantis
     type: url
     category: code
-    url: https://github.com/runatlantis/atlantis
+    url: 'https://github.com/runatlantis/atlantis'
   - title: Atlantis OpenTofu support blog post
     type: url
     category: other
-    url: https://www.runatlantis.io/blog/2024/integrating-atlantis-with-opentofu
+    url: 'https://www.runatlantis.io/blog/2024/integrating-atlantis-with-opentofu'
   - title: Atlantis Helm chart
     type: url
     category: code
-    url: https://github.com/runatlantis/helm-charts
+    url: 'https://github.com/runatlantis/helm-charts'
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/cloud-server-side-webassembly.md
+++ b/content/videos/shows/cloud-native-compass/2025/cloud-server-side-webassembly.md
@@ -3,14 +3,18 @@ id: e683nfwoau6e8epn8g9zmwn9
 slug: cloud-server-side-webassembly
 title: Cloud Server-Side WebAssembly
 description: >-
-  In this episode, David and Laura catch up with Mikkel Mørk Hegnhøj from
-  Fermyon to break down the latest in WebAssembly. They'll cover how it's
-  changing cloud computing, what's new with Spin and WASI, and why devs should
-  care. Tune in for some great insights!
+  Mikkel Mørk Hegnhøj from Fermyon joins David and Laura to unpack Spin 3.0,
+  WASI 0.3, and the WebAssembly component model. They cover running Wasm on
+  Kubernetes via SpinKube, polyglot components, and built-in OpenTelemetry.
 publishedAt: 2025-02-28T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - webassembly
+  - spin
+  - spinkube
+  - kubernetes
+  - opentelemetry
 show: cloud-native-compass
 duration: 2296
 audioFileSize: 55097401
@@ -54,9 +58,23 @@ guests:
 resources:
   - title: Spin OpenTelemetry plugin
     type: url
+    url: https://github.com/spinframework/spin-plugins
     category: code
   - title: Wasm I/O
     type: url
+    url: https://wasm.io/
     category: other
+  - title: Spin
+    type: url
+    url: https://spinframework.dev/
+    category: documentation
+  - title: SpinKube
+    type: url
+    url: https://www.spinkube.dev/
+    category: documentation
+  - title: Spin observability docs
+    type: url
+    url: https://spinframework.dev/v3/observing-apps
+    category: documentation
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/cloud-server-side-webassembly.md
+++ b/content/videos/shows/cloud-native-compass/2025/cloud-server-side-webassembly.md
@@ -58,23 +58,23 @@ guests:
 resources:
   - title: Spin OpenTelemetry plugin
     type: url
-    url: https://github.com/spinframework/spin-plugins
+    url: 'https://github.com/spinframework/spin-plugins'
     category: code
   - title: Wasm I/O
     type: url
-    url: https://wasm.io/
+    url: 'https://wasm.io/'
     category: other
   - title: Spin
     type: url
-    url: https://spinframework.dev/
+    url: 'https://spinframework.dev/'
     category: documentation
   - title: SpinKube
     type: url
-    url: https://www.spinkube.dev/
+    url: 'https://www.spinkube.dev/'
     category: documentation
   - title: Spin observability docs
     type: url
-    url: https://spinframework.dev/v3/observing-apps
+    url: 'https://spinframework.dev/v3/observing-apps'
     category: documentation
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/dapr-the-future-of-microservices.md
+++ b/content/videos/shows/cloud-native-compass/2025/dapr-the-future-of-microservices.md
@@ -21,22 +21,22 @@ guests:
 resources:
   - title: State of Dapr Report 2025
     type: url
-    url: https://www.diagrid.io/blog/state-of-dapr-2025
+    url: 'https://www.diagrid.io/blog/state-of-dapr-2025'
     category: other
   - title: Carl Hewitt actor model paper
     type: url
     category: other
   - title: Dapr Agents framework
     type: url
-    url: https://github.com/dapr/dapr-agents
+    url: 'https://github.com/dapr/dapr-agents'
     category: code
   - title: Diagrid Conductor
     type: url
-    url: https://www.diagrid.io/conductor
+    url: 'https://www.diagrid.io/conductor'
     category: other
   - title: Diagrid Catalyst
     type: url
-    url: https://www.diagrid.io/catalyst
+    url: 'https://www.diagrid.io/catalyst'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/dapr-the-future-of-microservices.md
+++ b/content/videos/shows/cloud-native-compass/2025/dapr-the-future-of-microservices.md
@@ -3,14 +3,16 @@ id: xnmoo3urafyt4khqozj6d0af
 slug: dapr-the-future-of-microservices
 title: 'Dapr: The Future of Microservices'
 description: >-
-  In this episode of Cloud Native Compass, host David Flanagan is joined by Mark
-  Fussell, co-founder and CEO of Diagrid, to discuss the intricacies of Dapr and
-  its role in microservices and distributed systems. They delve into the actor
-  model, the new Dapr Agents, and much more.
+  Mark Fussell, CEO of Diagrid, explains how Dapr's building blocks (pub/sub,
+  state, workflows, virtual actors) tame microservice complexity, and how Dapr
+  Agents extends that same actor and durable-workflow model to agentic LLM
+  systems.
 publishedAt: 2025-03-21T12:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - dapr
+  - kubernetes
 show: cloud-native-compass
 duration: 3189
 audioFileSize: 76517386
@@ -19,18 +21,22 @@ guests:
 resources:
   - title: State of Dapr Report 2025
     type: url
+    url: https://www.diagrid.io/blog/state-of-dapr-2025
     category: other
   - title: Carl Hewitt actor model paper
     type: url
     category: other
   - title: Dapr Agents framework
     type: url
+    url: https://github.com/dapr/dapr-agents
     category: code
   - title: Diagrid Conductor
     type: url
-    category: demos
+    url: https://www.diagrid.io/conductor
+    category: other
   - title: Diagrid Catalyst
     type: url
-    category: demos
+    url: https://www.diagrid.io/catalyst
+    category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/flatcar-linux-a-modern-os-for-the-always-on-infrastructure.md
+++ b/content/videos/shows/cloud-native-compass/2025/flatcar-linux-a-modern-os-for-the-always-on-infrastructure.md
@@ -52,19 +52,19 @@ guests:
 resources:
   - title: Flatcar Getting Started documentation
     type: url
-    url: https://www.flatcar.org/docs/latest/
+    url: 'https://www.flatcar.org/docs/latest/'
     category: documentation
   - title: Flatcar SysExt Bakery
     type: url
-    url: https://github.com/flatcar/sysext-bakery
+    url: 'https://github.com/flatcar/sysext-bakery'
     category: code
   - title: Flatcar Linux update operator
     type: url
-    url: https://github.com/flatcar/flatcar-linux-update-operator
+    url: 'https://github.com/flatcar/flatcar-linux-update-operator'
     category: code
   - title: libguestfs tools
     type: url
-    url: https://libguestfs.org/
+    url: 'https://libguestfs.org/'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/flatcar-linux-a-modern-os-for-the-always-on-infrastructure.md
+++ b/content/videos/shows/cloud-native-compass/2025/flatcar-linux-a-modern-os-for-the-always-on-infrastructure.md
@@ -3,14 +3,20 @@ id: luwalhnnh9j8wt1tab5de6wx
 slug: flatcar-linux-a-modern-os-for-the-always-on-infrastructure
 title: 'Flatcar Linux: A Modern OS for the Always-On Infrastructure'
 description: >-
-  In this episode, we dive deep into Flatcar Linux, an immutable Linux
-  distribution designed for always-on infrastructures. The discussion covers the
-  architecture and features of Flatcar, including its self-updating capabilities
-  and minimal attack surface.
+  Flatcar maintainers Thilo, Mathieu, and Chewy explain the immutable A/B
+  partition layout, Ignition provisioning, systemd-sysext for Kubernetes,
+  LUKS/TPM disk encryption, and how Nebraska coordinates monthly fleet updates
+  without SSH.
 publishedAt: 2025-10-15T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - flatcar
+  - kubernetes
+  - containerd
+  - docker
+  - prometheus
+  - kured
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -46,15 +52,19 @@ guests:
 resources:
   - title: Flatcar Getting Started documentation
     type: url
+    url: https://www.flatcar.org/docs/latest/
     category: documentation
-  - title: Flatcar SysEx Bakery
+  - title: Flatcar SysExt Bakery
     type: url
+    url: https://github.com/flatcar/sysext-bakery
     category: code
   - title: Flatcar Linux update operator
     type: url
+    url: https://github.com/flatcar/flatcar-linux-update-operator
     category: code
   - title: libguestfs tools
     type: url
+    url: https://libguestfs.org/
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/from-kubernetes-to-cloud-run-chainguards-journey.md
+++ b/content/videos/shows/cloud-native-compass/2025/from-kubernetes-to-cloud-run-chainguards-journey.md
@@ -3,12 +3,18 @@ id: hbkqmiw7xfe2dxrarck938yl
 slug: from-kubernetes-to-cloud-run-chainguards-journey
 title: 'From Kubernetes to Cloud Run: Chainguard''s Journey'
 description: >-
-  In this episode of the Cloud Native Compass podcast, hosts David Flanagan and
-  Laura Santamaria chat with Jason Hall, Principal Engineer at Chainguard.
+  Jason Hall walks through Chainguard's migration of its image-serving
+  infrastructure from Kubernetes and Knative to Google Cloud Run, covering
+  multi-region Terraform modules, least-privilege IAM, R2 for blob storage, and
+  BigQuery-backed event logging.
 publishedAt: 2025-01-16T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
+  - knative
+  - terraform
+  - opentofu
 show: cloud-native-compass
 chapters:
   - startTime: 0
@@ -49,5 +55,9 @@ resources:
       Cloud Run
     type: url
     category: other
+  - title: chainguard-dev/terraform-infra-common
+    url: 'https://github.com/chainguard-dev/terraform-infra-common'
+    type: url
+    category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/java-for-serverless-functions.md
+++ b/content/videos/shows/cloud-native-compass/2025/java-for-serverless-functions.md
@@ -3,17 +3,51 @@ id: xxti5u3ooj17j37cavljrukn
 slug: java-for-serverless-functions
 title: Java for Serverless Functions
 description: >-
-  In this episode of Cloud Native Compass, hosts Laura and David explore the
-  world of Java for serverless functions with special guest Otávio Santana.
+  Otavio Santana joins Laura and David to dispel myths about modern Java on
+  Kubernetes. They cover JVM container awareness, GraalVM native compilation
+  for serverless cold starts, and frameworks like Quarkus and Spring.
 publishedAt: 2025-03-27T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
 show: cloud-native-compass
 duration: 1777
 audioFileSize: 42648905
 guests:
   - otavio-santana
-resources: []
+resources:
+  - type: url
+    title: Otavio Santana's website
+    category: other
+    url: https://otaviojava.com/
+  - type: url
+    title: GraalVM
+    category: documentation
+    url: https://www.graalvm.org/
+  - type: url
+    title: Quarkus
+    category: documentation
+    url: https://quarkus.io/
+  - type: url
+    title: Spring
+    category: documentation
+    url: https://spring.io/
+  - type: url
+    title: Micronaut
+    category: documentation
+    url: https://micronaut.io/
+  - type: url
+    title: Jakarta EE (Eclipse Foundation)
+    category: documentation
+    url: https://jakarta.ee/
+  - type: url
+    title: OpenJDK
+    category: documentation
+    url: https://openjdk.org/
+  - type: url
+    title: Java Community Process (JCP)
+    category: other
+    url: https://www.jcp.org/
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/java-for-serverless-functions.md
+++ b/content/videos/shows/cloud-native-compass/2025/java-for-serverless-functions.md
@@ -4,8 +4,8 @@ slug: java-for-serverless-functions
 title: Java for Serverless Functions
 description: >-
   Otavio Santana joins Laura and David to dispel myths about modern Java on
-  Kubernetes. They cover JVM container awareness, GraalVM native compilation
-  for serverless cold starts, and frameworks like Quarkus and Spring.
+  Kubernetes. They cover JVM container awareness, GraalVM native compilation for
+  serverless cold starts, and frameworks like Quarkus and Spring.
 publishedAt: 2025-03-27T17:00:00.000Z
 type: recorded
 category: interview
@@ -20,34 +20,34 @@ resources:
   - type: url
     title: Otavio Santana's website
     category: other
-    url: https://otaviojava.com/
+    url: 'https://otaviojava.com/'
   - type: url
     title: GraalVM
     category: documentation
-    url: https://www.graalvm.org/
+    url: 'https://www.graalvm.org/'
   - type: url
     title: Quarkus
     category: documentation
-    url: https://quarkus.io/
+    url: 'https://quarkus.io/'
   - type: url
     title: Spring
     category: documentation
-    url: https://spring.io/
+    url: 'https://spring.io/'
   - type: url
     title: Micronaut
     category: documentation
-    url: https://micronaut.io/
+    url: 'https://micronaut.io/'
   - type: url
     title: Jakarta EE (Eclipse Foundation)
     category: documentation
-    url: https://jakarta.ee/
+    url: 'https://jakarta.ee/'
   - type: url
     title: OpenJDK
     category: documentation
-    url: https://openjdk.org/
+    url: 'https://openjdk.org/'
   - type: url
     title: Java Community Process (JCP)
     category: other
-    url: https://www.jcp.org/
+    url: 'https://www.jcp.org/'
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/navigating-kairos-immutable-operating-systems-with-a-cloud-native-twist.md
+++ b/content/videos/shows/cloud-native-compass/2025/navigating-kairos-immutable-operating-systems-with-a-cloud-native-twist.md
@@ -53,23 +53,23 @@ guests:
 resources:
   - title: Kairos website
     type: url
-    url: https://kairos.io
+    url: 'https://kairos.io'
     category: documentation
   - title: Kairos on GitHub
     type: url
-    url: https://github.com/kairos-io/kairos
+    url: 'https://github.com/kairos-io/kairos'
     category: code
   - title: kairos-init
     type: url
-    url: https://github.com/kairos-io/kairos-init
+    url: 'https://github.com/kairos-io/kairos-init'
     category: code
   - title: SUSE Elemental Toolkit
     type: url
-    url: https://github.com/rancher/elemental-toolkit
+    url: 'https://github.com/rancher/elemental-toolkit'
     category: code
   - title: bootc project
     type: url
-    url: https://github.com/bootc-dev/bootc
+    url: 'https://github.com/bootc-dev/bootc'
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/navigating-kairos-immutable-operating-systems-with-a-cloud-native-twist.md
+++ b/content/videos/shows/cloud-native-compass/2025/navigating-kairos-immutable-operating-systems-with-a-cloud-native-twist.md
@@ -3,13 +3,16 @@ id: cpx1b17zh33oo8i72zptib9n
 slug: navigating-kairos-immutable-operating-systems-with-a-cloud-native-twist
 title: 'Navigating Kairos: Immutable Operating Systems with a Cloud Native Twist'
 description: >-
-  In this episode, we dive into the Kairos project, a CNCF initiative aimed at
-  converting any Linux distribution into an immutable operating system.
+  Mauro Morales and Dimitris Karakasilis explain how Kairos turns any Linux
+  distribution into an immutable, A/B-upgradeable OS shipped as an OCI image,
+  and where it fits alongside bootc and other immutable system efforts.
 publishedAt: 2025-12-18T10:00:00.000Z
 type: recorded
 category: interview
 technologies:
   - kairos
+  - bootc
+  - kubernetes
 show: cloud-native-compass
 duration: 2399
 audioFileSize: 57588862
@@ -48,11 +51,25 @@ guests:
   - mauro-morales
   - dimitris-karakasilis
 resources:
+  - title: Kairos website
+    type: url
+    url: https://kairos.io
+    category: documentation
+  - title: Kairos on GitHub
+    type: url
+    url: https://github.com/kairos-io/kairos
+    category: code
+  - title: kairos-init
+    type: url
+    url: https://github.com/kairos-io/kairos-init
+    category: code
   - title: SUSE Elemental Toolkit
     type: url
+    url: https://github.com/rancher/elemental-toolkit
     category: code
   - title: bootc project
     type: url
+    url: https://github.com/bootc-dev/bootc
     category: code
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/navigating-kubernetes-insights-challenges-and-the-release-cycle-with-kat-cosgrove.md
+++ b/content/videos/shows/cloud-native-compass/2025/navigating-kubernetes-insights-challenges-and-the-release-cycle-with-kat-cosgrove.md
@@ -6,9 +6,9 @@ title: >-
   Navigating Kubernetes: Insights, Challenges, and the Release Cycle with Kat
   Cosgrove
 description: >-
-  Kat Cosgrove joins David and Laura to unpack how SIG Release ships
-  Kubernetes: team structure, CI signal, bug triage, press embargoes,
-  maintainer burnout, and why a Kubernetes 2.0 is unlikely.
+  Kat Cosgrove joins David and Laura to unpack how SIG Release ships Kubernetes:
+  team structure, CI signal, bug triage, press embargoes, maintainer burnout,
+  and why a Kubernetes 2.0 is unlikely.
 publishedAt: 2025-01-30T17:00:00.000Z
 type: recorded
 category: interview
@@ -63,19 +63,19 @@ guests:
 resources:
   - title: Kubernetes website repository
     type: url
-    url: https://github.com/kubernetes/website
+    url: 'https://github.com/kubernetes/website'
     category: code
   - title: Kubernetes enhancements repository
     type: url
-    url: https://github.com/kubernetes/enhancements
+    url: 'https://github.com/kubernetes/enhancements'
     category: code
   - title: SIG Release
     type: url
-    url: https://github.com/kubernetes/sig-release
+    url: 'https://github.com/kubernetes/sig-release'
     category: code
   - title: Cloud Native Compass
     type: url
-    url: https://cloudnativecompass.fm/
+    url: 'https://cloudnativecompass.fm/'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/navigating-kubernetes-insights-challenges-and-the-release-cycle-with-kat-cosgrove.md
+++ b/content/videos/shows/cloud-native-compass/2025/navigating-kubernetes-insights-challenges-and-the-release-cycle-with-kat-cosgrove.md
@@ -6,13 +6,14 @@ title: >-
   Navigating Kubernetes: Insights, Challenges, and the Release Cycle with Kat
   Cosgrove
 description: >-
-  In this episode of Cloud Native Compass, hosts David Flanagan and Laura
-  Santamaria dive deep into the complexities of the Kubernetes release cycle
-  with guest Kat Cosgrove.
+  Kat Cosgrove joins David and Laura to unpack how SIG Release ships
+  Kubernetes: team structure, CI signal, bug triage, press embargoes,
+  maintainer burnout, and why a Kubernetes 2.0 is unlikely.
 publishedAt: 2025-01-30T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
 show: cloud-native-compass
 duration: 2366
 audioFileSize: 56784493
@@ -62,9 +63,19 @@ guests:
 resources:
   - title: Kubernetes website repository
     type: url
+    url: https://github.com/kubernetes/website
     category: code
   - title: Kubernetes enhancements repository
     type: url
+    url: https://github.com/kubernetes/enhancements
     category: code
+  - title: SIG Release
+    type: url
+    url: https://github.com/kubernetes/sig-release
+    category: code
+  - title: Cloud Native Compass
+    type: url
+    url: https://cloudnativecompass.fm/
+    category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/observability-for-developers.md
+++ b/content/videos/shows/cloud-native-compass/2025/observability-for-developers.md
@@ -24,23 +24,24 @@ guests:
 resources:
   - title: OpenTelemetry docs
     type: url
-    url: https://opentelemetry.io/docs/
+    url: 'https://opentelemetry.io/docs/'
     category: documentation
-  - title: 'Fundamentals of Observability with OpenTelemetry (O''Reilly video course)'
+  - title: Fundamentals of Observability with OpenTelemetry (O'Reilly video course)
     type: url
-    url: https://www.oreilly.com/library/view/fundamentals-of-observability/0636920926597/
+    url: >-
+      https://www.oreilly.com/library/view/fundamentals-of-observability/0636920926597/
     category: other
   - title: Build a custom Collector with OpenTelemetry Collector Builder
     type: url
-    url: https://opentelemetry.io/docs/collector/extend/ocb/
+    url: 'https://opentelemetry.io/docs/collector/extend/ocb/'
     category: documentation
-  - title: 'Thinking about contributing to OpenTelemetry? Here''s how I did it.'
+  - title: Thinking about contributing to OpenTelemetry? Here's how I did it.
     type: url
-    url: https://opentelemetry.io/blog/2023/contributing-to-otel/
+    url: 'https://opentelemetry.io/blog/2023/contributing-to-otel/'
     category: other
-  - title: 'Learning OpenTelemetry by Ted Young and Austin Parker (O''Reilly)'
+  - title: Learning OpenTelemetry by Ted Young and Austin Parker (O'Reilly)
     type: url
-    url: https://www.oreilly.com/library/view/learning-opentelemetry/9781098147174/
+    url: 'https://www.oreilly.com/library/view/learning-opentelemetry/9781098147174/'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/observability-for-developers.md
+++ b/content/videos/shows/cloud-native-compass/2025/observability-for-developers.md
@@ -3,13 +3,19 @@ id: ftzk1o7srttxqo5z9vdpjrxs
 slug: observability-for-developers
 title: 'Observability for Developers: What You Need to Know?'
 description: >-
-  In this episode, we discuss the intricacies of observability in microservices
-  with Adriana Villela, a principal developer advocate at Dynatrace and an
-  OpenTelemetry maintainer.
+  Adriana Villela explains why developers, not observability teams, should
+  instrument their own code. We cover OpenTelemetry's auto vs manual
+  instrumentation, sampling and cost trade-offs, single-pane-of-glass backends,
+  and the environmental impact of telemetry.
 publishedAt: 2025-06-19T10:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - opentelemetry
+  - jaeger
+  - prometheus
+  - grafana
+  - loki
 show: cloud-native-compass
 duration: 2922
 audioFileSize: 70129415
@@ -18,18 +24,23 @@ guests:
 resources:
   - title: OpenTelemetry docs
     type: url
+    url: https://opentelemetry.io/docs/
     category: documentation
-  - title: O'Reilly video course on observability with OpenTelemetry
+  - title: 'Fundamentals of Observability with OpenTelemetry (O''Reilly video course)'
     type: url
+    url: https://www.oreilly.com/library/view/fundamentals-of-observability/0636920926597/
     category: other
-  - title: OpenTelemetry Collector Builder docs
+  - title: Build a custom Collector with OpenTelemetry Collector Builder
     type: url
+    url: https://opentelemetry.io/docs/collector/extend/ocb/
     category: documentation
-  - title: How to contribute to OpenTelemetry blog post
+  - title: 'Thinking about contributing to OpenTelemetry? Here''s how I did it.'
     type: url
+    url: https://opentelemetry.io/blog/2023/contributing-to-otel/
     category: other
-  - title: Ted Young and Austin Parker book on OpenTelemetry
+  - title: 'Learning OpenTelemetry by Ted Young and Austin Parker (O''Reilly)'
     type: url
+    url: https://www.oreilly.com/library/view/learning-opentelemetry/9781098147174/
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/platform-engineering-asking-why.md
+++ b/content/videos/shows/cloud-native-compass/2025/platform-engineering-asking-why.md
@@ -6,17 +6,39 @@ subtitle: >-
    Today we had some long conversations about Arc Bash and the future of
   scripting as well as platforms and the rise and fall of Kubernetes.
 description: >-
-  Today we had some long conversations about Arc Bash and the future of
-  scripting as well as platforms and the rise and fall of Kubernetes.
+  Evelyn Osman joins David and Laura to defend AWK and Bash, argue platform
+  engineering must start by asking "why", and pick apart whether every
+  workload really belongs on Kubernetes. Also covers decoupling CI from CD.
 publishedAt: 2025-10-10T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
+  - backstage
+  - podman
+  - helm
+  - argo
 show: cloud-native-compass
 duration: 2636
 audioFileSize: 63253254
 guests:
   - evelyn-osman
-resources: []
+resources:
+  - type: "url"
+    title: "Start With Why by Simon Sinek"
+    category: "other"
+    url: "https://simonsinek.com/books/start-with-why/"
+  - type: "url"
+    title: "Podman Quadlet (systemd integration)"
+    category: "documentation"
+    url: "https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html"
+  - type: "url"
+    title: "Helmfile"
+    category: "code"
+    url: "https://github.com/helmfile/helmfile"
+  - type: "url"
+    title: "Argo CD"
+    category: "documentation"
+    url: "https://argo-cd.readthedocs.io/"
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/platform-engineering-asking-why.md
+++ b/content/videos/shows/cloud-native-compass/2025/platform-engineering-asking-why.md
@@ -7,8 +7,8 @@ subtitle: >-
   scripting as well as platforms and the rise and fall of Kubernetes.
 description: >-
   Evelyn Osman joins David and Laura to defend AWK and Bash, argue platform
-  engineering must start by asking "why", and pick apart whether every
-  workload really belongs on Kubernetes. Also covers decoupling CI from CD.
+  engineering must start by asking "why", and pick apart whether every workload
+  really belongs on Kubernetes. Also covers decoupling CI from CD.
 publishedAt: 2025-10-10T17:00:00.000Z
 type: recorded
 category: interview
@@ -24,21 +24,21 @@ audioFileSize: 63253254
 guests:
   - evelyn-osman
 resources:
-  - type: "url"
-    title: "Start With Why by Simon Sinek"
-    category: "other"
-    url: "https://simonsinek.com/books/start-with-why/"
-  - type: "url"
-    title: "Podman Quadlet (systemd integration)"
-    category: "documentation"
-    url: "https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html"
-  - type: "url"
-    title: "Helmfile"
-    category: "code"
-    url: "https://github.com/helmfile/helmfile"
-  - type: "url"
-    title: "Argo CD"
-    category: "documentation"
-    url: "https://argo-cd.readthedocs.io/"
+  - type: url
+    title: Start With Why by Simon Sinek
+    category: other
+    url: 'https://simonsinek.com/books/start-with-why/'
+  - type: url
+    title: Podman Quadlet (systemd integration)
+    category: documentation
+    url: 'https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html'
+  - type: url
+    title: Helmfile
+    category: code
+    url: 'https://github.com/helmfile/helmfile'
+  - type: url
+    title: Argo CD
+    category: documentation
+    url: 'https://argo-cd.readthedocs.io/'
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/simplifying-kubernetes-adoption-challenges.md
+++ b/content/videos/shows/cloud-native-compass/2025/simplifying-kubernetes-adoption-challenges.md
@@ -3,13 +3,22 @@ id: nv3julzu1xz6tcw457hjs5so
 slug: simplifying-kubernetes-adoption-challenges
 title: Simplifying Kubernetes Adoption Challenges
 description: >-
-  In this episode of Cloud Native Compass, host David Flanagan talks with Koray
-  Oksay, a Kubernetes consultant, trainer at Kubermatic, CNCF Ambassador, and
-  organizer of KCD Istanbul.
+  Koray Oksay (Kubermatic, CNCF Ambassador) joins David to discuss why
+  Kubernetes adoption still trips up teams: skipping container fundamentals,
+  picking between managed services and self-hosted clusters, navigating tooling
+  choices like Flux vs Argo CD, and structuring multi-cluster environments.
 publishedAt: 2025-03-13T17:00:00.000Z
 type: recorded
 category: interview
-technologies: []
+technologies:
+  - kubernetes
+  - argo
+  - fluxcd
+  - crossplane
+  - cilium
+  - opa
+  - kyverno
+  - cert-manager
 show: cloud-native-compass
 duration: 2239
 audioFileSize: 53732551
@@ -51,9 +60,15 @@ guests:
 resources:
   - title: Kubernetes The Hard Way
     type: url
+    url: https://github.com/kelseyhightower/kubernetes-the-hard-way
     category: documentation
-  - title: CNCF and Kubernetes Slack channels
+  - title: CNCF Slack
     type: url
+    url: https://slack.cncf.io/
+    category: other
+  - title: Kubernetes Slack
+    type: url
+    url: https://slack.k8s.io/
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/simplifying-kubernetes-adoption-challenges.md
+++ b/content/videos/shows/cloud-native-compass/2025/simplifying-kubernetes-adoption-challenges.md
@@ -60,15 +60,15 @@ guests:
 resources:
   - title: Kubernetes The Hard Way
     type: url
-    url: https://github.com/kelseyhightower/kubernetes-the-hard-way
+    url: 'https://github.com/kelseyhightower/kubernetes-the-hard-way'
     category: documentation
   - title: CNCF Slack
     type: url
-    url: https://slack.cncf.io/
+    url: 'https://slack.cncf.io/'
     category: other
   - title: Kubernetes Slack
     type: url
-    url: https://slack.k8s.io/
+    url: 'https://slack.k8s.io/'
     category: other
 ---
 

--- a/content/videos/shows/cloud-native-compass/2025/the-future-of-sustainability-in-open-source.md
+++ b/content/videos/shows/cloud-native-compass/2025/the-future-of-sustainability-in-open-source.md
@@ -3,37 +3,10 @@ id: nld4g7u2s213v93y76jbmnjm
 slug: the-future-of-sustainability-in-open-source
 title: The Future of Sustainability in Open Source
 description: >-
-  Can open source ever truly be sustainable?
-
-
-  In this mind-bending episode, Hazel Weakly guides us through the social,
-  economic, and emotional layers of open source communities. We dig into
-  governance, funding models, trust, burnout, and what it means to scale
-  collective ownership—without losing your mind.
-
-
-  Hazel Weakly: The Nivenly Foundation Fellow, Member of CNCF's Deaf and Hard of
-  Hearing WG, Software Developer | Leader
-
-
-  Hosts: David Flanagan and Laura Santamaria
-
-
-  00:00 Introduction to Open Source Sustainability
-
-  01:28 Meet Hazel Weakly
-
-  02:56 The Challenges of Open Source Sustainability
-
-  09:17 Maintainer Burnout and Governance
-
-  17:01 Funding Models and Economic Realities
-
-  27:26 Community Health and Conflict Resolution
-
-  40:46 The Future of Web Browsers as Public Utilities
-
-  47:07 Conclusion and Farewell
+  Hazel Weakly unpacks open source sustainability through Eleanor Ostrom's
+  commons principles, covering reciprocity, governance, VC funding pitfalls,
+  maintainer burnout, and why web browsers should be treated as international
+  public utilities.
 publishedAt: 2025-06-12T10:00:00.000Z
 type: recorded
 category: interview
@@ -44,7 +17,15 @@ audioFileSize: 68999671
 guests:
   - hazel-weakly
 resources:
-  - title: Eleanor Ostrom's principles for sustainable self-governing commons
+  - title: Eleanor Ostrom's design principles for self-governed commons
+    type: url
+    url: https://en.wikipedia.org/wiki/Elinor_Ostrom
+    category: other
+  - title: Nivenly Foundation
+    type: url
+    url: https://nivenly.org/
+    category: other
+  - title: CNCF Deaf and Hard of Hearing Working Group
     type: url
     category: other
 ---

--- a/content/videos/shows/cloud-native-compass/2025/the-future-of-sustainability-in-open-source.md
+++ b/content/videos/shows/cloud-native-compass/2025/the-future-of-sustainability-in-open-source.md
@@ -19,11 +19,11 @@ guests:
 resources:
   - title: Eleanor Ostrom's design principles for self-governed commons
     type: url
-    url: https://en.wikipedia.org/wiki/Elinor_Ostrom
+    url: 'https://en.wikipedia.org/wiki/Elinor_Ostrom'
     category: other
   - title: Nivenly Foundation
     type: url
-    url: https://nivenly.org/
+    url: 'https://nivenly.org/'
     category: other
   - title: CNCF Deaf and Hard of Hearing Working Group
     type: url

--- a/content/videos/shows/klustered/2021/klustered-10.md
+++ b/content/videos/shows/klustered/2021/klustered-10.md
@@ -3,13 +3,18 @@ id: gkvfatiptx9zm9zmvcyipvt7
 slug: klustered-10
 title: 'Klustered #10'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Walid Shaari and Noel Georgi join Rawkode to debug three broken Kubernetes
+  clusters, tackling kubelet failures, RBAC misconfigurations, a missing
+  scheduler role, an AlwaysDeny admission controller, mutating webhooks,
+  containerd registry rewrites, and CoreDNS Corefile sabotage.
 publishedAt: 2021-05-06T13:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - containerd
+  - coredns
 show: klustered
 chapters:
   - startTime: 0
@@ -105,6 +110,7 @@ resources:
     category: other
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-11.md
+++ b/content/videos/shows/klustered/2021/klustered-11.md
@@ -68,15 +68,15 @@ guests:
 resources:
   - title: SleuthKit FLS
     type: url
-    url: https://www.sleuthkit.org/sleuthkit/man/fls.html
+    url: 'https://www.sleuthkit.org/sleuthkit/man/fls.html'
     category: documentation
   - title: etcd
     type: url
-    url: https://etcd.io/
+    url: 'https://etcd.io/'
     category: documentation
   - title: Kubernetes static pods
     type: url
-    url: https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/
+    url: 'https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/'
     category: documentation
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-11.md
+++ b/content/videos/shows/klustered/2021/klustered-11.md
@@ -3,13 +3,16 @@ id: byfqy7h28x7wcs80mweqt6kb
 slug: klustered-11
 title: 'Klustered #11'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  KubeCon special part two with Thomas Stromberg and Kris Nova. Two broken
+  clusters: a malicious static pod manifest persisted via a systemd service and
+  LD_PRELOAD hook, and an etcd flooding attack that exhausted the database
+  quota.
 publishedAt: 2021-05-06T17:35:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
 show: klustered
 chapters:
   - startTime: 0
@@ -65,6 +68,15 @@ guests:
 resources:
   - title: SleuthKit FLS
     type: url
+    url: https://www.sleuthkit.org/sleuthkit/man/fls.html
+    category: documentation
+  - title: etcd
+    type: url
+    url: https://etcd.io/
+    category: documentation
+  - title: Kubernetes static pods
+    type: url
+    url: https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/
     category: documentation
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-12.md
+++ b/content/videos/shows/klustered/2021/klustered-12.md
@@ -3,12 +3,17 @@ id: eaev2s8b2r56vaeu61fr9qsr
 slug: klustered-12
 title: 'Klustered #12'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  KubeCon special part three. Jeffrey Sica and Chris Carty break clusters with a
+  modified kubelet, OPA Gatekeeper policies, a broken Cilium CNI, and a hidden
+  static pod manifest, then race to find and fix the sabotage live.
 publishedAt: 2021-05-08T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
+  - opa
+  - cilium
+  - postgresql
 show: klustered
 chapters:
   - startTime: 0
@@ -102,9 +107,11 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
+    url: https://deploy.equinix.com/product/bare-metal/
     category: other
   - title: Kubernetes Office Hours
     type: url
+    url: https://www.kubernetes.dev/resources/office-hours/
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-12.md
+++ b/content/videos/shows/klustered/2021/klustered-12.md
@@ -107,11 +107,11 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
-    url: https://deploy.equinix.com/product/bare-metal/
+    url: 'https://deploy.equinix.com/product/bare-metal/'
     category: other
   - title: Kubernetes Office Hours
     type: url
-    url: https://www.kubernetes.dev/resources/office-hours/
+    url: 'https://www.kubernetes.dev/resources/office-hours/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-13.md
+++ b/content/videos/shows/klustered/2021/klustered-13.md
@@ -3,13 +3,19 @@ id: kmhmcc41uglftsqr66vbo0di
 slug: klustered-13
 title: 'Klustered #13'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Mahmoud Saada and Marques Johansson debug two broken Kubernetes clusters,
+  tackling a LimitRange blocking scaling, a bad image pull secret, resource
+  quota and taint issues, plus a Cilium outage caused by a containerd registry
+  mirror rewriting images to honky.io.
 publishedAt: 2021-06-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - containerd
+  - teleport
+  - postgresql
 show: klustered
 chapters:
   - startTime: 0
@@ -91,6 +97,19 @@ resources:
     category: other
   - title: Kubernetes controller utils create pods code
     type: url
+    url: 'https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go'
     category: code
+  - title: Cilium documentation
+    type: url
+    url: 'https://docs.cilium.io/en/stable/'
+    category: documentation
+  - title: containerd registry configuration
+    type: url
+    url: 'https://github.com/containerd/containerd/blob/main/docs/cri/registry.md'
+    category: documentation
+  - title: Teleport documentation
+    type: url
+    url: 'https://goteleport.com/docs/'
+    category: documentation
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-13.md
+++ b/content/videos/shows/klustered/2021/klustered-13.md
@@ -97,7 +97,8 @@ resources:
     category: other
   - title: Kubernetes controller utils create pods code
     type: url
-    url: 'https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go'
+    url: >-
+      https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go
     category: code
   - title: Cilium documentation
     type: url

--- a/content/videos/shows/klustered/2021/klustered-14.md
+++ b/content/videos/shows/klustered/2021/klustered-14.md
@@ -3,13 +3,18 @@ id: x372c0fhltxzq4h7ll4mfqh1
 slug: klustered-14
 title: 'Klustered #14'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock. #KubernetesTutorial
+  Sid Palas and Arian van Putten each break a cluster for the other to fix.
+  Cluster 31 hides a kubelet cgroup driver mismatch starving Postgres and
+  Cilium, while Cluster 32 spawns replicating "not-a-virus" pods across rogue
+  namespaces.
 publishedAt: 2021-06-10T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - postgresql
+  - docker
 show: klustered
 chapters:
   - startTime: 0
@@ -105,6 +110,7 @@ guests:
 resources:
   - title: DevOps Directive YouTube channel
     type: url
+    url: 'https://www.youtube.com/c/DevOpsDirective'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-15.md
+++ b/content/videos/shows/klustered/2021/klustered-15.md
@@ -3,13 +3,20 @@ id: afzrby1hf2vpr1ist5fpg5sf
 slug: klustered-15
 title: 'Klustered #15'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Marek Counts and Abdel Sghiouar join David to debug two broken Kubernetes
+  clusters, fixing containerd socket paths, kubelet misconfigurations, a rogue
+  eBPF port blocker, a kubeconfig issue, and a Cilium NetworkPolicy blocking
+  Postgres egress.
 publishedAt: 2021-07-01T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - containerd
+  - ebpf
+  - postgresql
+  - coredns
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-16.md
+++ b/content/videos/shows/klustered/2021/klustered-16.md
@@ -5,8 +5,8 @@ title: 'Klustered #16'
 description: >-
   Rachel and Andy bring sabotaged Kubernetes clusters. Rachel's hides disabled
   schedulers, a 1m CPU limit, and a mangled Service. Andy's stacks a fake
-  kubectl, swapped API server image, Cilium IPv4 masquerade flip, hosts file
-  DNS hijack, and read-only worker.
+  kubectl, swapped API server image, Cilium IPv4 masquerade flip, hosts file DNS
+  hijack, and read-only worker.
 publishedAt: 2021-07-23T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2021/klustered-16.md
+++ b/content/videos/shows/klustered/2021/klustered-16.md
@@ -3,12 +3,23 @@ id: xgp6tiusatvjqsse8tour3hl
 slug: klustered-16
 title: 'Klustered #16'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Rachel and Andy bring sabotaged Kubernetes clusters. Rachel's hides disabled
+  schedulers, a 1m CPU limit, and a mangled Service. Andy's stacks a fake
+  kubectl, swapped API server image, Cilium IPv4 masquerade flip, hosts file
+  DNS hijack, and read-only worker.
 publishedAt: 2021-07-23T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
+  - cilium
+  - teleport
+  - coredns
+  - etcd
+  - containerd
+  - kube-vip
+  - flatcar
+  - cluster-api
 show: klustered
 chapters:
   - startTime: 0
@@ -208,8 +219,10 @@ resources:
   - title: Rawkode Academy Discord server
     type: url
     category: other
-  - title: Teleport sponsor link
+    url: 'https://rawkode.chat/'
+  - title: Teleport
     type: url
     category: other
+    url: 'https://goteleport.com/'
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-17.md
+++ b/content/videos/shows/klustered/2021/klustered-17.md
@@ -3,12 +3,21 @@ id: xn5lyqrxw1a9e6c39zsi17s2
 slug: klustered-17
 title: 'Klustered #17'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Adam Szücs-Mátyás and William Lightning debug two broken Kubernetes clusters.
+  Fixes cover cordoned nodes, a CoreDNS ConfigMap, a Harbor image redirect via
+  containerd, plus etcd permission and disk-full recovery from a loopback mount.
 publishedAt: 2021-08-20T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
+  - cilium
+  - coredns
+  - etcd
+  - postgresql
+  - teleport
+  - containerd
+  - harbor
 show: klustered
 chapters:
   - startTime: 0
@@ -92,7 +101,7 @@ guests:
 resources:
   - title: Teleport
     type: url
-    url: 'https://rawkode.live/Teleport'
+    url: 'https://goteleport.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-18.md
+++ b/content/videos/shows/klustered/2021/klustered-18.md
@@ -3,13 +3,16 @@ id: llclhowidfbrvg93zt05v77m
 slug: klustered-18
 title: 'Klustered #18'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Eric Smalling and Carlos Santana race the clock to debug broken Kubernetes
+  clusters. Expect rogue static pods, ZomboCom surprises, broken Cilium network
+  policies, CoreDNS misfires, and a mutating admission webhook swapping images.
 publishedAt: 2021-08-26T18:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-19.md
+++ b/content/videos/shows/klustered/2021/klustered-19.md
@@ -3,13 +3,18 @@ id: szryg6h4y89lh067p26a2g1f
 slug: klustered-19
 title: 'Klustered #19'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Matt Turner and Borko debug two broken Kubernetes clusters live. Issues
+  include a missing API server, etcd resource limits, a decoy DaemonSet, DNS
+  policy, AppArmor blocking kubectl, etcd encryption misconfig, and a malicious
+  Postgres startup command.
 publishedAt: 2021-09-09T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-9.md
+++ b/content/videos/shows/klustered/2021/klustered-9.md
@@ -3,13 +3,18 @@ id: weym8gw0c6g1ol7qjtde1521
 slug: klustered-9
 title: 'Klustered #9'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Marcos Nils joins to debug two Kubernetes clusters: cluster 17 from Sascha
+  Grunert (a rogue node debugger pod and a containerd 'honk' error pointing at
+  BPF) and cluster 18 from Billie Cleek (CoreDNS NXDOMAIN rule and a malicious
+  mutating webhook).
 publishedAt: 2021-04-15T16:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - coredns
+  - ebpf
 show: klustered
 chapters:
   - startTime: 0
@@ -100,9 +105,11 @@ guests:
 resources:
   - title: Play with Docker
     type: url
-    category: demos
+    url: 'https://labs.play-with-docker.com/'
+    category: other
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-community-vs-rawkode.md
+++ b/content/videos/shows/klustered/2021/klustered-community-vs-rawkode.md
@@ -3,13 +3,16 @@ id: a7z1litz91j0xw2nzuvxh240
 slug: klustered-community-vs-rawkode
 title: 'Klustered: Community vs. Rawkode'
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" #Kubernetes clusters ... on the clock.
+  Rawkode debugs three broken Kubernetes clusters solo: Russell W's bash alias
+  and static manifest trick, Noel Georgi's eBPF kubelet redirect, and a
+  community-destroyed cluster needing CoreDNS repair.
 publishedAt: 2021-08-12T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - ebpf
+  - coredns
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-newcomers-1.md
+++ b/content/videos/shows/klustered/2021/klustered-newcomers-1.md
@@ -3,13 +3,19 @@ id: phimrqhbsfj1y0gl2as0s3ce
 slug: klustered-newcomers-1
 title: 'Klustered: Newcomers #1'
 description: >-
-  Klustered is a live debugging and competitive Kubernetes series that aims to
-  provide the best CKA, CKAD, and CKS training materials on YouTube.
+  Newcomers edition of Klustered. Jeremy, Jason, and Tom from Equinix Metal
+  debug a broken Kubernetes cluster with kubectl, fixing a port mismatch, a 1Mi
+  memory limit, a scheduler startup delay, a scaled-down Postgres StatefulSet,
+  and a service selector typo.
 publishedAt: 2021-05-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - teleport
+  - postgresql
+  - rust
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-part-i.md
+++ b/content/videos/shows/klustered/2021/klustered-part-i.md
@@ -3,13 +3,18 @@ id: nbmmmzl4etklri5aruv7hbgq
 slug: klustered-part-i
 title: Klustered (Part I)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Rawkode and Walid Shaari debug two broken Kubernetes clusters deployed via
+  Cluster API on Equinix Metal. They track down a Cilium iptables misconfig,
+  swap-enabled kubelets, UFW interference, and a bad etcd endpoint.
 publishedAt: 2021-02-18T12:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cluster-api
+  - cilium
+  - etcd
+  - coredns
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-part-ii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-ii.md
@@ -3,10 +3,10 @@ id: j6uehaw57ynwqnbkjs3m1to6
 slug: klustered-part-ii
 title: Klustered (Part II)
 description: >-
-  Dan Finneran joins Rawkode to debug two broken Kubernetes clusters,
-  unpicking an etcd version mismatch, a bad kubelet flag, an etcd "no space"
-  alarm and quota, a block-all NetworkPolicy, and a PodSecurityPolicy
-  affecting static pods.
+  Dan Finneran joins Rawkode to debug two broken Kubernetes clusters, unpicking
+  an etcd version mismatch, a bad kubelet flag, an etcd "no space" alarm and
+  quota, a block-all NetworkPolicy, and a PodSecurityPolicy affecting static
+  pods.
 publishedAt: 2021-02-25T12:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2021/klustered-part-ii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-ii.md
@@ -3,13 +3,17 @@ id: j6uehaw57ynwqnbkjs3m1to6
 slug: klustered-part-ii
 title: Klustered (Part II)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Dan Finneran joins Rawkode to debug two broken Kubernetes clusters,
+  unpicking an etcd version mismatch, a bad kubelet flag, an etcd "no space"
+  alarm and quota, a block-all NetworkPolicy, and a PodSecurityPolicy
+  affecting static pods.
 publishedAt: 2021-02-25T12:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - cilium
 show: klustered
 chapters:
   - startTime: 0
@@ -118,6 +122,7 @@ guests:
 resources:
   - title: Hubble UI
     type: url
-    category: demos
+    url: 'https://docs.cilium.io/en/stable/observability/hubble/hubble-ui/'
+    category: documentation
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-iii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-iii.md
@@ -3,13 +3,17 @@ id: jder260f0z8zix9nh7u198mx
 slug: klustered-part-iii
 title: Klustered (Part III)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Michael Hausenblas joins to debug two broken Kubernetes clusters: Justin
+  Garrison's cluster with expired control-plane certificates and MetalLB
+  trouble, and SIG Honk's cluster with a malicious sshd, a swapped API server
+  image, and disabled controller-manager flags.
 publishedAt: 2021-03-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - metallb
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -80,6 +84,7 @@ guests:
 resources:
   - title: Klustered GitLab repository
     type: url
+    url: https://gitlab.com/rawkode/klustered
     category: code
   - title: Justin Garrison's Ansible playbook repository for breaking the cluster
     type: url

--- a/content/videos/shows/klustered/2021/klustered-part-iii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-iii.md
@@ -84,7 +84,7 @@ guests:
 resources:
   - title: Klustered GitLab repository
     type: url
-    url: https://gitlab.com/rawkode/klustered
+    url: 'https://gitlab.com/rawkode/klustered'
     category: code
   - title: Justin Garrison's Ansible playbook repository for breaking the cluster
     type: url

--- a/content/videos/shows/klustered/2021/klustered-part-iv.md
+++ b/content/videos/shows/klustered/2021/klustered-part-iv.md
@@ -3,13 +3,18 @@ id: pa7r65u76f3gfxp1ygtjgxu2
 slug: klustered-part-iv
 title: Klustered (Part IV)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Lee Briggs joins to debug two broken Kubernetes clusters live: missing kubelet
+  binaries, a renamed API server manifest, rogue validation and mutating
+  webhooks, a stopped containerd, and a Cilium CNI image pull policy bug.
 publishedAt: 2021-03-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - cilium
+  - etcd
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -82,6 +87,7 @@ guests:
 resources:
   - title: Teleport access platform
     type: url
+    url: https://goteleport.com/
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-iv.md
+++ b/content/videos/shows/klustered/2021/klustered-part-iv.md
@@ -87,7 +87,7 @@ guests:
 resources:
   - title: Teleport access platform
     type: url
-    url: https://goteleport.com/
+    url: 'https://goteleport.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-v.md
+++ b/content/videos/shows/klustered/2021/klustered-part-v.md
@@ -3,13 +3,18 @@ id: zun7qn3xym7pzttsckp91ame
 slug: klustered-part-v
 title: Klustered (Part V)
 description: >-
-  .Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Jason DeTiberus joins to debug two broken clusters from Thomas Stromberg and
+  CloudNative Wales. Expect rogue processes, mangled resolv.conf, exhausted
+  inodes in /tmp, a rickrolled manifest symlink, and recursive bind mounts.
 publishedAt: 2021-03-18T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - etcd
+  - coredns
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -220,11 +225,13 @@ duration: 7245
 guests:
   - jason-detiberus
 resources:
-  - title: Kubernetes kubectl bash completion documentation
+  - title: kubectl autocomplete documentation
     type: url
+    url: 'https://kubernetes.io/docs/tasks/tools/included/optional-kubectl-configs-bash-linux/'
     category: documentation
   - title: kubeadm CoreDNS manifest source code
     type: url
+    url: 'https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/addons/dns/manifests.go'
     category: code
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-v.md
+++ b/content/videos/shows/klustered/2021/klustered-part-v.md
@@ -227,11 +227,13 @@ guests:
 resources:
   - title: kubectl autocomplete documentation
     type: url
-    url: 'https://kubernetes.io/docs/tasks/tools/included/optional-kubectl-configs-bash-linux/'
+    url: >-
+      https://kubernetes.io/docs/tasks/tools/included/optional-kubectl-configs-bash-linux/
     category: documentation
   - title: kubeadm CoreDNS manifest source code
     type: url
-    url: 'https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/addons/dns/manifests.go'
+    url: >-
+      https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/addons/dns/manifests.go
     category: code
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-vi.md
+++ b/content/videos/shows/klustered/2021/klustered-part-vi.md
@@ -3,13 +3,19 @@ id: tpt5t0dgsrai5h4lzutozcvm
 slug: klustered-part-vi
 title: Klustered (Part VI)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Duffie Cooley joins to debug two broken Kubernetes clusters: an
+  ImagePolicyWebhook, Kyverno ClusterPolicy, deny NetworkPolicy and kubelet
+  config typo on cluster 11; missing static manifests, immutable etcd DB,
+  vm.min_free_kbytes starvation and kubelet memory limits on cluster 13.
 publishedAt: 2021-03-25T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - kyverno
+  - coredns
+  - etcd
+  - containerd
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-part-vii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-vii.md
@@ -3,13 +3,19 @@ id: dxxgafdnayd30spjingobsv8
 slug: klustered-part-vii
 title: Klustered (Part VII)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Guinevere Saenger joins to debug two broken clusters: a Cilium CNI failure
+  tangled with Kyverno mutating webhooks and a sneaky Pod Security Policy, then
+  a kubelet feature-gate error, an etcd request-size limit, and a CoreDNS
+  ConfigMap typo (clouster.local).
 publishedAt: 2021-04-01T18:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - kyverno
+  - etcd
+  - coredns
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2021/klustered-part-viii-ii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-viii-ii.md
@@ -63,11 +63,11 @@ guests:
 resources:
   - title: Cilium Quick Start documentation
     type: url
-    url: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
+    url: 'https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/'
     category: documentation
   - title: Equinix Metal
     type: url
-    url: https://deploy.equinix.com/
+    url: 'https://deploy.equinix.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-viii-ii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-viii-ii.md
@@ -3,13 +3,16 @@ id: e0osaaguckezvjzf42dm6zbc
 slug: klustered-part-viii-ii
 title: Klustered (Part VIII-II)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Noel Georgi returns to debug Kluster 015, where a corrupted Cilium CNI binary
+  and a malicious systemd-collector-d binary hijacking the containerd shim leave
+  pods stuck. crictl, shim comparisons, and Rawkode service fixes restore it.
 publishedAt: 2021-04-09T13:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - containerd
 show: klustered
 chapters:
   - startTime: 0
@@ -60,9 +63,11 @@ guests:
 resources:
   - title: Cilium Quick Start documentation
     type: url
+    url: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
     category: documentation
   - title: Equinix Metal
     type: url
+    url: https://deploy.equinix.com/
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-part-viii.md
+++ b/content/videos/shows/klustered/2021/klustered-part-viii.md
@@ -3,13 +3,17 @@ id: dxx8gdculzrd3zyc6m8nuxms
 slug: klustered-part-viii
 title: Klustered (Part VIII)
 description: >-
-  Klustered is a series of live streams in which myself and a guest join forces
-  to fix "broken" Kubernetes clusters ... on the clock.
+  Noel Georgi joins David to debug two broken Kubernetes clusters: a TLS 1.3
+  handshake mismatch blocking the API server, and rogue Cilium host network
+  policies plus a misconfigured native-routing-cidr breaking node readiness.
 publishedAt: 2021-04-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - cilium
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -216,6 +220,7 @@ guests:
 resources:
   - title: kubectl neat
     type: url
+    url: 'https://github.com/itaysk/kubectl-neat'
     category: code
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-carta-and-fairwinds.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-carta-and-fairwinds.md
@@ -5,8 +5,8 @@ title: 'Klustered Teams: Carta & Fairwinds'
 description: >-
   Teams from Carta and Fairwinds debug each other's broken Kubernetes clusters
   live, tackling admission webhooks, rogue pod re-creation, kubelet and
-  scheduler misconfigurations, an API server manifest typo, and a Cilium
-  network policy.
+  scheduler misconfigurations, an API server manifest typo, and a Cilium network
+  policy.
 publishedAt: 2021-08-05T17:30:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2021/klustered-teams-carta-and-fairwinds.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-carta-and-fairwinds.md
@@ -3,13 +3,17 @@ id: l7t356j2oeuhjpwdkt18tzzl
 slug: klustered-teams-carta-and-fairwinds
 title: 'Klustered Teams: Carta & Fairwinds'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from Carta and Fairwinds debug each other's broken Kubernetes clusters
+  live, tackling admission webhooks, rogue pod re-creation, kubelet and
+  scheduler misconfigurations, an API server manifest typo, and a Cilium
+  network policy.
 publishedAt: 2021-08-05T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - teleport
+  - cilium
 show: klustered
 chapters:
   - startTime: 0
@@ -93,6 +97,7 @@ resources:
     category: other
   - title: Fairwinds RBAC Lookup
     type: url
+    url: 'https://github.com/FairwindsOps/rbac-lookup'
     category: code
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-container-solutions-and-civo-cloud.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-container-solutions-and-civo-cloud.md
@@ -3,10 +3,10 @@ id: jpgna191w3vhmazhx8q5gypb
 slug: klustered-teams-container-solutions-and-civo-cloud
 title: 'Klustered Teams: Container Solutions & Civo Cloud'
 description: >-
-  Container Solutions and Civo Cloud race to repair broken Kubernetes
-  clusters, fixing expired apiserver certs, a tab-corrupted scheduler
-  manifest, a malicious validating webhook, node taints, scheduler port
-  mismatches, resource quotas, and a containerd registry redirect.
+  Container Solutions and Civo Cloud race to repair broken Kubernetes clusters,
+  fixing expired apiserver certs, a tab-corrupted scheduler manifest, a
+  malicious validating webhook, node taints, scheduler port mismatches, resource
+  quotas, and a containerd registry redirect.
 publishedAt: 2021-07-08T17:30:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2021/klustered-teams-container-solutions-and-civo-cloud.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-container-solutions-and-civo-cloud.md
@@ -3,13 +3,18 @@ id: jpgna191w3vhmazhx8q5gypb
 slug: klustered-teams-container-solutions-and-civo-cloud
 title: 'Klustered Teams: Container Solutions & Civo Cloud'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Container Solutions and Civo Cloud race to repair broken Kubernetes
+  clusters, fixing expired apiserver certs, a tab-corrupted scheduler
+  manifest, a malicious validating webhook, node taints, scheduler port
+  mismatches, resource quotas, and a containerd registry redirect.
 publishedAt: 2021-07-08T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - cilium
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -125,6 +130,7 @@ guests:
 resources:
   - title: Teleport access platform
     type: url
+    url: 'https://goteleport.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-control-plane-and-learnk8s.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-control-plane-and-learnk8s.md
@@ -3,13 +3,21 @@ id: r1erhp4o2yh4y37tpd8lruey
 slug: klustered-teams-control-plane-and-learnk8s
 title: 'Klustered Teams: Control Plane & Learnk8s'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Control Plane and Learnk8s go head-to-head debugging each other's broken
+  Kubernetes clusters. Issues include a rogue iptables rule, an etcd read-only
+  manifest, a missing PATH, a tampered kubectl, jsPolicy webhooks, and a stuck
+  containerd task.
 publishedAt: 2021-09-16T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - teleport
+  - etcd
+  - cilium
+  - kube-vip
+  - jspolicy
+  - containerd
 show: klustered
 chapters:
   - startTime: 0
@@ -187,5 +195,25 @@ resources:
     type: url
     url: 'https://rawkode.live/teleport'
     category: other
+  - title: jsPolicy
+    type: url
+    url: 'https://jspolicy.com/'
+    category: documentation
+  - title: kube-vip
+    type: url
+    url: 'https://kube-vip.io/'
+    category: documentation
+  - title: Cilium
+    type: url
+    url: 'https://cilium.io/'
+    category: documentation
+  - title: containerd
+    type: url
+    url: 'https://containerd.io/'
+    category: documentation
+  - title: nerdctl
+    type: url
+    url: 'https://github.com/containerd/nerdctl'
+    category: code
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-digitalocean-and-skyscanner.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-digitalocean-and-skyscanner.md
@@ -3,13 +3,19 @@ id: lb152fahj4mgnkhcx1lsnejr
 slug: klustered-teams-digitalocean-and-skyscanner
 title: 'Klustered Teams: DigitalOcean & Skyscanner'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Skyscanner and DigitalOcean each take on a broken Kubernetes cluster. Fixes
+  span expired certs, etcd probes and resource limits, a kube-vip VIP, a rogue
+  validating webhook, kube-monkey, and Cilium with kube-proxy replacement.
 publishedAt: 2021-07-29T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - cilium
+  - kube-vip
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -168,11 +174,11 @@ guests:
 resources:
   - title: Teleport sponsor link
     type: url
-    url: 'https://rawkode.live/Teleport'
+    url: 'https://rawkode.live/teleport'
     category: other
   - title: Rawkode Discord server
     type: url
-    url: 'https://Rawkode.chat'
+    url: 'https://rawkode.chat'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-raft-and-rx-m.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-raft-and-rx-m.md
@@ -3,13 +3,17 @@ id: x19zjl7plya11i3eqjkt2zra
 slug: klustered-teams-raft-and-rx-m
 title: 'Klustered Teams: Raft & RX-M'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Two teams, RXM and Raft, debug broken Kubernetes clusters. RXM chase an etcd
+  cert path typo and an API server namespace typo, then a missing Postgres
+  manifest. Raft fix an RBAC ClusterRole missing the create verb and work
+  around a broken scheduler.
 publishedAt: 2021-12-09T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - postgresql
 show: klustered
 chapters:
   - startTime: 0
@@ -137,5 +141,21 @@ resources:
     type: url
     url: 'https://metal.equinix.com'
     category: other
+  - title: Teleport
+    type: url
+    url: 'https://goteleport.com/'
+    category: other
+  - title: Kubernetes
+    type: url
+    url: 'https://kubernetes.io/'
+    category: documentation
+  - title: etcd
+    type: url
+    url: 'https://etcd.io/'
+    category: documentation
+  - title: PostgreSQL
+    type: url
+    url: 'https://www.postgresql.org/'
+    category: documentation
 ---
 

--- a/content/videos/shows/klustered/2021/klustered-teams-raft-and-rx-m.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-raft-and-rx-m.md
@@ -5,8 +5,8 @@ title: 'Klustered Teams: Raft & RX-M'
 description: >-
   Two teams, RXM and Raft, debug broken Kubernetes clusters. RXM chase an etcd
   cert path typo and an API server namespace typo, then a missing Postgres
-  manifest. Raft fix an RBAC ClusterRole missing the create verb and work
-  around a broken scheduler.
+  manifest. Raft fix an RBAC ClusterRole missing the create verb and work around
+  a broken scheduler.
 publishedAt: 2021-12-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2021/klustered-teams-redhat-and-talos-systems.md
+++ b/content/videos/shows/klustered/2021/klustered-teams-redhat-and-talos-systems.md
@@ -3,13 +3,17 @@ id: tzx0c1g2al9hmwgrzmhzpoap
 slug: klustered-teams-redhat-and-talos-systems
 title: 'Klustered Teams: RedHat & Talos Systems'
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from Talos Systems and Red Hat break each other's Kubernetes clusters
+  and race to fix them, debugging expired certificates, etcd quorum loss and
+  snapshot restore, Cilium network policies, and a broken CNI loopback plugin.
 publishedAt: 2021-07-15T17:30:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - etcd
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -110,7 +114,7 @@ resources:
     category: other
   - title: Rawkode Academy Discord server
     type: url
-    url: 'https://rockode.chat'
+    url: 'https://rawkode.chat'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/22-borko-vs-bojan.md
+++ b/content/videos/shows/klustered/2022/22-borko-vs-bojan.md
@@ -3,13 +3,19 @@ id: b5ezd2815ffos2t8d3h2qljv
 slug: 22-borko-vs-bojan
 title: 22. Borko Vs. Bojan
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Identical twins Borko and Bojan tackle broken Kubernetes clusters. Borko
+  hunts a malformed image name and a Cilium deny policy, then fixes a CoreDNS
+  rewrite. Bojan kills a cron job flushing iptables and repairs a bad Postgres
+  startup probe.
 publishedAt: 2022-03-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -107,7 +113,7 @@ guests:
 resources:
   - title: Teleport
     type: url
-    url: 'https://rokode.live/teleport'
+    url: 'https://goteleport.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/22-borko-vs-bojan.md
+++ b/content/videos/shows/klustered/2022/22-borko-vs-bojan.md
@@ -3,10 +3,10 @@ id: b5ezd2815ffos2t8d3h2qljv
 slug: 22-borko-vs-bojan
 title: 22. Borko Vs. Bojan
 description: >-
-  Identical twins Borko and Bojan tackle broken Kubernetes clusters. Borko
-  hunts a malformed image name and a Cilium deny policy, then fixes a CoreDNS
-  rewrite. Bojan kills a cron job flushing iptables and repairs a bad Postgres
-  startup probe.
+  Identical twins Borko and Bojan tackle broken Kubernetes clusters. Borko hunts
+  a malformed image name and a Cilium deny policy, then fixes a CoreDNS rewrite.
+  Bojan kills a cron job flushing iptables and repairs a bad Postgres startup
+  probe.
 publishedAt: 2022-03-11T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/22-leigh-capili-vs-marcus-noble.md
+++ b/content/videos/shows/klustered/2022/22-leigh-capili-vs-marcus-noble.md
@@ -4,8 +4,8 @@ slug: 22-leigh-capili-vs-marcus-noble
 title: 22. Leigh Capili vs. Marcus Noble
 description: >-
   Leigh Capili and Marcus Noble debug broken Kubernetes clusters: kubelet
-  systemd units, kubeconfig ports, admission webhooks from Kyverno, Pod
-  Security Policies, quotas, and a kubeadm certificate renewal gone wrong.
+  systemd units, kubeconfig ports, admission webhooks from Kyverno, Pod Security
+  Policies, quotas, and a kubeadm certificate renewal gone wrong.
 publishedAt: 2022-04-08T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/22-leigh-capili-vs-marcus-noble.md
+++ b/content/videos/shows/klustered/2022/22-leigh-capili-vs-marcus-noble.md
@@ -3,13 +3,17 @@ id: peig5ghfiyldrd5pm4u9opzu
 slug: 22-leigh-capili-vs-marcus-noble
 title: 22. Leigh Capili vs. Marcus Noble
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Leigh Capili and Marcus Noble debug broken Kubernetes clusters: kubelet
+  systemd units, kubeconfig ports, admission webhooks from Kyverno, Pod
+  Security Policies, quotas, and a kubeadm certificate renewal gone wrong.
 publishedAt: 2022-04-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - kyverno
+  - helm
+  - artifacthub
 show: klustered
 chapters:
   - startTime: 0
@@ -102,6 +106,7 @@ resources:
     category: other
   - title: Artifact Hub
     type: url
+    url: 'https://artifacthub.io/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/adobe-and-zapier.md
+++ b/content/videos/shows/klustered/2022/adobe-and-zapier.md
@@ -3,13 +3,21 @@ id: xakqjecrktz236keekzkj3t7
 slug: adobe-and-zapier
 title: Adobe & Zapier
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from Adobe and Zapier debug each other's broken Kubernetes clusters.
+  Issues span admission webhooks, Cilium networking, image pull policies,
+  resource quotas, etcd manifests, kubelet permissions, and a CoreDNS ConfigMap
+  reverted by Cloud Custodian.
 publishedAt: 2022-04-29T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
+  - etcd
+  - postgresql
+  - cloudcustodian
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -208,10 +216,11 @@ duration: 5384
 resources:
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
   - title: Rawkode Academy t-shirt giveaway
     type: url
-    url: 'https://Rawkode.live/win'
+    url: 'https://rawkode.live/win'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/alex-jones-and-alistair-hey.md
+++ b/content/videos/shows/klustered/2022/alex-jones-and-alistair-hey.md
@@ -3,10 +3,10 @@ id: dpcat5afr4tp3p580cp0370w
 slug: alex-jones-and-alistair-hey
 title: Alex Jones & Alistair Hey
 description: >-
-  Alex Jones and Alistair Hay break each other's Kubernetes clusters. Alex
-  hunts a disabled replica set controller, a blocking NetworkPolicy, and a
-  tampered cluster DNS IP. Alistair unwinds tc traffic-control delays, a rogue
-  kubectl alias, and dropping iptables rules.
+  Alex Jones and Alistair Hay break each other's Kubernetes clusters. Alex hunts
+  a disabled replica set controller, a blocking NetworkPolicy, and a tampered
+  cluster DNS IP. Alistair unwinds tc traffic-control delays, a rogue kubectl
+  alias, and dropping iptables rules.
 publishedAt: 2022-11-11T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/alex-jones-and-alistair-hey.md
+++ b/content/videos/shows/klustered/2022/alex-jones-and-alistair-hey.md
@@ -3,13 +3,19 @@ id: dpcat5afr4tp3p580cp0370w
 slug: alex-jones-and-alistair-hey
 title: Alex Jones & Alistair Hey
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Alex Jones and Alistair Hay break each other's Kubernetes clusters. Alex
+  hunts a disabled replica set controller, a blocking NetworkPolicy, and a
+  tampered cluster DNS IP. Alistair unwinds tc traffic-control delays, a rogue
+  kubectl alias, and dropping iptables rules.
 publishedAt: 2022-11-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
+  - teleport
+  - postgresql
 show: klustered
 chapters:
   - startTime: 124
@@ -100,11 +106,13 @@ resources:
   - title: Equinix Metal free credits link
     type: url
     category: other
-  - title: Teleport information link
+  - title: Teleport
     type: url
+    url: 'https://goteleport.com/'
     category: documentation
-  - title: webi.shell / web install
+  - title: webinstall.dev
     type: url
-    category: code
+    url: 'https://webinstall.dev/'
+    category: other
 ---
 

--- a/content/videos/shows/klustered/2022/hans-kristian-flaatten-and-zach-wachtel.md
+++ b/content/videos/shows/klustered/2022/hans-kristian-flaatten-and-zach-wachtel.md
@@ -3,13 +3,19 @@ id: fehk0hl4a1z3tpdrcdvnwvqz
 slug: hans-kristian-flaatten-and-zach-wachtel
 title: Hans Kristian Flaatten & Zach Wachtel
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Hans Kristian Flaatten and Zach Wachtel tackle two broken Kubernetes clusters,
+  debugging a bad kubeconfig IP, an encryption provider config, a disk IO
+  throttle cron job, plus Kyverno webhooks and a Cilium egress policy.
 publishedAt: 2022-10-28T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - teleport
+  - cilium
+  - kyverno
+  - etcd
+  - coredns
 show: klustered
 chapters:
   - startTime: 161
@@ -97,6 +103,7 @@ guests:
 resources:
   - title: Ship It podcast
     type: url
+    url: 'https://changelog.com/shipit'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/ibm-and-nisum.md
+++ b/content/videos/shows/klustered/2022/ibm-and-nisum.md
@@ -3,13 +3,16 @@ id: ck185zb8r3zzexy490hywv3j
 slug: ibm-and-nisum
 title: IBM & Nisum
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from IBM and Nisum take on broken Kubernetes clusters live, hunting down
+  sabotaged Cilium operator labels, a tampered CoreDNS ConfigMap, and other
+  breaks with kubectl while pair debugging over Teleport.
 publishedAt: 2022-05-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
 show: klustered
 chapters:
   - startTime: 0
@@ -22,6 +25,7 @@ resources:
     category: other
   - title: Teleport Rawkode promo link
     type: url
+    url: 'https://goteleport.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/jetstack-and-crashbeerbackoff.md
+++ b/content/videos/shows/klustered/2022/jetstack-and-crashbeerbackoff.md
@@ -3,13 +3,16 @@ id: sv0mv7oqjeu35421sjkffdou
 slug: jetstack-and-crashbeerbackoff
 title: Jetstack & CrashBeerBackOff
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Team JetStack and Team CrashBeerBackOff tackle two broken Kubernetes clusters,
+  debugging containerd log limits, a disabled deployment controller, kubelet
+  service typos, and iptables NAT rules redirecting API server and DNS traffic.
 publishedAt: 2022-08-12T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -118,11 +121,11 @@ duration: 5355
 resources:
   - title: Teleport
     type: url
-    url: 'https://Rawkode.link/Teleport'
+    url: 'https://goteleport.com/'
     category: other
   - title: Equinix Metal
     type: url
-    url: 'https://Rawkode.link/metal'
+    url: 'https://deploy.equinix.com/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/klustered-20.md
+++ b/content/videos/shows/klustered/2022/klustered-20.md
@@ -3,13 +3,20 @@ id: wogx7o39wy4eodmd70kbc8o9
 slug: klustered-20
 title: Klustered 20
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Russell and Marek return to break two clusters. Russell hides a recompiled
+  kubectl, a rogue process killing deployments, a CoreDNS ConfigMap edit, and a
+  kubelet that swaps images. Marek drops the kubelet port with UFW and removes
+  the scheduler manifest.
 publishedAt: 2022-02-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - coredns
+  - postgresql
+  - teleport
+  - kube-vip
 show: klustered
 chapters:
   - startTime: 0
@@ -104,6 +111,30 @@ duration: 6164
 guests:
   - russellwaite
   - marek-counts
-resources: []
+resources:
+  - type: url
+    title: Teleport
+    url: 'https://goteleport.com/'
+    category: other
+  - type: url
+    title: Cilium
+    url: 'https://cilium.io/'
+    category: documentation
+  - type: url
+    title: CoreDNS
+    url: 'https://coredns.io/'
+    category: documentation
+  - type: url
+    title: kube-vip
+    url: 'https://kube-vip.io/'
+    category: documentation
+  - type: url
+    title: PostgreSQL
+    url: 'https://www.postgresql.org/'
+    category: documentation
+  - type: url
+    title: UFW (Uncomplicated Firewall)
+    url: 'https://help.ubuntu.com/community/UFW'
+    category: documentation
 ---
 

--- a/content/videos/shows/klustered/2022/klustered-21.md
+++ b/content/videos/shows/klustered/2022/klustered-21.md
@@ -3,13 +3,20 @@ id: kuzv09qa7pptdqchkv2ci5p9
 slug: klustered-21
 title: Klustered 21
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Two broken clusters from Adyen and William. Debug a Cilium CNI image typo,
+  chase a rogue service rewriting resolv.conf, then unpick etcd client auth, a
+  validating webhook blocking a new ReplicaSet, and a server-side apply fix.
 publishedAt: 2022-03-05T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - etcd
+  - coredns
+  - helm
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -93,6 +100,22 @@ resources:
   - title: Rawkode Chat
     type: url
     url: 'https://rawkode.chat'
+    category: other
+  - title: Teleport
+    type: url
+    url: 'https://goteleport.com/'
+    category: other
+  - title: Cilium
+    type: url
+    url: 'https://cilium.io/'
+    category: other
+  - title: etcd documentation
+    type: url
+    url: 'https://etcd.io/docs/'
+    category: documentation
+  - title: CoreDNS
+    type: url
+    url: 'https://coredns.io/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/klustered-teams-aerospike-and-pixielabs.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-aerospike-and-pixielabs.md
@@ -3,13 +3,18 @@ id: jtqwn91v0x5dxjuy02z7a8j8
 slug: klustered-teams-aerospike-and-pixielabs
 title: Klustered Teams - Aerospike & PixieLabs
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams Aerospike and Pixie Labs tackle broken Kubernetes clusters via Teleport.
+  Aerospike untangles etcd auth, ImagePullPolicy and registry DNS; Pixie hits
+  etcd ports, a rogue manifest, kubelet run-once and containerd socket paths.
 publishedAt: 2022-04-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - containerd
+  - teleport
+  - pixie
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2022/klustered-teams-ambassador-labs-and-fairwinds.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-ambassador-labs-and-fairwinds.md
@@ -5,8 +5,8 @@ title: Klustered Teams - Ambassador Labs & Fairwinds
 description: >-
   Ambassador Labs and Fairwinds break each other's Kubernetes clusters. Fixes
   include OOM memory limits, a CoreDNS rewrite hijack pointing to a rogue
-  Postgres in kube-public, a hijacked kubectl shell function, node taints, and
-  a self-recreating NetworkPolicy.
+  Postgres in kube-public, a hijacked kubectl shell function, node taints, and a
+  self-recreating NetworkPolicy.
 publishedAt: 2022-03-04T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/klustered-teams-ambassador-labs-and-fairwinds.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-ambassador-labs-and-fairwinds.md
@@ -3,13 +3,18 @@ id: vt7ini6wdrms1hbc8z9rk44u
 slug: klustered-teams-ambassador-labs-and-fairwinds
 title: Klustered Teams - Ambassador Labs & Fairwinds
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Ambassador Labs and Fairwinds break each other's Kubernetes clusters. Fixes
+  include OOM memory limits, a CoreDNS rewrite hijack pointing to a rogue
+  Postgres in kube-public, a hijacked kubectl shell function, node taints, and
+  a self-recreating NetworkPolicy.
 publishedAt: 2022-03-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - coredns
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -134,6 +139,14 @@ guests:
   - edidiong-asikpo
   - alexandre-gervais
   - andy-suderman
-resources: []
+resources:
+  - type: url
+    title: Teleport
+    url: 'https://goteleport.com/'
+    category: other
+  - type: url
+    title: Emissary-Ingress
+    url: 'https://emissary-ingress.dev/'
+    category: other
 ---
 

--- a/content/videos/shows/klustered/2022/klustered-teams-armo-and-kong.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-armo-and-kong.md
@@ -3,9 +3,9 @@ id: wjbc4rn7siavu2yg490msojv
 slug: klustered-teams-armo-and-kong
 title: Klustered Teams - Armo & Kong
 description: >-
-  Teams Kong and Armo trade broken clusters, debugging liveness probes,
-  Postgres ConfigMap init scripts, a malicious mutating webhook, a rogue
-  NodePort process, a fake kubectl alias, and a kubeconfig HTTP/HTTPS swap.
+  Teams Kong and Armo trade broken clusters, debugging liveness probes, Postgres
+  ConfigMap init scripts, a malicious mutating webhook, a rogue NodePort
+  process, a fake kubectl alias, and a kubeconfig HTTP/HTTPS swap.
 publishedAt: 2022-03-24T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/klustered-teams-armo-and-kong.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-armo-and-kong.md
@@ -3,13 +3,15 @@ id: wjbc4rn7siavu2yg490msojv
 slug: klustered-teams-armo-and-kong
 title: Klustered Teams - Armo & Kong
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams Kong and Armo trade broken clusters, debugging liveness probes,
+  Postgres ConfigMap init scripts, a malicious mutating webhook, a rogue
+  NodePort process, a fake kubectl alias, and a kubeconfig HTTP/HTTPS swap.
 publishedAt: 2022-03-24T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - postgresql
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2022/klustered-teams-chainguard-vs-chainguard-2.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-chainguard-vs-chainguard-2.md
@@ -100,7 +100,8 @@ resources:
     category: other
   - title: Networking and Kubernetes
     type: url
-    url: 'https://www.oreilly.com/library/view/networking-and-kubernetes/9781492081647/'
+    url: >-
+      https://www.oreilly.com/library/view/networking-and-kubernetes/9781492081647/
     category: other
   - title: Sleuth Kit
     type: url

--- a/content/videos/shows/klustered/2022/klustered-teams-chainguard-vs-chainguard-2.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-chainguard-vs-chainguard-2.md
@@ -3,13 +3,17 @@ id: ncbb7hjqxhn4oev9ezbtrgu8
 slug: klustered-teams-chainguard-vs-chainguard-2
 title: Klustered Teams - Chainguard Vs. Chainguard
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Two Chainguard teams race to repair broken Kubernetes clusters, digging into
+  containerd config, service selectors, Cilium CNI, Postgres StatefulSets,
+  corrupted kubelet certificates, and a kubeadm reset to bring the apps back.
 publishedAt: 2022-04-01T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - cilium
+  - postgresql
 show: klustered
 chapters:
   - startTime: 0
@@ -96,9 +100,11 @@ resources:
     category: other
   - title: Networking and Kubernetes
     type: url
+    url: 'https://www.oreilly.com/library/view/networking-and-kubernetes/9781492081647/'
     category: other
   - title: Sleuth Kit
     type: url
+    url: 'https://www.sleuthkit.org/'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/klustered-teams-giant-swarm-and-wildlife-studios.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-giant-swarm-and-wildlife-studios.md
@@ -3,13 +3,17 @@ id: mkpg23vllzcc5ld4672zgzgv
 slug: klustered-teams-giant-swarm-and-wildlife-studios
 title: Klustered Teams - Giant Swarm & Wildlife Studios
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from Giant Swarm and Wildlife Studios swap broken Kubernetes clusters
+  and debug live, working through Cilium CNI sabotage, tampered pause images,
+  replaced kubectl binaries, broken DNS, etcd failures, and iptables policy
+  traps.
 publishedAt: 2022-02-17T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - cilium
+  - etcd
 show: klustered
 chapters:
   - startTime: 0

--- a/content/videos/shows/klustered/2022/klustered-teams-polarsignals-and-pulumi.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-polarsignals-and-pulumi.md
@@ -3,10 +3,10 @@ id: hsykkz8ovuiwzlj438z8ddav
 slug: klustered-teams-polarsignals-and-pulumi
 title: Klustered Teams - PolarSignals & Pulumi
 description: >-
-  Teams from Polar Signals and Pulumi tackle broken Kubernetes clusters,
-  chasing a controller manager pointed at the wrong API server address,
-  Postgres DNS resolution failures, and a containerd freezer cgroup trap
-  hiding on the worker nodes.
+  Teams from Polar Signals and Pulumi tackle broken Kubernetes clusters, chasing
+  a controller manager pointed at the wrong API server address, Postgres DNS
+  resolution failures, and a containerd freezer cgroup trap hiding on the worker
+  nodes.
 publishedAt: 2022-03-17T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/klustered/2022/klustered-teams-polarsignals-and-pulumi.md
+++ b/content/videos/shows/klustered/2022/klustered-teams-polarsignals-and-pulumi.md
@@ -3,13 +3,19 @@ id: hsykkz8ovuiwzlj438z8ddav
 slug: klustered-teams-polarsignals-and-pulumi
 title: Klustered Teams - PolarSignals & Pulumi
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Teams from Polar Signals and Pulumi tackle broken Kubernetes clusters,
+  chasing a controller manager pointed at the wrong API server address,
+  Postgres DNS resolution failures, and a containerd freezer cgroup trap
+  hiding on the worker nodes.
 publishedAt: 2022-03-17T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - coredns
+  - postgresql
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -93,10 +99,6 @@ chapters:
   - startTime: 5997
     title: Recap and Conclusion
 duration: 6155
-resources:
-  - title: rocketacademy/custard
-    type: url
-    url: 'https://github.com/rocketacademy/custard'
-    category: code
+resources: []
 ---
 

--- a/content/videos/shows/klustered/2022/marino-wijay-and-john-anderson.md
+++ b/content/videos/shows/klustered/2022/marino-wijay-and-john-anderson.md
@@ -3,13 +3,20 @@ id: gpflupb79utj4zwvq76deu98
 slug: marino-wijay-and-john-anderson
 title: Marino Wijay & John Anderson
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Marino Wijay and John Anderson fix a sabotaged cluster: Kyverno admission
+  webhooks, a Not Ready node with a bad kubelet eviction flag, controller
+  manager RBAC, a corrupt API server cert, and Cilium CNI mismatched with
+  containerd.
 publishedAt: 2022-05-13T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - kyverno
+  - cilium
+  - cni
+  - containerd
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -179,6 +186,7 @@ guests:
 resources:
   - title: Rawkode Academy Teleport sponsor link
     type: url
+    url: 'https://rawkode.live/teleport'
     category: other
   - title: Rawkode Academy Equinix Metal sponsor link
     type: url

--- a/content/videos/shows/klustered/2022/rawkode-and-the-null-channel-vs-the-community.md
+++ b/content/videos/shows/klustered/2022/rawkode-and-the-null-channel-vs-the-community.md
@@ -3,13 +3,17 @@ id: l87s0mff9plb3tn1r8b1l3ie
 slug: rawkode-and-the-null-channel-vs-the-community
 title: Rawkode & The Null Channel Vs. The Community
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Rawkode teams up with Marek Houns (The Null Channel) to debug two
+  community-submitted broken clusters featuring a fake kubelet binary, a
+  restricted-bash shell, a custom Wordle game, blocked PATH tricks, etcd cert
+  trust failures, and a kernel namespace limit.
 publishedAt: 2022-04-21T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - containerd
+  - etcd
 show: klustered
 chapters:
   - startTime: 0
@@ -130,15 +134,15 @@ guests:
 resources:
   - title: Teleport sponsor landing page
     type: url
-    url: 'https://Rawkode.live/Teleport'
+    url: 'https://rawkode.live/teleport'
     category: other
   - title: Equinix Metal sponsor landing page
     type: url
-    url: 'https://Rawkode.live/metal'
+    url: 'https://rawkode.live/metal'
     category: other
   - title: Rawkode Academy T-shirt competition page
     type: url
-    url: 'https://Rawkode.live/win'
+    url: 'https://rawkode.live/win'
     category: other
 ---
 

--- a/content/videos/shows/klustered/2022/the-community-vs-rawkode.md
+++ b/content/videos/shows/klustered/2022/the-community-vs-rawkode.md
@@ -3,13 +3,18 @@ id: ydqpwfanic1vdp76g6xaq23s
 slug: the-community-vs-rawkode
 title: The Community Vs. Rawkode
 description: >-
-  We use Teleport every week on Klustered and we encourage you to try it out
-  too. Check them out at https://rawkode.live/teleport
+  Community volunteers each get ten minutes to debug two broken Kubernetes
+  clusters live. Cluster one hides a renamed etcd static pod manifest; cluster
+  two has a rogue process scaling a deployment to zero via a malicious kubectl
+  auth helper.
 publishedAt: 2022-06-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - etcd
+  - containerd
+  - teleport
 show: klustered
 chapters:
   - startTime: 0
@@ -164,18 +169,18 @@ duration: 5996
 resources:
   - title: Teleport
     type: url
-    url: 'https://rawkode.live/Teleport'
+    url: 'https://goteleport.com/'
     category: other
   - title: Equinix Metal
     type: url
-    url: 'https://rawkode.live/metal'
+    url: 'https://deploy.equinix.com/'
     category: other
-  - title: Clustered playlist
+  - title: Klustered playlist
     type: url
     category: other
   - title: KubeHuddle
     type: url
-    url: 'https://kubehuddle.com'
+    url: 'https://kubehuddle.com/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/building-php-applications-with-docker-docker-compose-and-kubernetes-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/building-php-applications-with-docker-docker-compose-and-kubernetes-rtfm-with-rawkode.md
@@ -6,9 +6,10 @@ title: >-
   Building PHP Applications with Docker, Docker Compose, and Kubernetes (RTFM
   with Rawkode)
 description: >-
-  In this episode, joined by Ciaran McNulty, we take a look at the best
-  practices for developing Laravel PHP applications with Docker, Docker Compose,
-  and Kubernetes.
+  Ciaran McNulty joins to containerise a Slim Framework PHP app: NGINX and
+  PHP-FPM as separate containers, Compose 2.x for health-check dependencies, a
+  multi-stage Dockerfile, then Kubernetes with NGINX as a sidecar and
+  independently scaled via a service.
 publishedAt: 2020-09-09T17:00:00.000Z
 type: live
 category: tutorial
@@ -52,6 +53,7 @@ resources:
     category: other
   - title: Kustomize documentation
     type: url
+    url: 'https://kustomize.io/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-ii.md
+++ b/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-ii.md
@@ -3,14 +3,16 @@ id: knjh17mds1g14mv1smmzoqoq
 slug: docker-kubernetes-and-php-laravel-edition-part-ii
 title: 'Docker, Kubernetes, & PHP: Laravel Edition (Part II)'
 description: >-
-  In this episode, joined by Ciaran McNulty, we take a look at the best
-  practices for developing Laravel PHP applications with Docker, Docker Compose,
-  and Kubernetes.
+  Ciaran McNulty returns to refine the Laravel dev environment from Part I:
+  tuning Docker for Mac volume performance, splitting Node.js asset compilation
+  (Webpack, Laravel Mix, Tailwind) out of the PHP container, and tidying the
+  Compose and Kubernetes manifests.
 publishedAt: 2020-09-23T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - docker
+  - docker-compose
   - kubernetes
   - laravel
   - php
@@ -36,9 +38,11 @@ guests:
 resources:
   - title: Ping CRM
     type: url
+    url: 'https://github.com/inertiajs/pingcrm'
     category: demos
   - title: Laravel Mix documentation
     type: url
+    url: 'https://laravel-mix.com/docs/6.0/installation'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-iii.md
+++ b/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-iii.md
@@ -3,14 +3,16 @@ id: dbs5yf9vg0tg7k73uo0gfivh
 slug: docker-kubernetes-and-php-laravel-edition-part-iii
 title: 'Docker, Kubernetes, & PHP: Laravel Edition (Part III)'
 description: >-
-  In this episode, joined by Ciaran McNulty & Alex Bowers, we take a look at the
-  best practices for developing Laravel PHP applications with Docker, Docker
-  Compose, and Kubernetes.
+  Ciaran McNulty and Alex Bowers join David to wire up a Laravel dev loop in
+  Docker Compose: fixing the npm watcher, running Artisan migrations, chasing
+  HMR port bindings, and refactoring the production Dockerfile for Composer
+  caching.
 publishedAt: 2020-10-06T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - docker
+  - docker-compose
   - kubernetes
   - laravel
   - php
@@ -149,9 +151,11 @@ guests:
 resources:
   - title: Ping CRM
     type: url
+    url: https://github.com/inertiajs/pingcrm
     category: demos
   - title: Laravel Dusk
     type: url
-    category: code
+    url: https://laravel.com/docs/dusk
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-iii.md
+++ b/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition-part-iii.md
@@ -151,11 +151,11 @@ guests:
 resources:
   - title: Ping CRM
     type: url
-    url: https://github.com/inertiajs/pingcrm
+    url: 'https://github.com/inertiajs/pingcrm'
     category: demos
   - title: Laravel Dusk
     type: url
-    url: https://laravel.com/docs/dusk
+    url: 'https://laravel.com/docs/dusk'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition.md
+++ b/content/videos/shows/rawkode-live/2020/docker-kubernetes-and-php-laravel-edition.md
@@ -3,9 +3,9 @@ id: kpfeh5ghghzqkarckn9sxme0
 slug: docker-kubernetes-and-php-laravel-edition
 title: 'Docker, Kubernetes, and PHP: Laravel Edition'
 description: >-
-  In this episode, joined by Ciaran McNulty, we' take a look at the best
-  practices for developing Laravel PHP applications with Docker, Docker Compose,
-  and Kubernetes.
+  Ciaran McNulty joins David to containerize the Ping CRM Laravel app from
+  scratch: building a docker-compose stack with PHP-FPM, Nginx and MariaDB,
+  layering a Dockerfile with PHP extensions, then deploying to Kubernetes.
 publishedAt: 2020-09-16T17:00:00.000Z
 type: live
 category: tutorial
@@ -52,6 +52,7 @@ guests:
 resources:
   - title: Inertia Ping CRM
     type: url
+    url: 'https://github.com/inertiajs/pingcrm'
     category: code
   - title: rawcode/php-examples
     type: url
@@ -59,9 +60,11 @@ resources:
     category: code
   - title: Refactoring Databases
     type: url
+    url: 'https://databaserefactoring.com/'
     category: other
   - title: The Twelve-Factor App manifesto
     type: url
+    url: 'https://12factor.net/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/example-mapping-by-example.md
+++ b/content/videos/shows/rawkode-live/2020/example-mapping-by-example.md
@@ -3,14 +3,14 @@ id: cmcp750zcoi58w150z7e1ekp
 slug: example-mapping-by-example
 title: Example Mapping by Example
 description: >-
-  Example mapping is a technique for fleshing out and gaining clarity around the
-  acceptance criteria for a given story. It is based on the idea that multiple
-  examples of specific cases convey information better than a single bad
-  abstraction of a concept.
+  Ciaran McNulty walks David through Example Mapping and BDD applied to a real
+  Rust GitOps library, capturing rules and examples for cloning and reconciling
+  Git repositories before translating them into Gherkin scenarios.
 publishedAt: 2020-12-02T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -63,13 +63,15 @@ guests:
 resources:
   - title: Rawkode/getsynced
     type: url
-    url: 'https://getlab.com/Rawkode/getsynced'
     category: code
   - title: Matt Wynne's Example Mapping blog post
     type: url
+    url: 'https://cucumber.io/blog/bdd/example-mapping-introduction/'
     category: other
   - title: John Smart's Feature Mapping
     type: url
+    url: >-
+      https://johnfergusonsmart.com/feature-mapping-a-simpler-path-from-stories-to-executable-acceptance-criteria/
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/gitops-tutorial-with-fluxcd-2-gitops-toolkit.md
+++ b/content/videos/shows/rawkode-live/2020/gitops-tutorial-with-fluxcd-2-gitops-toolkit.md
@@ -3,14 +3,18 @@ id: fhspicv0ccs7sce6vc047vt3
 slug: gitops-tutorial-with-fluxcd-2-gitops-toolkit
 title: GitOps Tutorial with FluxCD 2 (GitOps Toolkit)
 description: >-
-  GitOps is a way to do Kubernetes cluster management and application delivery.
-  It works by using Git as a single source of truth for declarative
-  infrastructure and applications.
+  Stefan Prodan walks through the GitOps Toolkit (Flux v2): bootstrapping with
+  gotk, the source, kustomize, helm, and notification controllers, then adding
+  Git and Helm repository sources, customizations with dependencies and health
+  checks, and Helm releases on Kubernetes.
 publishedAt: 2020-10-13T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - fluxcd
+  - kubernetes
+  - helm
+  - contour
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -110,16 +114,19 @@ resources:
   - title: >-
       GitOps Toolkit development guide for building a controller with
       Kubebuilder
+    url: 'https://fluxcd.io/flux/gitops-toolkit/source-watcher/'
     type: url
     category: documentation
   - title: >-
       GitOps Toolkit Kustomization custom resource definition health assessment
       documentation
+    url: 'https://fluxcd.io/flux/components/kustomize/kustomizations/#health-assessment'
     type: url
     category: documentation
   - title: >-
       GitOps Toolkit monitoring stack add-on with Prometheus and Grafana
       dashboards
+    url: 'https://github.com/fluxcd/flux2-monitoring-example'
     type: url
     category: code
 ---

--- a/content/videos/shows/rawkode-live/2020/gitops-tutorial-with-fluxcd-2-gitops-toolkit.md
+++ b/content/videos/shows/rawkode-live/2020/gitops-tutorial-with-fluxcd-2-gitops-toolkit.md
@@ -120,7 +120,8 @@ resources:
   - title: >-
       GitOps Toolkit Kustomization custom resource definition health assessment
       documentation
-    url: 'https://fluxcd.io/flux/components/kustomize/kustomizations/#health-assessment'
+    url: >-
+      https://fluxcd.io/flux/components/kustomize/kustomizations/#health-assessment
     type: url
     category: documentation
   - title: >-

--- a/content/videos/shows/rawkode-live/2020/hands-on-autoscaling-with-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2020/hands-on-autoscaling-with-kubernetes.md
@@ -3,14 +3,17 @@ id: x2f0csy494v9sk7kmp20jwlr
 slug: hands-on-autoscaling-with-kubernetes
 title: Hands-on Autoscaling with Kubernetes
 description: >-
-  Kubernetes (commonly stylized as k8s) is an open-source
-  container-orchestration system for automating computer application deployment,
-  scaling, and management.
+  Guy Templeton, co-chair of SIG Autoscaling, walks through Kubernetes
+  autoscaling end to end: horizontal pod autoscaling on resource, custom
+  (Prometheus adapter), and external (RabbitMQ) metrics, plus vertical pod
+  autoscaling.
 publishedAt: 2020-12-10T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - prometheus
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -55,9 +58,11 @@ guests:
 resources:
   - title: Kubernetes Autoscaling by Example repository
     type: url
+    url: 'https://github.com/gjtempleton/k8s-autoscaling-by-example'
     category: code
-  - title: Prometheus Adapter documentation
+  - title: Prometheus Adapter
     type: url
+    url: 'https://github.com/kubernetes-sigs/prometheus-adapter'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/hands-on-introduction-to-tektoncd.md
+++ b/content/videos/shows/rawkode-live/2020/hands-on-introduction-to-tektoncd.md
@@ -3,14 +3,16 @@ id: yefvbphvn4f2frn2g1n9srlh
 slug: hands-on-introduction-to-tektoncd
 title: Hands-on Introduction to TektonCD
 description: >-
-  Tekton is a powerful and flexible open-source framework for creating CI/CD
-  systems, allowing developers to build, test, and deploy across cloud providers
-  and on-premise systems.
+  Kevin McDermott walks through TektonCD on Kubernetes: installing pipelines,
+  triggers, and the dashboard, building Tasks and TaskRuns with parameters and
+  results, wiring up workspaces and the git-clone catalog task, and finishing
+  with a GitHub webhook driving an end-to-end image build.
 publishedAt: 2020-12-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - tektoncd
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -71,15 +73,19 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
   - title: Tekton Pipelines release documentation
     type: url
+    url: 'https://tekton.dev/docs/pipelines/install/'
     category: documentation
   - title: Tekton Catalog git-clone task
     type: url
+    url: 'https://github.com/tektoncd/catalog/tree/main/task/git-clone'
     category: code
   - title: Tekton Catalog
     type: url
+    url: 'https://github.com/tektoncd/catalog'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/hands-on-with-faasd-and-inlets.md
+++ b/content/videos/shows/rawkode-live/2020/hands-on-with-faasd-and-inlets.md
@@ -3,9 +3,10 @@ id: mdv5rucpczre2hmjslcad38r
 slug: hands-on-with-faasd-and-inlets
 title: Hands-on with faasd & Inlets
 description: >-
-  faasd is OpenFaaS reimagined, but without the cost and complexity of
-  Kubernetes. It runs on a single host with very modest requirements, making it
-  fast and easy to manage.
+  Alex Ellis joins David to install faasd on Equinix Metal via cloud-init,
+  deploy a Go function, demo containerd pause for fast cold starts and async
+  callbacks, then expose a cluster service publicly using inlets-operator and
+  arkade.
 publishedAt: 2020-11-20T17:00:00.000Z
 type: live
 category: tutorial
@@ -178,10 +179,11 @@ guests:
 resources:
   - title: arkade
     type: url
-    url: 'https://get-arkade.dev'
+    url: 'https://github.com/alexellis/arkade'
     category: code
   - title: Start With Why
     type: url
+    url: 'https://simonsinek.com/books/start-with-why/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/hands-on-with-pipedream.md
+++ b/content/videos/shows/rawkode-live/2020/hands-on-with-pipedream.md
@@ -3,8 +3,9 @@ id: psekx95vb79ashjkm2ibmc3k
 slug: hands-on-with-pipedream
 title: Hands-on with Pipedream
 description: >-
-  Pipedream is a serverless integration and compute platform that makes it easy
-  to connect apps and develop event-driven workflows.
+  Hands-on tour of Pipedream with cofounder Dylan Sather, building event-driven
+  workflows in the UI that wire Twitter searches into Spotify playlists and pipe
+  Discord messages out to Twitter using Node.js code steps.
 publishedAt: 2020-12-16T17:00:00.000Z
 type: live
 category: tutorial
@@ -97,15 +98,18 @@ resources:
     category: other
   - title: Pipedream REST API docs
     type: url
+    url: 'https://pipedream.com/docs/rest-api'
     category: documentation
   - title: Pipedream workflow state docs
     type: url
     category: documentation
   - title: SSLMate Cert Spotter API
     type: url
+    url: 'https://sslmate.com/certspotter/api'
     category: other
   - title: Pipedream parking tickets in San Francisco blog post
     type: url
+    url: 'https://pipedream.com/blog/avoiding-parking-tickets-with-pipedream/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-carvel.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-carvel.md
@@ -3,8 +3,10 @@ id: nkb7uezm4s80fze37vjfqyfb
 slug: introduction-to-carvel
 title: Introduction to Carvel
 description: >-
-  In this episode, I am joined by Dmitriy Kalinin (VMware); the maintainer of
-  Carvel.
+  Dmitriy Kalinin (VMware), maintainer of Carvel, walks through the suite
+  formerly known as k14s: kapp for diff-aware deployments, ytt's structural
+  YAML templating in Starlark, kapp-controller for GitOps, plus kbld and
+  imgpkg for image and bundle workflows.
 publishedAt: 2020-09-30T17:00:00.000Z
 type: live
 category: tutorial
@@ -76,12 +78,14 @@ guests:
 resources:
   - title: ytt Playground
     type: url
+    url: 'https://carvel.dev/ytt/'
     category: demos
   - title: kapp-controller NGINX Helm example
     type: url
     category: demos
   - title: ytt load documentation
     type: url
+    url: 'https://carvel.dev/ytt/docs/latest/lang-ref-load/'
     category: documentation
   - title: KubeCon Carvel talk
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-carvel.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-carvel.md
@@ -4,9 +4,9 @@ slug: introduction-to-carvel
 title: Introduction to Carvel
 description: >-
   Dmitriy Kalinin (VMware), maintainer of Carvel, walks through the suite
-  formerly known as k14s: kapp for diff-aware deployments, ytt's structural
-  YAML templating in Starlark, kapp-controller for GitOps, plus kbld and
-  imgpkg for image and bundle workflows.
+  formerly known as k14s: kapp for diff-aware deployments, ytt's structural YAML
+  templating in Starlark, kapp-controller for GitOps, plus kbld and imgpkg for
+  image and bundle workflows.
 publishedAt: 2020-09-30T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-cilium-part-ii.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-cilium-part-ii.md
@@ -3,13 +3,17 @@ id: mrdik35fprvp6caj44dpkhnz
 slug: introduction-to-cilium-part-ii
 title: Introduction to Cilium (Part II)
 description: >-
-  In this episode, joined by Ilya Dmitrichenko, we'll take a look at Cilium; a
-  CNI implementation for Kubernetes, integrated with eBPF.
+  Ilya Dmitrichenko joins David to install Cilium on a bare-metal Kubernetes
+  cluster, run the Star Wars demo, apply L3/L4 and L7 (HTTP) network policies,
+  explore Hubble UI, lock down DNS egress, and replace kube-proxy.
 publishedAt: 2020-11-12T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - cilium
+  - kubernetes
+  - ebpf
+  - envoy
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -93,14 +97,18 @@ resources:
   - title: Cilium Star Wars demo application
     type: url
     category: demos
+    url: 'https://github.com/cilium/star-wars-demo'
   - title: Cilium 1.9 blog post
     type: url
     category: other
+    url: 'https://cilium.io/blog/2020/11/10/cilium-19/'
   - title: Locking Down External Access with DNS-based Policies
     type: url
     category: documentation
+    url: 'https://docs.cilium.io/en/stable/security/policy/language/#dns-based'
   - title: Kubernetes Without kube-proxy guide
     type: url
     category: documentation
+    url: 'https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/'
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-cilium.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-cilium.md
@@ -3,13 +3,18 @@ id: w6ui2iu1ib1yzoir8k1bolqa
 slug: introduction-to-cilium
 title: Introduction to Cilium
 description: >-
-  In this episode, joined by Ilya Dmitrichenko, we'll take a look at Cilium; a
-  CNI implementation for Kubernetes, integrated with eBPF.
+  Ilya Dmitrichenko joins David to install Cilium on a Cluster API cluster,
+  debug IPAM and stale CiliumNode CRDs, and walk through eBPF-powered kube-proxy
+  replacement, L7 policy, and Hubble visibility via the Star Wars demo.
 publishedAt: 2020-09-25T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - cilium
+  - ebpf
+  - kubernetes
+  - helm
+  - cluster-api
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -116,18 +121,23 @@ guests:
 resources:
   - title: Cilium Quick Installation guide
     type: url
+    url: 'https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/'
     category: documentation
   - title: Cilium IPAM documentation
     type: url
+    url: 'https://docs.cilium.io/en/stable/network/concepts/ipam/'
     category: documentation
   - title: Cilium connectivity test manifest
     type: url
+    url: 'https://github.com/cilium/cilium/tree/master/examples/kubernetes/connectivity-check'
     category: demos
   - title: Cilium Star Wars demo
     type: url
+    url: 'https://docs.cilium.io/en/stable/gettingstarted/demo/'
     category: demos
   - title: Introduction to Cilium and Hubble
     type: url
+    url: 'https://docs.cilium.io/en/stable/overview/intro/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-cilium.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-cilium.md
@@ -129,7 +129,8 @@ resources:
     category: documentation
   - title: Cilium connectivity test manifest
     type: url
-    url: 'https://github.com/cilium/cilium/tree/master/examples/kubernetes/connectivity-check'
+    url: >-
+      https://github.com/cilium/cilium/tree/master/examples/kubernetes/connectivity-check
     category: demos
   - title: Cilium Star Wars demo
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-containerd.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-containerd.md
@@ -3,14 +3,17 @@ id: a2fq3imoh0w5zz0vx1p9czm4
 slug: introduction-to-containerd
 title: Introduction to containerd
 description: >-
-  In this episode, joined by Phil Estes (@estes), maintainer for the containerd
-  project; we discuss the history and creation of containerd, as well as some
-  best practices for using and operating containerd.
+  Phil Estes, containerd maintainer, walks through how containerd was extracted
+  from Docker, its gRPC service architecture, snapshotters and CRI integration
+  versus CRI-O, plus hands-on debugging with ctr and microk8s.
 publishedAt: 2020-09-22T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - containerd
+  - docker
+  - kubernetes
+  - crio
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -50,9 +53,11 @@ resources:
     category: other
   - title: containerd issue 4531
     type: url
-    category: other
+    url: https://github.com/containerd/containerd/issues/4531
+    category: code
   - title: Kata Containers
     type: url
+    url: https://katacontainers.io/
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-containerd.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-containerd.md
@@ -53,11 +53,11 @@ resources:
     category: other
   - title: containerd issue 4531
     type: url
-    url: https://github.com/containerd/containerd/issues/4531
+    url: 'https://github.com/containerd/containerd/issues/4531'
     category: code
   - title: Kata Containers
     type: url
-    url: https://katacontainers.io/
+    url: 'https://katacontainers.io/'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-coredns.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-coredns.md
@@ -2,7 +2,7 @@
 id: c46r2bn411wdonadyion4cxd
 slug: introduction-to-coredns
 title: Introduction to CoreDNS
-description: CoreDNS creator Miek Gieben walks through the plugin-driven Go DNS server: Corefile syntax, plugin ordering at compile time, DNS-over-HTTPS, multi-zone servers, debugging with dnstap, writing a plugin, and how coredns.io is hosted with automated DNSSEC signing.
+description: 'CoreDNS creator Miek Gieben walks through the plugin-driven Go DNS server: Corefile syntax, plugin ordering at compile time, DNS-over-HTTPS, multi-zone servers, debugging with dnstap, writing a plugin, and how coredns.io is hosted with automated DNSSEC signing.'
 publishedAt: 2020-11-05T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-coredns.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-coredns.md
@@ -2,7 +2,7 @@
 id: c46r2bn411wdonadyion4cxd
 slug: introduction-to-coredns
 title: Introduction to CoreDNS
-description: "CoreDNS is a DNS server. It is written in Go.\n\nCoreDNS is different from other DNS servers, such as (all excellent) BIND, Knot, PowerDNS and Unbound (technically a resolver, but still worth a mention), because it is very flexible, and almost all functionality is outsourced into plugins.\n\nPlugins can be stand-alone or work together to perform a “DNS function”.\n\nSo what’s a “DNS function”? For the purpose of CoreDNS, we define it as a piece of software that implements the CoreDNS Plugin API. The functionality implemented can wildly deviate. There are plugins that don’t themselves create a response, such as metrics or cache, but that add functionality. Then there are plugins that do generate a response. These can also do anything: There are plugins that communicate with Kubernetes to provide service discovery, plugins that read data from a file or a database.\n\nThere are currently about 30 plugins included in the default CoreDNS install, but there are also a whole bunch of external plugins that you can compile into CoreDNS to extend its functionality.\n\nCoreDNS is powered by plugins.\n\nWriting new plugins should be easy enough, but requires knowing Go and having some insight into how DNS works. CoreDNS abstracts away a lot of DNS details, so that you can just focus on writing the plugin functionality you need.\n\n\U0001F570 Timeline\n\n00:00 - Holding screen\n01:20 - Introductions\n03:22 - Why do we need new DNS software?\n05:10 - Is DNS still evolving?\n08:45 - What is CoreDNS?\n16:00 - Demo: Supporting multiple protocols\n20:50 - UDP or DNS over HTTPS?\n22:40 - Demo: Multiple Zones\n26:00 - Debugging DNS\n30:00 - Demo: dnstap\n37:45 - Building a plugin\n42:00 - CoreDNS's DNS configuration\n47:00 - Future roadmap\n48:30 - Questions\n\n\n\U0001F30E Resources\n\nMiek Gieben - https://twitter.com/miekg\nGopher - LEGO - DNS - creator of CoreDNS\n\nCoreDNS - https://coredns.io"
+description: CoreDNS creator Miek Gieben walks through the plugin-driven Go DNS server: Corefile syntax, plugin ordering at compile time, DNS-over-HTTPS, multi-zone servers, debugging with dnstap, writing a plugin, and how coredns.io is hosted with automated DNSSEC signing.
 publishedAt: 2020-11-05T17:00:00.000Z
 type: live
 category: tutorial
@@ -84,6 +84,7 @@ guests:
 resources:
   - title: CoreDNS example plugin repository
     type: url
+    url: https://github.com/coredns/example
     category: code
   - title: Sysdig article on DNS request latency in Kubernetes
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-cortex.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-cortex.md
@@ -3,13 +3,18 @@ id: p2b72nkxzbj3rgb4v4knvo4y
 slug: introduction-to-cortex
 title: Introduction to Cortex
 description: >-
-  Cortex: horizontally scalable, highly available, multi-tenant, long term
-  storage for Prometheus.
+  Ganesh Vernekar joins to walk through Cortex: building from source, wiring
+  Prometheus remote_write, scaling it with Docker Compose and MinIO, the
+  single-binary vs microservices architecture, and how it compares to Thanos.
 publishedAt: 2020-11-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - cortex
+  - prometheus
+  - grafana
+  - thanos
+  - docker-compose
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -70,12 +75,15 @@ guests:
 resources:
   - title: Cortex Getting Started block storage documentation
     type: url
+    url: 'https://cortexmetrics.io/docs/getting-started/'
     category: documentation
   - title: Cortex upstream Docker Compose demos
     type: url
+    url: 'https://github.com/cortexproject/cortex/tree/master/development'
     category: demos
   - title: Thanos project
     type: url
+    url: 'https://github.com/thanos-io/thanos'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-crossplane.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-crossplane.md
@@ -3,15 +3,16 @@ id: gh80b8535py01j2wjsqlc12z
 slug: introduction-to-crossplane
 title: Introduction to Crossplane
 description: >-
-  Crossplane, a Cloud Native Computing Foundation sandbox project, is an open
-  source Kubernetes add-on that extends any cluster with the ability to
-  provision and manage cloud infrastructure, services, and applications using
-  kubectl, GitOps, or any tool that works with the Kubernet…
+  Dan Mangum and Marques Johansson join Rawkode to introduce Crossplane,
+  contrast it with Terraform and Pulumi, install the Equinix Metal provider,
+  walk through CompositeResourceDefinitions and Compositions, and provision a
+  device that boots Tinkerbell.
 publishedAt: 2020-10-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - crossplane
+  - tinkerbell
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2020/introduction-to-dgraph.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-dgraph.md
@@ -3,10 +3,9 @@ id: dcbrb2qy3wm14ehhz2bgspfi
 slug: introduction-to-dgraph
 title: Introduction to Dgraph
 description: >-
-  Dgraph is a horizontally scalable and distributed GraphQL database with a
-  graph backend. It provides ACID transactions, consistent replication and
-  linearizable reads. It's built from ground up to perform for a rich set of
-  queries.
+  Xuanyi Chew, community engineer at Dgraph, walks through running Dgraph in
+  Docker, exploring the Ratel UI, writing queries and schemas in DQL versus
+  native GraphQL, and using the hosted Slash GraphQL service.
 publishedAt: 2020-11-09T17:00:00.000Z
 type: live
 category: tutorial
@@ -72,6 +71,7 @@ guests:
 resources:
   - title: Dgraph Docker image
     type: url
+    url: 'https://hub.docker.com/r/dgraph/dgraph'
     category: code
   - title: Dgraph DQL query language functions documentation
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-falco.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-falco.md
@@ -3,15 +3,17 @@ id: dlz3w6ojomalhbj1j2anqgxd
 slug: introduction-to-falco
 title: Introduction to Falco
 description: >-
-  Falco, the open-source cloud-native runtime security project, is the de facto
-  Kubernetes threat detection engine. Falco was created by Sysdig in 2016 and is
-  the first runtime security project to join CNCF as an incubation-level
-  project.
+  Lorenzo Fontana and Leo Di Donato from Sysdig walk through Falco end-to-end:
+  installing it on a host, the kernel module vs eBPF driver, writing rules in
+  YAML, triggering syscall and Kubernetes audit alerts, and routing output via
+  Falcosidekick.
 publishedAt: 2020-10-30T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - falco
+  - kubernetes
+  - ebpf
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -101,8 +103,9 @@ guests:
   - leo-di-donato
   - lorenzo-fontana
 resources:
-  - title: Falco Sidekick
+  - title: Falcosidekick
     type: url
+    url: 'https://github.com/falcosecurity/falcosidekick'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-fleet-k3s-and-rancher.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-fleet-k3s-and-rancher.md
@@ -3,8 +3,10 @@ id: lb438p217zya3imz0gaex2gb
 slug: introduction-to-fleet-k3s-and-rancher
 title: 'Introduction to Fleet, k3s, & Rancher'
 description: >-
-  In this episode, I am joined by Bastian Hofmann (Field Engineer at Rancher);
-  Bastian will be introducing us to Fleet.
+  Bastian Hofmann from Rancher walks through k3s as a lightweight single-binary
+  Kubernetes, Rancher for multi-cluster management, and the new Fleet GitOps
+  engine in Rancher 2.5. Hands-on: provision clusters, install Rancher via Helm
+  and cert-manager, then deploy with Fleet.
 publishedAt: 2020-10-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -98,9 +100,11 @@ guests:
 resources:
   - title: Installing Rancher documentation page
     type: url
+    url: 'https://rancher.com/docs/'
     category: documentation
   - title: Fleet documentation page
     type: url
+    url: 'https://fleet.rancher.io/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-gitpod.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-gitpod.md
@@ -3,24 +3,20 @@ id: l2iuanpln1slft075q8ahyon
 slug: introduction-to-gitpod
 title: Introduction to Gitpod
 description: >-
-  Gitpod is frictionless coding.
-
-
-  Whether you just want to hack, have code to review or feel like trying
-  something new on GitLab, GitHub, or Bitbucket, Gitpod launches a prebuilt dev
-  environment with a single click.
-
-
-  Because Gitpod is based on open-source tech like VS Code, Docker, and
-  Kubernetes, it is familiar, comprehensive, extensible, and easy to use. With
-  deep code-hosting platform integrations, tools for sharing and collaborating,
-  and a focus on usability, Gitpod contains your entire dev workflow in a
-  browser tab.
+  Chris (chief architect) and Sven (CEO) of Gitpod demo cloud dev environments
+  defined in code: .gitpod.yml, Dockerfile-based workspaces on Kubernetes, Go
+  and Rust projects, Docker Compose, port forwarding, OpenVSX extensions, and
+  pull request review workflows.
 publishedAt: 2020-12-15T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - gitpod
+  - docker
+  - docker-compose
+  - kubernetes
+  - rust
+  - gitlab
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -134,13 +130,15 @@ resources:
     category: other
   - title: Eclipse Theia
     type: url
+    url: 'https://theia-ide.org/'
     category: code
   - title: gitpod-io/gitpod repository
     type: url
     url: 'https://github.com/gitpod-io/gitpod'
     category: code
-  - title: Gitpod docker images repository
+  - title: Gitpod workspace images repository
     type: url
+    url: 'https://github.com/gitpod-io/workspace-images'
     category: code
   - title: GitLab project Gitpod configuration
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-grafana.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-grafana.md
@@ -3,14 +3,17 @@ id: xls03x1eryvd5y7lpzbwgblt
 slug: introduction-to-grafana
 title: Introduction to Grafana
 description: >-
-  Grafana is open source visualization and analytics software. It allows you to
-  query, visualize, alert on, and explore your metrics no matter where they are
-  stored.
+  Marcus Olsson joins to introduce Grafana from scratch: installing it on
+  Equinix Metal, wiring up Prometheus and InfluxDB data sources, building
+  dashboards, configuring alert rules with webhook notifications, and importing
+  community dashboards.
 publishedAt: 2020-10-29T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - grafana
+  - prometheus
+  - influxdb
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -83,7 +86,23 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
-    url: 'https://metal.equinix.com'
+    url: 'https://metal.equinix.com/'
     category: other
+  - title: Grafana downloads
+    type: url
+    url: 'https://grafana.com/grafana/download'
+    category: documentation
+  - title: Grafana community dashboards
+    type: url
+    url: 'https://grafana.com/grafana/dashboards/'
+    category: demos
+  - title: Prometheus
+    type: url
+    url: 'https://prometheus.io/'
+    category: documentation
+  - title: InfluxDB
+    type: url
+    url: 'https://www.influxdata.com/'
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-influxdb-2-and-flux.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-influxdb-2-and-flux.md
@@ -98,7 +98,8 @@ resources:
     category: code
   - title: InfluxDB 2 operational monitoring template
     type: url
-    url: 'https://github.com/influxdata/community-templates/tree/master/influxdb2_operational_monitoring'
+    url: >-
+      https://github.com/influxdata/community-templates/tree/master/influxdb2_operational_monitoring
     category: code
   - title: rbx.app request bin
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-influxdb-2-and-flux.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-influxdb-2-and-flux.md
@@ -3,15 +3,15 @@ id: ln4np34ziqhps5xk39cwkjp0
 slug: introduction-to-influxdb-2-and-flux
 title: Introduction to InfluxDB 2 & Flux
 description: >-
-  InfluxDB is an open source time series platform. This includes APIs for
-  storing and querying data, processing it in the background for ETL or
-  monitoring and alerting purposes, user dashboards, and visualizing and
-  exploring the data and more.
+  Anais Dottis-Georgiou from InfluxData walks through InfluxDB 2 and Flux:
+  installing the OSS release, collecting metrics with Telegraf, exploring data,
+  building dashboards, downsampling via tasks, and configuring webhook alerts.
 publishedAt: 2020-11-18T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - influxdb
+  - telegraf
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -94,9 +94,11 @@ guests:
 resources:
   - title: InfluxData Community Templates repository
     type: url
+    url: 'https://github.com/influxdata/community-templates'
     category: code
-  - title: InfluxDB 2 operational metrics template
+  - title: InfluxDB 2 operational monitoring template
     type: url
+    url: 'https://github.com/influxdata/community-templates/tree/master/influxdb2_operational_monitoring'
     category: code
   - title: rbx.app request bin
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-keptn-part-i.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-keptn-part-i.md
@@ -3,14 +3,19 @@ id: emlycwa6qjji1saoicrkwbpr
 slug: introduction-to-keptn-part-i
 title: Introduction to Keptn (Part I)
 description: >-
-  In this episode, we take a look at on-boarding and deploying our first Keptn
-  managed service to our Kubernetes clusters, using Prometheus to provide safety
-  for continuous delivery through progressive delivery.
+  Jurgen Etzlstorfer introduces Keptn, the CNCF sandbox control plane for
+  delivery and operations. We install Istio and Keptn on Kubernetes, write a
+  shipyard, onboard a Helm-packaged service, and let Prometheus-backed SLO
+  quality gates gate the staging rollout.
 publishedAt: 2020-12-02T14:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - keptn
+  - kubernetes
+  - istio
+  - helm
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -129,12 +134,14 @@ resources:
     category: other
   - title: Keptn tutorials
     type: url
+    url: 'https://tutorials.keptn.sh/'
     category: documentation
   - title: Keptn installation on k3s guide
     type: url
     category: documentation
   - title: Sock Shop demo application
     type: url
+    url: 'https://github.com/microservices-demo/microservices-demo'
     category: demos
   - title: Potato Head CNCF demo project
     type: url

--- a/content/videos/shows/rawkode-live/2020/introduction-to-kube-vip-bare-metal-load-balancing-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-kube-vip-bare-metal-load-balancing-rtfm-with-rawkode.md
@@ -3,14 +3,16 @@ id: xga6a9uvs6yot1u103nmv77z
 slug: introduction-to-kube-vip-bare-metal-load-balancing-rtfm-with-rawkode
 title: 'Introduction to kube-vip: Bare Metal Load Balancing (RTFM with Rawkode)'
 description: >-
-  In this episode, joined by my colleague Dan Finneran, we take a practical look
-  at one of his open source projects, Plunder, and get hands on with the
-  kube-vip component.
+  Dan Finneran walks through kube-vip, his bare-metal load balancer for
+  Kubernetes. We cover Plunder for provisioning, then demo a control plane VIP
+  via Raft leader election and Service type LoadBalancer announced over BGP on
+  Equinix Metal.
 publishedAt: 2020-09-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kube-vip
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -37,6 +39,11 @@ guests:
 resources:
   - title: kube-vip documentation
     type: url
+    url: 'https://kube-vip.io/docs/'
     category: documentation
+  - title: kube-vip source code
+    type: url
+    url: 'https://github.com/kube-vip/kube-vip'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-linkerd.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-linkerd.md
@@ -3,14 +3,18 @@ id: ogx55a28acwbzuwd1d1ic3lm
 slug: introduction-to-linkerd
 title: Introduction to Linkerd
 description: >-
-  Linkerd is a service mesh for Kubernetes. It makes running services easier and
-  safer by giving you runtime debugging, observability, reliability, and
-  security—all without requiring any changes to your code.
+  Thomas Rampelberg from Buoyant walks through installing Linkerd 2 on
+  Kubernetes, exploring the dashboard and CLI (tap, stat, top), running the
+  EmojiVoto and Books demos, configuring service profiles for retries and
+  timeouts, traffic split fault injection, mTLS, and multi-cluster.
 publishedAt: 2020-11-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - linkerd
+  - kubernetes
+  - prometheus
+  - grafana
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -123,15 +127,19 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
   - title: EmojiVoto demo application
     type: url
+    url: 'https://github.com/BuoyantIO/emojivoto'
     category: demos
   - title: Books app fault injection tutorial demo
     type: url
+    url: 'https://linkerd.io/2/tasks/books/'
     category: demos
   - title: Google SRE handbook
     type: url
+    url: 'https://sre.google/sre-book/table-of-contents/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-n8n.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-n8n.md
@@ -3,9 +3,9 @@ id: wqob01glppj9tkopb81c1cp5
 slug: introduction-to-n8n
 title: Introduction to n8n
 description: >-
-  n8n (pronounced n-eight-n) helps you to interconnect every app with an API in
-  the world with each other to share and manipulate its data without a single
-  line of code.
+  Tanay Pant walks David through n8n, building workflows in the editor UI with
+  HTTP Request, Cron, Set, Webhook and Function nodes, then wiring up Philips
+  Hue, OpenWeatherMap and a Telegram bot via BotFather.
 publishedAt: 2020-11-06T17:00:00.000Z
 type: live
 category: tutorial
@@ -71,18 +71,23 @@ guests:
 resources:
   - title: TheCocktailDB API
     type: url
+    url: 'https://www.thecocktaildb.com/api.php'
     category: documentation
   - title: TheCocktailDB random cocktail endpoint
     type: url
+    url: 'https://www.thecocktaildb.com/api/json/v1/1/random.php'
     category: demos
   - title: n8n Node Library documentation
     type: url
+    url: 'https://docs.n8n.io/integrations/'
     category: documentation
   - title: n8n Getting Started documentation
     type: url
+    url: 'https://docs.n8n.io/'
     category: documentation
   - title: BotFather Telegram bot creation flow
     type: url
+    url: 'https://core.telegram.org/bots/tutorial'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-open-policy-agent.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-open-policy-agent.md
@@ -5,8 +5,8 @@ title: Introduction to Open Policy Agent
 description: >-
   Torin Sandall walks through Open Policy Agent end-to-end: Rego basics in the
   OPA Playground, Kubernetes admission policies for label and image-source
-  validation using iteration, running OPA locally with bundles and the REPL,
-  and writing unit tests for Rego policies.
+  validation using iteration, running OPA locally with bundles and the REPL, and
+  writing unit tests for Rego policies.
 publishedAt: 2020-11-19T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-open-policy-agent.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-open-policy-agent.md
@@ -3,13 +3,16 @@ id: cwauu9hyqp49qiqdn5c2vq4i
 slug: introduction-to-open-policy-agent
 title: Introduction to Open Policy Agent
 description: >-
-  Torin Sandall is VP of Open Source at Styra and a co-creator of the Open
-  Policy Agent (OPA) project.
+  Torin Sandall walks through Open Policy Agent end-to-end: Rego basics in the
+  OPA Playground, Kubernetes admission policies for label and image-source
+  validation using iteration, running OPA locally with bundles and the REPL,
+  and writing unit tests for Rego policies.
 publishedAt: 2020-11-19T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
-  - open-policy-agent
+  - opa
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -76,12 +79,15 @@ guests:
 resources:
   - title: OPA Playground
     type: url
+    url: 'https://play.openpolicyagent.org/'
     category: demos
   - title: OPA VS Code plugin
     type: url
+    url: 'https://marketplace.visualstudio.com/items?itemName=tsandall.opa'
     category: code
   - title: OPA policy testing documentation
     type: url
+    url: 'https://www.openpolicyagent.org/docs/policy-testing'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-openebs.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-openebs.md
@@ -3,15 +3,17 @@ id: t9v6vfqfjcxjfohd2vrxpeet
 slug: introduction-to-openebs
 title: Introduction to OpenEBS
 description: >-
-  OpenEBS builds on Kubernetes to enable Stateful applications to easily access
-  Dynamic Local PVs or Replicated PVs. By using the Container Attached Storage
-  pattern users report lower costs, easier management, and more control for
-  their teams.
+  Paul Burt and Jeffry Molanus join Rawkode for OpenEBS and its new Mayastor
+  engine. They cover Container Attached Storage, DPDK/SPDK, huge pages, and
+  NVMe-oF replication via the Nexus, then deploy Mayastor on a Kubernetes
+  cluster and benchmark it with fio.
 publishedAt: 2020-10-21T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - openebs
+  - kubernetes
+  - nats
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2020/introduction-to-opentelemetry.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-opentelemetry.md
@@ -3,15 +3,16 @@ id: qsajojlbooovvzl4r05aabx8
 slug: introduction-to-opentelemetry
 title: Introduction to OpenTelemetry
 description: >-
-  Amy has worked in web operations for more than 20 years at companies of every
-  size, touching everything from kernel code to user interfaces. When she's not
-  working she can usually be found around her home in San Jose, caring for her
-  family, making music, or doing yoga in the sun.
+  Amy Tobey and Liz Fong-Jones join David to instrument a Go gRPC service
+  (Tinkerbell) with OpenTelemetry from scratch, wiring up the SDK, a stdout
+  exporter, a Honeycomb exporter, custom attributes, and database spans.
 publishedAt: 2020-11-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - opentelemetry
+  - grpc
+  - tinkerbell
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -73,9 +74,11 @@ guests:
 resources:
   - title: OpenTelemetry Go contrib gRPC instrumentation example
     type: url
+    url: 'https://github.com/open-telemetry/opentelemetry-go-contrib'
     category: code
   - title: OpenTelemetry Go trace API documentation
     type: url
+    url: 'https://pkg.go.dev/go.opentelemetry.io/otel/trace'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-prometheus-promql-and-promlens.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-prometheus-promql-and-promlens.md
@@ -3,8 +3,9 @@ id: chf9r0pa0ypqa70iucjn897m
 slug: introduction-to-prometheus-promql-and-promlens
 title: 'Introduction to Prometheus, PromQL, & PromLens'
 description: >-
-  In this episode, I am joined by Julius Volz; co-founder of Prometheus, and
-  founder of PromCon and PromLabs.
+  Julius Volz, Prometheus co-founder, walks through the data model and four
+  metric types, scraping node_exporter, writing PromQL in PromLens, and
+  building a predict_linear disk-fill alert.
 publishedAt: 2020-10-10T17:00:00.000Z
 type: live
 category: tutorial
@@ -92,12 +93,15 @@ resources:
     category: other
   - title: Prometheus best practices docs page on histograms and summaries
     type: url
+    url: 'https://prometheus.io/docs/practices/histograms/'
     category: documentation
   - title: kube-prometheus Prometheus rules manifests
     type: url
+    url: 'https://github.com/prometheus-operator/kube-prometheus/tree/main/manifests'
     category: code
   - title: Cortex monitoring project
     type: url
-    category: code
+    url: 'https://cortexmetrics.io/'
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-prometheus-promql-and-promlens.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-prometheus-promql-and-promlens.md
@@ -4,8 +4,8 @@ slug: introduction-to-prometheus-promql-and-promlens
 title: 'Introduction to Prometheus, PromQL, & PromLens'
 description: >-
   Julius Volz, Prometheus co-founder, walks through the data model and four
-  metric types, scraping node_exporter, writing PromQL in PromLens, and
-  building a predict_linear disk-fill alert.
+  metric types, scraping node_exporter, writing PromQL in PromLens, and building
+  a predict_linear disk-fill alert.
 publishedAt: 2020-10-10T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-i.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-i.md
@@ -3,9 +3,9 @@ id: lqoxvc2zwgos1jkwcst7aj6z
 slug: introduction-to-rust-part-i
 title: Introduction to Rust (Part I)
 description: >-
-  Rust is a multi-paradigm programming language designed for performance and
-  safety, especially safe concurrency. Rust is syntactically similar to C++ but
-  can guarantee memory safety by using a borrow checker to validate references.
+  Steve Klabnik, co-author of The Rust Programming Language book, joins to teach
+  Rust from scratch. Working through Rustlings exercises, they cover variables,
+  mutability, shadowing, functions, strings (&str vs String), and structs.
 publishedAt: 2020-12-02T17:00:00.000Z
 type: live
 category: tutorial
@@ -81,9 +81,15 @@ guests:
 resources:
   - title: The Rust Programming Language book
     type: url
+    url: https://doc.rust-lang.org/stable/book/
     category: documentation
+  - title: Rustlings exercises
+    type: url
+    url: https://github.com/rust-lang/rustlings
+    category: code
   - title: Rust Users Forum
     type: url
+    url: https://users.rust-lang.org/
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-i.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-i.md
@@ -81,15 +81,15 @@ guests:
 resources:
   - title: The Rust Programming Language book
     type: url
-    url: https://doc.rust-lang.org/stable/book/
+    url: 'https://doc.rust-lang.org/stable/book/'
     category: documentation
   - title: Rustlings exercises
     type: url
-    url: https://github.com/rust-lang/rustlings
+    url: 'https://github.com/rust-lang/rustlings'
     category: code
   - title: Rust Users Forum
     type: url
-    url: https://users.rust-lang.org/
+    url: 'https://users.rust-lang.org/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-ii.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-ii.md
@@ -3,9 +3,10 @@ id: d6x3tfwo4ijvoew49ycderha
 slug: introduction-to-rust-part-ii
 title: Introduction to Rust (Part II)
 description: >-
-  Rust is a multi-paradigm programming language designed for performance and
-  safety, especially safe concurrency. Rust is syntactically similar to C++ but
-  can guarantee memory safety by using a borrow checker to validate references.
+  Part two of the Rustlings walkthrough with Rust core team member Manish
+  Goregaokar. We cover if/else, match, move semantics and borrowing,
+  Option<T> with if let and while let, enum variants and pattern matching,
+  Clippy lints, and writing unit tests.
 publishedAt: 2020-12-05T17:00:00.000Z
 type: live
 category: tutorial
@@ -121,6 +122,15 @@ guests:
 resources:
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
+  - title: Rustlings
+    type: url
+    url: 'https://github.com/rust-lang/rustlings'
+    category: code
+  - title: Clippy
+    type: url
+    url: 'https://github.com/rust-lang/rust-clippy'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-ii.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-ii.md
@@ -4,9 +4,9 @@ slug: introduction-to-rust-part-ii
 title: Introduction to Rust (Part II)
 description: >-
   Part two of the Rustlings walkthrough with Rust core team member Manish
-  Goregaokar. We cover if/else, match, move semantics and borrowing,
-  Option<T> with if let and while let, enum variants and pattern matching,
-  Clippy lints, and writing unit tests.
+  Goregaokar. We cover if/else, match, move semantics and borrowing, Option<T>
+  with if let and while let, enum variants and pattern matching, Clippy lints,
+  and writing unit tests.
 publishedAt: 2020-12-05T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-iii.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-rust-part-iii.md
@@ -3,9 +3,10 @@ id: mz4qbj0rv0214w4idf272hhw
 slug: introduction-to-rust-part-iii
 title: Introduction to Rust (Part III)
 description: >-
-  Rust is a multi-paradigm programming language designed for performance and
-  safety, especially safe concurrency. Rust is syntactically similar to C++ but
-  can guarantee memory safety by using a borrow checker to validate references.
+  Jane Lusby walks David through writing a CLI anagram finder in Rust, covering
+  cargo project setup, editions, lifetimes, generics with impl Into and where
+  clauses, command-line parsing with structopt, and reading the system
+  dictionary with BufReader and iterators.
 publishedAt: 2020-12-11T17:00:00.000Z
 type: live
 category: tutorial
@@ -95,20 +96,23 @@ guests:
 resources:
   - title: Awesome Rust Mentors Project
     type: url
+    url: 'https://github.com/RustBeginners/awesome-rust-mentors'
     category: code
   - title: StructOpt crate
     type: url
+    url: 'https://github.com/TeXitoi/structopt'
     category: code
   - title: Cargo Edit
     type: url
+    url: 'https://github.com/killercup/cargo-edit'
     category: code
   - title: std.rs BufReader documentation
     type: url
-    url: 'https://std.rs/buffreader'
+    url: 'https://doc.rust-lang.org/std/io/struct.BufReader.html'
     category: documentation
   - title: cheats.rs Rust cheat sheet
     type: url
-    url: 'https://cheats.rs'
+    url: 'https://cheats.rs/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-teleport.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-teleport.md
@@ -3,9 +3,10 @@ id: qamuh4bhe90e6gwbs5bsoufk
 slug: introduction-to-teleport
 title: Introduction to Teleport
 description: >-
-  Gravitational Teleport is a gateway for managing access to clusters of Linux
-  servers via SSH or the Kubernetes API. It is intended to be used instead of
-  traditional OpenSSH for organisations that need to:
+  Steven Martin walks through Teleport, the unified access plane for SSH nodes,
+  Kubernetes clusters, and web apps. We cover short-lived certificates, session
+  recording, and audit, then install Teleport, add a node, and connect a
+  Kubernetes cluster via the Helm chart.
 publishedAt: 2020-12-04T17:00:00.000Z
 type: live
 category: tutorial
@@ -89,12 +90,15 @@ guests:
 resources:
   - title: Teleport Quick Start / Getting Started guide
     type: url
+    url: https://goteleport.com/docs/get-started/
     category: documentation
   - title: gravitational/teleport Kubernetes agent Helm chart example
     type: url
+    url: https://github.com/gravitational/teleport/tree/master/examples/chart
     category: code
   - title: Teleport documentation for OpenSSH integration
     type: url
+    url: https://goteleport.com/docs/enroll-resources/server-access/openssh/
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-teleport.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-teleport.md
@@ -90,15 +90,15 @@ guests:
 resources:
   - title: Teleport Quick Start / Getting Started guide
     type: url
-    url: https://goteleport.com/docs/get-started/
+    url: 'https://goteleport.com/docs/get-started/'
     category: documentation
   - title: gravitational/teleport Kubernetes agent Helm chart example
     type: url
-    url: https://github.com/gravitational/teleport/tree/master/examples/chart
+    url: 'https://github.com/gravitational/teleport/tree/master/examples/chart'
     category: code
   - title: Teleport documentation for OpenSSH integration
     type: url
-    url: https://goteleport.com/docs/enroll-resources/server-access/openssh/
+    url: 'https://goteleport.com/docs/enroll-resources/server-access/openssh/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-thanos.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-thanos.md
@@ -3,13 +3,17 @@ id: p78opknhykk7739gvc7kf5z5
 slug: introduction-to-thanos
 title: Introduction to Thanos
 description: >-
-  Bartek Plotka is a Principal Software Engineer at Red Hat with a background in
-  SRE, currently working on OpenShift Observability.
+  Bartek Plotka walks through Thanos, the CNCF project that extends Prometheus
+  with global query, HA deduplication, and long-term storage. Covers the
+  Sidecar, Querier, Store Gateway, and Compactor, plus a live demo running
+  three Prometheus servers against MinIO.
 publishedAt: 2020-11-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - thanos
+  - prometheus
+  - minio
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -110,9 +114,11 @@ resources:
     category: demos
   - title: Site Reliability Engineering book
     type: url
+    url: 'https://sre.google/books/'
     category: other
-  - title: CNCF SIG Observability meetings
+  - title: CNCF SIG Observability
     type: url
+    url: 'https://github.com/cncf/tag-observability'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-thanos.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-thanos.md
@@ -5,8 +5,8 @@ title: Introduction to Thanos
 description: >-
   Bartek Plotka walks through Thanos, the CNCF project that extends Prometheus
   with global query, HA deduplication, and long-term storage. Covers the
-  Sidecar, Querier, Store Gateway, and Compactor, plus a live demo running
-  three Prometheus servers against MinIO.
+  Sidecar, Querier, Store Gateway, and Compactor, plus a live demo running three
+  Prometheus servers against MinIO.
 publishedAt: 2020-11-11T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-the-kubernetes-seccomp-operator-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-the-kubernetes-seccomp-operator-rtfm-with-rawkode.md
@@ -3,14 +3,16 @@ id: jk9tbioqoc16ukeec1z9fi5h
 slug: introduction-to-the-kubernetes-seccomp-operator-rtfm-with-rawkode
 title: Introduction to the Kubernetes Seccomp Operator (RTFM with Rawkode)
 description: >-
-  In this episode, joined by Daniel Mangum and Sascha Grunert, we take a look at
-  the Seecomp Operator for Kubernetes; allowing for new security primitives for
-  your Kubernetes environments.
+  Daniel Mangum and Sascha Grunert walk through the Kubernetes seccomp operator:
+  what seccomp is, installing the operator, applying profiles to nginx pods,
+  tracing blocked syscalls with strace, and generating profiles with podman.
 publishedAt: 2020-09-10T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - security-profiles-operator
+  - kubernetes
+  - podman
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -37,6 +39,23 @@ duration: 5032
 guests:
   - daniel-mangum
   - sascha-grunert
-resources: []
+resources:
+  - type: url
+    title: kubernetes-sigs/security-profiles-operator
+    url: 'https://github.com/kubernetes-sigs/security-profiles-operator'
+    category: code
+  - type: url
+    title: Security Profiles Operator installation and usage
+    url: >-
+      https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md
+    category: documentation
+  - type: url
+    title: Kubernetes seccomp tutorial
+    url: 'https://kubernetes.io/docs/tutorials/security/seccomp/'
+    category: documentation
+  - type: url
+    title: podman generate seccomp profiles
+    url: 'https://docs.podman.io/en/latest/markdown/podman-generate.1.html'
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-the-operatorsdk.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-the-operatorsdk.md
@@ -3,14 +3,16 @@ id: x7i5glnt55z23vrd3th0wgbb
 slug: introduction-to-the-operatorsdk
 title: Introduction to the OperatorSDK
 description: >-
-  This Operator SDK is a component of the Operator Framework, an open source
-  toolkit to manage Kubernetes native applications, called Operators, in an
-  effective, automated, and scalable way.
+  Dennis Kelly walks through the Operator SDK by building a Go-based "add"
+  operator: scaffolding a project, defining a custom resource, writing the
+  reconciler with controller-runtime, generating CRDs and RBAC, and deploying
+  it to a Kubernetes cluster.
 publishedAt: 2020-12-09T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
-  - operatorsdk
+  - operatorframework
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2020/introduction-to-the-operatorsdk.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-the-operatorsdk.md
@@ -5,8 +5,8 @@ title: Introduction to the OperatorSDK
 description: >-
   Dennis Kelly walks through the Operator SDK by building a Go-based "add"
   operator: scaffolding a project, defining a custom resource, writing the
-  reconciler with controller-runtime, generating CRDs and RBAC, and deploying
-  it to a Kubernetes cluster.
+  reconciler with controller-runtime, generating CRDs and RBAC, and deploying it
+  to a Kubernetes cluster.
 publishedAt: 2020-12-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/introduction-to-tilt.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-tilt.md
@@ -3,13 +3,18 @@ id: qkzz0unysafq2cec03jmyhyr
 slug: introduction-to-tilt
 title: Introduction to Tilt
 description: >-
-  In this episode, joined by Dan Bentley and Ellen Korbes, we take a look at how
-  Tilt can make developing our applications against Kubernetes easier.
+  Dan Bentley and Ellen Korbes show how Tilt automates the inner loop for
+  Kubernetes development. We write a Tiltfile in Starlark, build a Docker image,
+  deploy via kubectl and Helm, and use live_update to sync changes without
+  rebuilds.
 publishedAt: 2020-09-23T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - tilt
+  - kubernetes
+  - docker
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -64,17 +69,22 @@ resources:
   - title: 'Tilt tutorial: The First Fifteen Minutes'
     type: url
     category: documentation
+    url: 'https://docs.tilt.dev/tutorial.html'
   - title: 'Tilt guide: Faster Development with Live Update'
     type: url
     category: documentation
+    url: 'https://docs.tilt.dev/live_update_tutorial.html'
   - title: Tilt Helm Remote README
     type: url
     category: documentation
+    url: 'https://github.com/tilt-dev/tilt-extensions/tree/master/helm_remote'
   - title: 'Tilt API Reference: kustomize function'
     type: url
     category: documentation
+    url: 'https://docs.tilt.dev/api.html#api.kustomize'
   - title: Tilt Extensions repository
     type: url
     category: code
+    url: 'https://github.com/tilt-dev/tilt-extensions'
 ---
 

--- a/content/videos/shows/rawkode-live/2020/introduction-to-webassembly-and-wascc.md
+++ b/content/videos/shows/rawkode-live/2020/introduction-to-webassembly-and-wascc.md
@@ -3,15 +3,16 @@ id: flgpktp3odrmizcskj38xa0v
 slug: introduction-to-webassembly-and-wascc
 title: Introduction to WebAssembly & waSCC
 description: >-
-  WebAssembly (abbreviated Wasm) is a binary instruction format for a
-  stack-based virtual machine. Wasm is designed as a portable compilation target
-  for programming languages, enabling deployment on the web for client and
-  server applications.
+  Kevin Hoffman, author of Programming WebAssembly with Rust and tech lead of
+  waSCC, walks through WebAssembly beyond the browser: the WAT text format,
+  wasmtime, and waSCC's capability-secure actors, signed JWT entitlements, and
+  Lattice clustering.
 publishedAt: 2020-10-22T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - webassembly
+  - wasmcloud
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -132,15 +133,19 @@ guests:
 resources:
   - title: Programming WebAssembly with Rust
     type: url
+    url: 'https://pragprog.com/titles/khrust/programming-webassembly-with-rust/'
     category: other
   - title: WebAssembly Binary Toolkit
     type: url
+    url: 'https://github.com/WebAssembly/wabt'
     category: code
   - title: WASC new actor template
     type: url
+    url: 'https://github.com/wascc/new-actor-template'
     category: code
   - title: WASC new provider template
     type: url
+    url: 'https://github.com/wascc/new-provider-template'
     category: code
   - title: waSCC demo YouTube playlist
     type: url

--- a/content/videos/shows/rawkode-live/2020/ipv6-only-kubernetes-clusters-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/ipv6-only-kubernetes-clusters-rtfm-with-rawkode.md
@@ -46,7 +46,8 @@ guests:
 resources:
   - title: Calico over IP Fabrics
     type: url
-    url: 'https://docs.tigera.io/calico/latest/reference/architecture/design/l3-interconnect-fabric'
+    url: >-
+      https://docs.tigera.io/calico/latest/reference/architecture/design/l3-interconnect-fabric
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/ipv6-only-kubernetes-clusters-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/ipv6-only-kubernetes-clusters-rtfm-with-rawkode.md
@@ -3,14 +3,17 @@ id: qzf07xf4d395p3bm5ugkqxp0
 slug: ipv6-only-kubernetes-clusters-rtfm-with-rawkode
 title: IPv6 ONLY Kubernetes Clusters (RTFM with Rawkode)
 description: >-
-  In this episode, joined by Arian van Putten, we take a look at the steps
-  involved for creating / provisioning an IPv6 ONLY Kubernetes cluster on
-  Packet.
+  Arian van Putten walks through building an IPv6-only Kubernetes cluster on
+  Packet bare metal: provisioning nodes with Pulumi and TypeScript,
+  bootstrapping with kubeadm, installing Calico CNI, and announcing pod and
+  service IPv6 addresses to the upstream router via BGP.
 publishedAt: 2020-09-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - pulumi
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -43,6 +46,7 @@ guests:
 resources:
   - title: Calico over IP Fabrics
     type: url
+    url: 'https://docs.tigera.io/calico/latest/reference/architecture/design/l3-interconnect-fabric'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2020/kubernetes-1-19-accentuate-the-paw-sitive-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/kubernetes-1-19-accentuate-the-paw-sitive-rtfm-with-rawkode.md
@@ -49,7 +49,8 @@ resources:
   - title: Kubernetes 1.19 release article
     type: url
     category: documentation
-    url: 'https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/'
+    url: >-
+      https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/
   - title: seccomp operator
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2020/kubernetes-1-19-accentuate-the-paw-sitive-rtfm-with-rawkode.md
+++ b/content/videos/shows/rawkode-live/2020/kubernetes-1-19-accentuate-the-paw-sitive-rtfm-with-rawkode.md
@@ -3,8 +3,10 @@ id: wkbhvz7pos9b1z431hb4dqxe
 slug: kubernetes-1-19-accentuate-the-paw-sitive-rtfm-with-rawkode
 title: 'Kubernetes 1.19: Accentuate the Paw-sitive (RTFM with Rawkode)'
 description: >-
-  In this episode, joined by Taylor Dolezal, we take a hands-on look at some of
-  the latest features that landed in the latest release of Kubernetes; 1.19.
+  Taylor Dolezal joins to walk through Kubernetes 1.19, including the extended
+  12-month support window, storage capacity tracking, CSI volume health, Ingress
+  going GA, and live demos of structured logging with klog, immutable
+  ConfigMaps, and seccomp profiles.
 publishedAt: 2020-09-15T17:00:00.000Z
 type: live
 category: tutorial
@@ -43,11 +45,14 @@ resources:
   - title: kind project
     type: url
     category: code
+    url: 'https://kind.sigs.k8s.io/'
   - title: Kubernetes 1.19 release article
     type: url
     category: documentation
+    url: 'https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/'
   - title: seccomp operator
     type: url
     category: code
+    url: 'https://github.com/kubernetes-sigs/security-profiles-operator'
 ---
 

--- a/content/videos/shows/rawkode-live/2020/kubernetes-cluster-api-for-equinix-metal-formely-packet.md
+++ b/content/videos/shows/rawkode-live/2020/kubernetes-cluster-api-for-equinix-metal-formely-packet.md
@@ -3,8 +3,10 @@ id: tq4z0nov4d8znm2y0pubx56b
 slug: kubernetes-cluster-api-for-equinix-metal-formely-packet
 title: Kubernetes Cluster API for Equinix Metal (Formely Packet)
 description: >-
-  In this episode, joined by my colleague Jason DeTiberus, we explore using the
-  Kubernetes Cluster API to deploy new Kubernetes clusters on Packet.
+  Jason DeTiberus joins to walk through declaratively defining Kubernetes
+  clusters with Cluster API, installing the Packet infrastructure provider,
+  generating a workload cluster config with clusterctl, and bootstrapping nodes
+  via kubeadm on Packet bare metal.
 publishedAt: 2020-08-26T15:30:00.000Z
 type: live
 category: tutorial
@@ -45,18 +47,23 @@ guests:
 resources:
   - title: Cluster API Book Quick Start
     type: url
+    url: 'https://cluster-api.sigs.k8s.io/user/quick-start.html'
     category: documentation
   - title: Cluster API Provider Packet repository
     type: url
+    url: 'https://github.com/kubernetes-sigs/cluster-api-provider-packet'
     category: code
   - title: Kubernetes SIGs Image Builder
     type: url
+    url: 'https://github.com/kubernetes-sigs/image-builder'
     category: code
   - title: Cluster Addons project
     type: url
+    url: 'https://github.com/kubernetes-sigs/cluster-addons'
     category: code
   - title: Cluster Autoscaler
     type: url
+    url: 'https://github.com/kubernetes/autoscaler'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/living-documentation-with-bdd.md
+++ b/content/videos/shows/rawkode-live/2020/living-documentation-with-bdd.md
@@ -2,7 +2,10 @@
 id: xtay8a6iyr4u6ow9kc6iojpe
 slug: living-documentation-with-bdd
 title: Living Documentation with BDD
-description: Ciaran McNulty joins David to apply BDD to the git-sync Rust library. They turn example-mapping outcomes into Gherkin scenarios, refine wording, group rules, and decide between library-level and CLI end-to-end acceptance tests.
+description: >-
+  Ciaran McNulty joins David to apply BDD to the git-sync Rust library. They
+  turn example-mapping outcomes into Gherkin scenarios, refine wording, group
+  rules, and decide between library-level and CLI end-to-end acceptance tests.
 publishedAt: 2020-12-16T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2020/living-documentation-with-bdd.md
+++ b/content/videos/shows/rawkode-live/2020/living-documentation-with-bdd.md
@@ -2,11 +2,12 @@
 id: xtay8a6iyr4u6ow9kc6iojpe
 slug: living-documentation-with-bdd
 title: Living Documentation with BDD
-description: Video content coming soon.
+description: Ciaran McNulty joins David to apply BDD to the git-sync Rust library. They turn example-mapping outcomes into Gherkin scenarios, refine wording, group rules, and decide between library-level and CLI end-to-end acceptance tests.
 publishedAt: 2020-12-16T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 75
@@ -49,6 +50,7 @@ guests:
 resources:
   - title: git sync Rust library
     type: url
+    url: 'https://github.com/rawkode/gitsync'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/managing-linux-in-real-time-with-saltstack.md
+++ b/content/videos/shows/rawkode-live/2020/managing-linux-in-real-time-with-saltstack.md
@@ -3,13 +3,15 @@ id: akvx71sbz8fsyk50yhcde4vz
 slug: managing-linux-in-real-time-with-saltstack
 title: Managing Linux in Real Time with SaltStack
 description: >-
-  In this episode, joined by my colleague Edward Vielmetti, we go through the
-  installation and configuration of a SaltStack cluster for managing a
-  heterogeneous collection of systems.
+  Edward Vielmetti joins to provision a mixed Ubuntu, CentOS and FreeBSD fleet
+  on Packet bare metal using Pulumi with TypeScript, then drive it with Salt:
+  bootstrap, grains, pillars, targeting, and state modules for cron, files and
+  SSH keys.
 publishedAt: 2020-09-17T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - pulumi
   - salt
 show: rawkode-live
 chapters:
@@ -73,15 +75,19 @@ guests:
 resources:
   - title: Salt Pillar Modules documentation
     type: url
+    url: 'https://docs.saltproject.io/en/latest/topics/pillar/'
     category: documentation
   - title: Salt Targeting documentation
     type: url
+    url: 'https://docs.saltproject.io/en/latest/topics/targeting/'
     category: documentation
   - title: Salt State Modules documentation
     type: url
+    url: 'https://docs.saltproject.io/en/latest/ref/states/all/'
     category: documentation
   - title: Salt Bootstrap
     type: url
+    url: 'https://github.com/saltstack/salt-bootstrap'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2020/profiling-php-applications-with-xdebug.md
+++ b/content/videos/shows/rawkode-live/2020/profiling-php-applications-with-xdebug.md
@@ -3,10 +3,10 @@ id: ilwszy3zkvzjrijebbn58eps
 slug: profiling-php-applications-with-xdebug
 title: Profiling PHP Applications with Xdebug
 description: >-
-  In this episode, joined by Derick Rethans, we take a look at Xdebug and how it
-  help you profile your PHP applications, allowing you to use a profiling
-  front-end, like qcachegrind, to visualise your call graphs and dig into the
-  bottlenecks of your applications.
+  Derick Rethans walks through installing Xdebug via PECL, enabling its
+  profiler, and reading the resulting Cachegrind files in QCachegrind to find
+  hot paths, starting from hello-world and factorial scripts before profiling
+  Composer install on a real project.
 publishedAt: 2020-09-18T17:00:00.000Z
 type: live
 category: tutorial
@@ -39,14 +39,16 @@ duration: 5372
 guests:
   - derick-rethans
 resources:
-  - title: QCachegrind profiling viewer
-    type: url
-    category: other
   - title: KCachegrind profiling viewer
+    type: url
+    url: https://kcachegrind.github.io/
+    category: other
+  - title: QCachegrind profiling viewer
     type: url
     category: other
   - title: Composer dependency manager
     type: url
+    url: https://getcomposer.org/
     category: other
   - title: Zulu CMS project
     type: url

--- a/content/videos/shows/rawkode-live/2020/profiling-php-applications-with-xdebug.md
+++ b/content/videos/shows/rawkode-live/2020/profiling-php-applications-with-xdebug.md
@@ -41,14 +41,14 @@ guests:
 resources:
   - title: KCachegrind profiling viewer
     type: url
-    url: https://kcachegrind.github.io/
+    url: 'https://kcachegrind.github.io/'
     category: other
   - title: QCachegrind profiling viewer
     type: url
     category: other
   - title: Composer dependency manager
     type: url
-    url: https://getcomposer.org/
+    url: 'https://getcomposer.org/'
     category: other
   - title: Zulu CMS project
     type: url

--- a/content/videos/shows/rawkode-live/2020/the-newcomers-guide-to-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2020/the-newcomers-guide-to-kubernetes.md
@@ -3,15 +3,16 @@ id: kda08fq63i5ibx1panb4xixj
 slug: the-newcomers-guide-to-kubernetes
 title: The Newcomers Guide to Kubernetes
 description: >-
-  In this episode, joined by David Simmons, we'll take a look at Kubernetes from
-  a newcomers perspective! David has no prior Kubernetes experience and I'll be
-  doing my best to get him up and running, deploying his first application to
-  Kubernetes; in under an hour.
+  David Simmons joins with zero Kubernetes experience and gets walked through
+  kubectl, pods, deployments, multi-container pods, services, ConfigMaps,
+  Secrets, namespaces, port-forwarding, and DaemonSets on a Docker for Mac
+  cluster.
 publishedAt: 2020-09-24T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2020/the-path-to-cloud-native.md
+++ b/content/videos/shows/rawkode-live/2020/the-path-to-cloud-native.md
@@ -3,13 +3,14 @@ id: x4szsngpepdfp7umx1u35jrr
 slug: the-path-to-cloud-native
 title: The Path to Cloud Native
 description: >-
-  Cloud native computing is an approach in software development that utilizes
-  cloud computing to "build and run scalable applications in modern, dynamic
-  environments such as public, private, and hybrid clouds".
+  CNCF ambassador Ihor Dvoretskyi joins David to unpack cloud native adoption,
+  the role of Kubernetes, when microservices make sense versus a monolith,
+  stateful workloads, and the common pitfalls teams hit on the journey.
 publishedAt: 2020-10-20T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2020/what-is-advent-of-code.md
+++ b/content/videos/shows/rawkode-live/2020/what-is-advent-of-code.md
@@ -3,9 +3,10 @@ id: g8ln43qrv5dyrv109fnk9led
 slug: what-is-advent-of-code
 title: What is Advent of Code?
 description: >-
-  Advent of Code is an Advent calendar of small programming puzzles for a
-  variety of skill sets and skill levels that can be solved in any programming
-  language you like.
+  David and Ian George (Orlando Go meetup organizer) tackle Advent of Code 2020
+  Day 7, the bag rules puzzle, live in Go. They cover the philosophy of the
+  puzzles, input parsing with fmt.Sscanf, and recursive logic for counting
+  containing and contained bags.
 publishedAt: 2020-12-08T17:00:00.000Z
 type: live
 category: tutorial
@@ -45,6 +46,7 @@ guests: []
 resources:
   - title: Advent of Code
     type: url
-    category: demos
+    url: 'https://adventofcode.com/'
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/bdd-test-automation.md
+++ b/content/videos/shows/rawkode-live/2021/bdd-test-automation.md
@@ -3,9 +3,10 @@ id: lz9asjenvnxctyheh2554ow8
 slug: bdd-test-automation
 title: BDD Test Automation
 description: >-
-  In this episode, we'll take a look at writing acceptance tests, in Rust, that
-  confirm the scenarios and examples we wrote in previous episodes are
-  implemented correctly.
+  Ciaran McNulty joins David to wire acceptance tests for a Git sync tool in
+  Rust with the Cucumber Rust crate, mapping Gherkin steps to step definitions,
+  matching parameters with cucumber expressions and regex, then driving the
+  Given/When/Then loop until the scenarios pass.
 publishedAt: 2021-01-19T17:00:00.000Z
 type: live
 category: tutorial
@@ -60,6 +61,18 @@ chapters:
 duration: 5375
 guests:
   - ciaran-mcnulty
-resources: []
+resources:
+  - type: url
+    title: Cucumber Rust on GitHub
+    url: 'https://github.com/cucumber-rs/cucumber'
+    category: code
+  - type: url
+    title: Cucumber Rust Book
+    url: 'https://cucumber-rs.github.io/cucumber/main/'
+    category: documentation
+  - type: url
+    title: Gherkin Reference
+    url: 'https://cucumber.io/docs/gherkin/'
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/buiding-a-webassembly-graphql-client.md
+++ b/content/videos/shows/rawkode-live/2021/buiding-a-webassembly-graphql-client.md
@@ -3,12 +3,14 @@ id: d4p1so8omkjzyrpsgvyf5n6d
 slug: buiding-a-webassembly-graphql-client
 title: Buiding a WebAssembly GraphQL Client
 description: >-
-  In this episode, joined by Connor and Francis, we'll attempt to build a
-  GraphQL client using WebAssembly, to hook into Connor's Suborbital project.
+  Connor Hicks and Francis Gulotta join David to add a GraphQL host capability
+  to Suborbital's Reactor, writing the Go-side client and exposing it to a Rust
+  Wasm module over the FFI boundary so sandboxed modules can call GraphQL APIs.
 publishedAt: 2021-07-06T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - rust
   - suborbital
   - webassembly
 show: rawkode-live

--- a/content/videos/shows/rawkode-live/2021/cka-tutorial-with-killer-sh-part-1.md
+++ b/content/videos/shows/rawkode-live/2021/cka-tutorial-with-killer-sh-part-1.md
@@ -3,10 +3,10 @@ id: a1djak0y4g0irt3wnrg17uwa
 slug: cka-tutorial-with-killer-sh-part-1
 title: CKA Tutorial with Killer.sh (Part 1)
 description: >-
-  Rawkode tackles the Killer.sh CKA exam simulator live, working through
-  kubectl contexts, scheduling pods onto control plane nodes, scaling
-  StatefulSets, creating PVs and PVCs with hostPath, kubectl top, and
-  manually scheduling pods by stopping the scheduler.
+  Rawkode tackles the Killer.sh CKA exam simulator live, working through kubectl
+  contexts, scheduling pods onto control plane nodes, scaling StatefulSets,
+  creating PVs and PVCs with hostPath, kubectl top, and manually scheduling pods
+  by stopping the scheduler.
 publishedAt: 2021-06-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/cka-tutorial-with-killer-sh-part-1.md
+++ b/content/videos/shows/rawkode-live/2021/cka-tutorial-with-killer-sh-part-1.md
@@ -3,10 +3,10 @@ id: a1djak0y4g0irt3wnrg17uwa
 slug: cka-tutorial-with-killer-sh-part-1
 title: CKA Tutorial with Killer.sh (Part 1)
 description: >-
-  Kubernetes is a portable, extensible, open-source platform for managing
-  containerized workloads and services, that facilitates both declarative
-  configuration and automation. It has a large, rapidly growing ecosystem.
-  Kubernetes services, support, and tools are widely
+  Rawkode tackles the Killer.sh CKA exam simulator live, working through
+  kubectl contexts, scheduling pods onto control plane nodes, scaling
+  StatefulSets, creating PVs and PVCs with hostPath, kubectl top, and
+  manually scheduling pods by stopping the scheduler.
 publishedAt: 2021-06-09T17:00:00.000Z
 type: live
 category: tutorial
@@ -65,6 +65,7 @@ resources:
     category: demos
   - title: Kubernetes nodeSelector documentation
     type: url
+    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/crossplane-in-action.md
+++ b/content/videos/shows/rawkode-live/2021/crossplane-in-action.md
@@ -3,13 +3,16 @@ id: i3y48lfgt09qvoupcis4dkov
 slug: crossplane-in-action
 title: Crossplane in Action
 description: >-
-  In this episode, Viktor guides us through a complete demo of Crossplane in
-  action.
+  Viktor Farcic walks through Crossplane as a control plane for everything,
+  contrasts it with Terraform and Pulumi, then live-demos provisioning a GKE
+  cluster, building composite resources, and watching drift detection rebuild
+  a deleted node group.
 publishedAt: 2021-09-09T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - crossplane
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -50,20 +53,25 @@ duration: 3334
 guests:
   - viktor-farcic
 resources:
-  - title: Crossplane Getting Started documentation
+  - title: Crossplane documentation
     type: url
+    url: 'https://docs.crossplane.io/'
     category: documentation
   - title: Crossplane contrib providers
     type: url
+    url: 'https://github.com/crossplane-contrib'
     category: code
   - title: Equinix Metal provider for Crossplane
     type: url
+    url: 'https://github.com/crossplane-contrib/provider-equinix-metal'
     category: code
   - title: Civo provider for Crossplane
     type: url
+    url: 'https://github.com/crossplane-contrib/provider-civo'
     category: code
   - title: SQL provider for Crossplane
     type: url
+    url: 'https://github.com/crossplane-contrib/provider-sql'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/crossplane-in-action.md
+++ b/content/videos/shows/rawkode-live/2021/crossplane-in-action.md
@@ -5,8 +5,8 @@ title: Crossplane in Action
 description: >-
   Viktor Farcic walks through Crossplane as a control plane for everything,
   contrasts it with Terraform and Pulumi, then live-demos provisioning a GKE
-  cluster, building composite resources, and watching drift detection rebuild
-  a deleted node group.
+  cluster, building composite resources, and watching drift detection rebuild a
+  deleted node group.
 publishedAt: 2021-09-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hacking-kubernetes-ctf-edition.md
+++ b/content/videos/shows/rawkode-live/2021/hacking-kubernetes-ctf-edition.md
@@ -3,8 +3,10 @@ id: h9myn3s1d0z4rjleaspu4z2f
 slug: hacking-kubernetes-ctf-edition
 title: 'Hacking Kubernetes: CTF Edition'
 description: >-
-  In this episode, Andrew guides me through some #CTFs from his org, Control
-  Plane.
+  Andrew Martin of Control Plane walks David through Kubernetes CTF scenarios
+  from KubeCon: escaping via host mounts, killing crypto-miner deployments
+  through RBAC gaps, executing commands blindly via log streams, and pivoting
+  between containers via shared process namespaces.
 publishedAt: 2021-05-14T17:00:00.000Z
 type: live
 category: tutorial
@@ -116,18 +118,23 @@ guests:
 resources:
   - title: Kubernetes Simulator
     type: url
+    url: 'https://github.com/controlplaneio/simulator'
     category: code
   - title: Hacking Kubernetes book
     type: url
+    url: 'https://www.oreilly.com/library/view/hacking-kubernetes/9781492081722/'
     category: other
   - title: Am I Contained
     type: url
+    url: 'https://github.com/genuinetools/amicontained'
     category: code
   - title: Stern Kubernetes log tailing tool
     type: url
+    url: 'https://github.com/stern/stern'
     category: code
   - title: Bane AppArmor profile tool
     type: url
+    url: 'https://github.com/genuinetools/bane'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cdk8s.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cdk8s.md
@@ -3,9 +3,9 @@ id: mq6iyahwdxmkgsfthongzl40
 slug: hands-on-introduction-to-cdk8s
 title: Hands-on Introduction to cdk8s
 description: >-
-  CDK8s is a software development framework for defining Kubernetes applications
-  and reusable abstractions using familiar programming languages and rich
-  object-oriented APIs.
+  Live walkthrough of cdk8s with creator Elad Ben Israel, covering the App and
+  Chart model, snapshot testing, cdk8s+, importing CRDs, wrapping Helm charts,
+  and JSON escape patches.
 publishedAt: 2021-04-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -93,14 +93,13 @@ duration: 4359
 guests:
   - elad-ben-israel
 resources:
-  - title: Cluster API project
-    type: url
-    category: code
   - title: 'cdk8s Concepts: Escape Patches'
     type: url
+    url: 'https://cdk8s.io/docs/latest/basics/escape-hatches/'
     category: documentation
   - title: Construct Catalog
     type: url
+    url: 'https://constructs.dev/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cue.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cue.md
@@ -3,8 +3,10 @@ id: ny3894ofmg0wckadbxrcum2l
 slug: hands-on-introduction-to-cue
 title: Hands-on Introduction to CUE
 description: >-
-  In this episode, Marcel and I will teach you everything you need to know to
-  get started with CUE.
+  Marcel van Lohuizen, creator of CUE, joins Rawkode for a hands-on
+  introduction to the data constraint language. They cover unification, the
+  type lattice, validation, and Kubernetes manifest generation, then work
+  through the official tutorial together.
 publishedAt: 2021-04-28T17:00:00.000Z
 type: live
 category: tutorial
@@ -104,12 +106,15 @@ guests:
 resources:
   - title: CUE Kubernetes tutorial
     type: url
+    url: 'https://github.com/cue-lang/cue/blob/master/doc/tutorial/kubernetes/README.md'
     category: documentation
   - title: CUE GitHub Discussions
     type: url
+    url: 'https://github.com/cue-lang/cue/discussions'
     category: other
   - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cue.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cue.md
@@ -3,10 +3,10 @@ id: ny3894ofmg0wckadbxrcum2l
 slug: hands-on-introduction-to-cue
 title: Hands-on Introduction to CUE
 description: >-
-  Marcel van Lohuizen, creator of CUE, joins Rawkode for a hands-on
-  introduction to the data constraint language. They cover unification, the
-  type lattice, validation, and Kubernetes manifest generation, then work
-  through the official tutorial together.
+  Marcel van Lohuizen, creator of CUE, joins Rawkode for a hands-on introduction
+  to the data constraint language. They cover unification, the type lattice,
+  validation, and Kubernetes manifest generation, then work through the official
+  tutorial together.
 publishedAt: 2021-04-28T17:00:00.000Z
 type: live
 category: tutorial
@@ -106,7 +106,8 @@ guests:
 resources:
   - title: CUE Kubernetes tutorial
     type: url
-    url: 'https://github.com/cue-lang/cue/blob/master/doc/tutorial/kubernetes/README.md'
+    url: >-
+      https://github.com/cue-lang/cue/blob/master/doc/tutorial/kubernetes/README.md
     category: documentation
   - title: CUE GitHub Discussions
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cueblox.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cueblox.md
@@ -4,9 +4,8 @@ slug: hands-on-introduction-to-cueblox
 title: Hands-on Introduction to CueBlox
 description: >-
   Brian Ketelsen and David walk through CueBlox: defining content schemas in
-  CUE, validating Markdown/YAML data, serving it as a GraphQL API, and
-  extending the workflow with HashiCorp-style plugins for image processing
-  and CDN sync.
+  CUE, validating Markdown/YAML data, serving it as a GraphQL API, and extending
+  the workflow with HashiCorp-style plugins for image processing and CDN sync.
 publishedAt: 2021-09-08T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cueblox.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-cueblox.md
@@ -3,14 +3,16 @@ id: wlmkeyi2ain92p240tlugp07
 slug: hands-on-introduction-to-cueblox
 title: Hands-on Introduction to CueBlox
 description: >-
-  In this episode, Brian and David will show you how to use CUE and CueBlox to
-  validate your arbitrary data with explicit schemata and serve it over REST and
-  GraphQL.
+  Brian Ketelsen and David walk through CueBlox: defining content schemas in
+  CUE, validating Markdown/YAML data, serving it as a GraphQL API, and
+  extending the workflow with HashiCorp-style plugins for image processing
+  and CDN sync.
 publishedAt: 2021-09-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - cueblox
+  - cue
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -62,9 +64,11 @@ resources:
     category: other
   - title: CueBlox dogfood directory
     type: url
+    url: 'https://github.com/cueblox/blox/tree/main/dogfood'
     category: demos
   - title: bketelsen/bkapi repository
     type: url
+    url: 'https://github.com/bketelsen/bkapi'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-dagger.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-dagger.md
@@ -2,12 +2,14 @@
 id: u3iqqcgeoamsqzclierrpqdl
 slug: hands-on-introduction-to-dagger
 title: Hands-on Introduction to Dagger
-description: "In this episode, we get hands-on with Dagger.\n\n\n\U0001F37F Rawkode Live\n\nHosted by David McKay / \U0001F426 https://twitter.com/rawkode\nWebsite: https://rawkode.live\nDiscord Chat: https://rawkode.live/chat\n\n#RawkodeLive\n\n\U0001F570 Timeline\n\n00:00 - Holding Screen\n00:50 - Introductions\n03:20 - What is Dagger?\n07:45 - Why CUE and BuildKit\n10:45 - Installing Dagger\n16:00 - Dagger Example: Static Todo Deployment\n\n\U0001F465 About the Guests\n\nSolomon Hykes\n\n  Cofounder of Docker\n\n\n\U0001F426 https://twitter.com/solomonstre\n\U0001F9E9 https://github.com/shykes\n\n\n\n\U0001F528 About the Technologies\n\nDagger\n\nDagger is a programmable deployment system.\nUsing Dagger, software builders can automate the deployment of any application to any infrastructure, in just a few lines of code.\n\n\U0001F30F https://dagger.io/\n\n\U0001F9E9 https://github.com/dagger/dagger"
+description: Solomon Hykes introduces Dagger, a programmable deployment system built on CUE and BuildKit. We install the CLI, write a Dagger plan to deploy a static todo app to S3, then extend it to multi-bucket and Netlify environments using inputs and secrets.
 publishedAt: 2021-06-29T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - dagger
+  - cue
+  - buildkit
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -74,9 +76,7 @@ resources:
     category: other
   - title: CUE interactive playground
     type: url
+    url: 'https://cuelang.org/play/'
     category: demos
-  - title: sigstore project
-    type: url
-    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-dagger.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-dagger.md
@@ -2,7 +2,11 @@
 id: u3iqqcgeoamsqzclierrpqdl
 slug: hands-on-introduction-to-dagger
 title: Hands-on Introduction to Dagger
-description: Solomon Hykes introduces Dagger, a programmable deployment system built on CUE and BuildKit. We install the CLI, write a Dagger plan to deploy a static todo app to S3, then extend it to multi-bucket and Netlify environments using inputs and secrets.
+description: >-
+  Solomon Hykes introduces Dagger, a programmable deployment system built on CUE
+  and BuildKit. We install the CLI, write a Dagger plan to deploy a static todo
+  app to S3, then extend it to multi-bucket and Netlify environments using
+  inputs and secrets.
 publishedAt: 2021-06-29T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-firecracker.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-firecracker.md
@@ -2,9 +2,10 @@
 id: czi3j87pkjuupnifphnpqnor
 slug: hands-on-introduction-to-firecracker
 title: Hands-on Introduction to Firecracker
-description: >-
-  In this episode, Radu and Grabriel will walk us through everything we need to
-  know to get started with Firecracker.
+description: Radu and Gabriel from AWS demo Firecracker from the ground up: the
+  firecracker and jailer binaries, booting a microVM over the REST API on a Unix
+  socket, networking and device emulation, the Go SDK, plus a hands-on
+  snapshotting walkthrough comparing full and diff snapshots.
 publishedAt: 2021-05-25T17:00:00.000Z
 type: live
 category: tutorial
@@ -94,14 +95,18 @@ resources:
   - title: Firecracker Quick Start Guide
     type: url
     category: documentation
+    url: https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
   - title: Firecracker Swagger API specification
     type: url
     category: documentation
+    url: https://github.com/firecracker-microvm/firecracker/blob/main/src/firecracker/swagger/firecracker.yaml
   - title: Firecracker Go SDK
     type: url
     category: code
+    url: https://github.com/firecracker-microvm/firecracker-go-sdk
   - title: Weave Ignite
     type: url
     category: code
+    url: https://github.com/weaveworks/ignite
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-firecracker.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-firecracker.md
@@ -2,10 +2,11 @@
 id: czi3j87pkjuupnifphnpqnor
 slug: hands-on-introduction-to-firecracker
 title: Hands-on Introduction to Firecracker
-description: Radu and Gabriel from AWS demo Firecracker from the ground up: the
-  firecracker and jailer binaries, booting a microVM over the REST API on a Unix
-  socket, networking and device emulation, the Go SDK, plus a hands-on
-  snapshotting walkthrough comparing full and diff snapshots.
+description: >-
+  Radu and Gabriel from AWS demo Firecracker from the ground up. They walk
+  through firecracker and jailer binaries, booting a microVM over the REST API
+  on a Unix socket, networking and device emulation, the Go SDK, plus a
+  hands-on snapshotting walkthrough comparing full and diff snapshots.
 publishedAt: 2021-05-25T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-jspolicy.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-jspolicy.md
@@ -3,13 +3,18 @@ id: p4bjwtw1dwufd4yipdrp7dhi
 slug: hands-on-introduction-to-jspolicy
 title: Hands-on Introduction to jsPolicy
 description: >-
-  In this episode, we take a look at jsPolicy. We'll see how to get started
-  writing validating and mutating policies in JavaScript for Kubernetes.
+  Lukas Gentele from Loft Labs joins to introduce jsPolicy, a Kubernetes
+  admission controller that lets you write validating, mutating, and controller
+  policies in JavaScript or TypeScript, with comparisons to OPA and Kyverno.
 publishedAt: 2021-09-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - jspolicy
+  - kubernetes
+  - kyverno
+  - opa
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -91,11 +96,14 @@ resources:
   - title: jsPolicy Architecture docs page
     type: url
     category: documentation
+    url: 'https://www.jspolicy.com/docs/architecture'
   - title: jsPolicy example policies repository
     type: url
     category: code
+    url: 'https://github.com/loft-sh/jspolicy/tree/main/examples'
   - title: jsPolicy SDK starter project
     type: url
     category: code
+    url: 'https://github.com/loft-sh/jspolicy-sdk'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-k0s.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-k0s.md
@@ -3,13 +3,16 @@ id: yd4z5rt8qgwxouhdzkzpt8ly
 slug: hands-on-introduction-to-k0s
 title: Hands-on Introduction to K0s
 description: >-
-  In this episode, Jussi will guide us through everything we need to know about
-  K0s.
+  Jussi Nummelin walks through k0s, the single-binary Kubernetes distribution
+  from Mirantis. We cover control plane isolation, single-node and HA install,
+  then drive multi-node deploys and upgrades with k0sctl plus a Terraform demo.
 publishedAt: 2021-08-12T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - k0s
+  - kubernetes
+  - terraform
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -78,8 +81,13 @@ duration: 3913
 guests:
   - jussi-nummelin
 resources:
-  - title: k0s Getting Started Guide
+  - title: k0s documentation
     type: url
+    url: 'https://docs.k0sproject.io/'
     category: documentation
+  - title: k0sctl on GitHub
+    type: url
+    url: 'https://github.com/k0sproject/k0sctl'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-kaniko.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-kaniko.md
@@ -106,14 +106,14 @@ resources:
   - title: Kaniko Getting Started tutorial
     type: url
     category: documentation
-    url: https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
+    url: 'https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts'
   - title: Kaniko build context documentation
     type: url
     category: documentation
-    url: https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
+    url: 'https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts'
   - title: GitLab tutorial dedicated to Kaniko
     type: url
     category: documentation
-    url: https://docs.gitlab.com/ci/docker/using_kaniko/
+    url: 'https://docs.gitlab.com/ci/docker/using_kaniko/'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-kaniko.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-kaniko.md
@@ -3,13 +3,17 @@ id: nf0c2zf2w370qg9s6d74ywjd
 slug: hands-on-introduction-to-kaniko
 title: Hands-on Introduction to Kaniko
 description: >-
-  In this episode, we'll guide you through everything you need to know to get
-  started with Kaniko
+  Tejal Desai (Kaniko maintainer at Google) walks through building container
+  images inside Kubernetes without Docker-in-Docker, covering the executor pod,
+  registry secrets, layer caching, snapshot modes, and Tekton/GitLab CI.
 publishedAt: 2021-04-23T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kaniko
+  - kubernetes
+  - tektoncd
+  - gitlab
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -102,11 +106,14 @@ resources:
   - title: Kaniko Getting Started tutorial
     type: url
     category: documentation
+    url: https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
   - title: Kaniko build context documentation
     type: url
     category: documentation
+    url: https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
   - title: GitLab tutorial dedicated to Kaniko
     type: url
     category: documentation
+    url: https://docs.gitlab.com/ci/docker/using_kaniko/
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-lens.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-lens.md
@@ -101,15 +101,15 @@ resources:
   - title: Mirantis Kubernetes cheat sheet
     type: url
     category: documentation
-    url: https://www.mirantis.com/blog/kubernetes-cheat-sheet/
+    url: 'https://www.mirantis.com/blog/kubernetes-cheat-sheet/'
   - title: Aqua Security Starboard extension
     type: url
     category: code
-    url: https://github.com/aquasecurity/starboard
+    url: 'https://github.com/aquasecurity/starboard'
   - title: Lens Resource Map extension
     type: url
     category: code
-    url: https://github.com/nevalla/lens-resource-map-extension
+    url: 'https://github.com/nevalla/lens-resource-map-extension'
   - title: BoardD open source technology
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-lens.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-lens.md
@@ -3,13 +3,18 @@ id: gy8w7dfqeaszt1c49v5k1ah0
 slug: hands-on-introduction-to-lens
 title: Hands-on Introduction to Lens
 description: >-
-  In this episode, Edwards walks us through everything we need to know to get
-  started with Lens, the Kubernetes IDE.
+  Edward from Mirantis tours Lens, the Kubernetes IDE: unified catalog, hotbar,
+  command palette, built-in Prometheus metrics, smart terminal context
+  switching, Helm chart deployment, extensions (Starboard, Resource Map), and
+  sharing clusters via Lens Spaces with ClusterConnect.
 publishedAt: 2021-08-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - lens
+  - kubernetes
+  - helm
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -96,12 +101,15 @@ resources:
   - title: Mirantis Kubernetes cheat sheet
     type: url
     category: documentation
+    url: https://www.mirantis.com/blog/kubernetes-cheat-sheet/
   - title: Aqua Security Starboard extension
     type: url
     category: code
+    url: https://github.com/aquasecurity/starboard
   - title: Lens Resource Map extension
     type: url
     category: code
+    url: https://github.com/nevalla/lens-resource-map-extension
   - title: BoardD open source technology
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-litestream.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-litestream.md
@@ -2,7 +2,10 @@
 id: fkojb4nty2dmx3byhpltqwnn
 slug: hands-on-introduction-to-litestream
 title: Hands-on Introduction to Litestream
-description: Ben Johnson walks through Litestream, his streaming replication tool for SQLite. We cover how it tails the WAL, ships segments to S3 or Azure, and restores point-in-time copies, then install it and replicate a live database.
+description: >-
+  Ben Johnson walks through Litestream, his streaming replication tool for
+  SQLite. We cover how it tails the WAL, ships segments to S3 or Azure, and
+  restores point-in-time copies, then install it and replicate a live database.
 publishedAt: 2021-06-22T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-litestream.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-litestream.md
@@ -2,7 +2,7 @@
 id: fkojb4nty2dmx3byhpltqwnn
 slug: hands-on-introduction-to-litestream
 title: Hands-on Introduction to Litestream
-description: ".\n\n\n\U0001F37F Rawkode Live\n\nHosted by David McKay / \U0001F426 https://twitter.com/rawkode\nWebsite: https://rawkode.live\nDiscord Chat: https://rawkode.live/chat\n\n#RawkodeLive\n\n\U0001F570 Timeline\n\n00:00 - Holding Screen\n01:30 - Introductions\n09:45 - Slides: SQLite Streaming Replication with Litestream\n19:0 - Installing Litestream\n25:00 - Creating a SQLite Database\n28:40 - Replicating SQLite with Litestream\n34:30 - Litestream Subcommands\n44:30 - Restoring SQLite with Litestream\n50:00 - Summary\n\n\U0001F465 About the Guests\n\nBen Johnson\n\n  Building @litestreamio to help developers run SQLite in production and at scale.\n\n\n\U0001F426 https://twitter.com/benbjohnson\n\U0001F9E9 https://github.com/benbjohnson\n\n\n\n\U0001F528 About the Technologies\n\nLitestream\n\nLitestream is a standalone streaming replication tool for SQLite. It runs as a background process and safely replicates changes incrementally to another file or S3. Litestream only communicates with SQLite through the SQLite API so it will not corrupt your database.\n\n\U0001F30F https://litestream.io/\n\U0001F426 https://twitter.com/litestreamio\n\U0001F9E9 https://github.com/benbjohnson/litestream"
+description: Ben Johnson walks through Litestream, his streaming replication tool for SQLite. We cover how it tails the WAL, ships segments to S3 or Azure, and restores point-in-time copies, then install it and replicate a live database.
 publishedAt: 2021-06-22T17:00:00.000Z
 type: live
 category: tutorial
@@ -94,9 +94,11 @@ guests:
 resources:
   - title: Litestream Getting Started guide
     type: url
+    url: 'https://litestream.io/getting-started/'
     category: documentation
   - title: Litestream Tips and Caveats section
     type: url
+    url: 'https://litestream.io/tips/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-loki.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-loki.md
@@ -3,14 +3,19 @@ id: jevfafsrta5dekkl6td02hhc
 slug: hands-on-introduction-to-loki
 title: Hands-on Introduction to Loki
 description: >-
-  Cyril Tovena is a software engineer at Grafana Labs and a member of the Loki
-  team. He previously worked at Ubisoft, where he co-founded Agones, a platform
-  to scale dedicated game servers on top of Kubernetes.
+  Cyril Tovena from Grafana Labs walks through Loki hands-on: installing the
+  Loki stack on Kubernetes via Helm, shipping logs with Promtail, and querying
+  the Sock Shop demo with LogQL filters, parsers, and metric aggregations in
+  Grafana.
 publishedAt: 2021-04-29T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - loki
+  - grafana
+  - prometheus
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -71,9 +76,11 @@ guests:
 resources:
   - title: Weaveworks Sock Shop microservice demo
     type: url
+    url: https://github.com/microservices-demo/microservices-demo
     category: demos
   - title: Grafana LogQL documentation
     type: url
+    url: https://grafana.com/docs/loki/latest/logql/
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-loki.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-loki.md
@@ -76,11 +76,11 @@ guests:
 resources:
   - title: Weaveworks Sock Shop microservice demo
     type: url
-    url: https://github.com/microservices-demo/microservices-demo
+    url: 'https://github.com/microservices-demo/microservices-demo'
     category: demos
   - title: Grafana LogQL documentation
     type: url
-    url: https://grafana.com/docs/loki/latest/logql/
+    url: 'https://grafana.com/docs/loki/latest/logql/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-okteto.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-okteto.md
@@ -3,10 +3,9 @@ id: mbehnf2kqdrdmagxryh6e7tc
 slug: hands-on-introduction-to-okteto
 title: Hands-on Introduction to Okteto
 description: >-
-  Ramiro Berrelleza walks through Okteto Cloud and the okteto CLI, deploying
-  the Movies sample with Helm and BuildKit, then using okteto up to sync code
-  into a live Kubernetes pod. Plus Docker Compose support and preview
-  environments.
+  Ramiro Berrelleza walks through Okteto Cloud and the okteto CLI, deploying the
+  Movies sample with Helm and BuildKit, then using okteto up to sync code into a
+  live Kubernetes pod. Plus Docker Compose support and preview environments.
 publishedAt: 2021-05-19T17:00:00.000Z
 type: live
 category: tutorial
@@ -77,18 +76,18 @@ resources:
   - title: Okteto Quick Start Guide
     type: url
     category: documentation
-    url: https://www.okteto.com/docs/get-started/dev-quickstart/
+    url: 'https://www.okteto.com/docs/get-started/dev-quickstart/'
   - title: Okteto Movies sample application
     type: url
     category: demos
-    url: https://github.com/okteto/movies
+    url: 'https://github.com/okteto/movies'
   - title: Okteto Preview Environments documentation
     type: url
     category: documentation
-    url: https://www.okteto.com/docs/previews/
+    url: 'https://www.okteto.com/docs/previews/'
   - title: Docker samples voting app
     type: url
     category: demos
-    url: https://github.com/dockersamples/example-voting-app
+    url: 'https://github.com/dockersamples/example-voting-app'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-okteto.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-okteto.md
@@ -3,13 +3,19 @@ id: mbehnf2kqdrdmagxryh6e7tc
 slug: hands-on-introduction-to-okteto
 title: Hands-on Introduction to Okteto
 description: >-
-  In this episode, we'll guide you through everything you need to get started
-  developing on Kubernetes with Okteto.
+  Ramiro Berrelleza walks through Okteto Cloud and the okteto CLI, deploying
+  the Movies sample with Helm and BuildKit, then using okteto up to sync code
+  into a live Kubernetes pod. Plus Docker Compose support and preview
+  environments.
 publishedAt: 2021-05-19T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - okteto
+  - kubernetes
+  - helm
+  - buildkit
+  - docker-compose
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -71,14 +77,18 @@ resources:
   - title: Okteto Quick Start Guide
     type: url
     category: documentation
+    url: https://www.okteto.com/docs/get-started/dev-quickstart/
   - title: Okteto Movies sample application
     type: url
     category: demos
+    url: https://github.com/okteto/movies
   - title: Okteto Preview Environments documentation
     type: url
     category: documentation
+    url: https://www.okteto.com/docs/previews/
   - title: Docker samples voting app
     type: url
     category: demos
+    url: https://github.com/dockersamples/example-voting-app
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-pixie.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-pixie.md
@@ -2,7 +2,11 @@
 id: ymhs0sxdh5vb6uwi88xcfiuw
 slug: hands-on-introduction-to-pixie
 title: Hands-on Introduction to Pixie
-description: 'Natalie Serrino walks through Pixie, the eBPF-powered Kubernetes observability tool. We deploy Vizier with the etcd operator, explore PxL scripts, trace HTTP and gRPC traffic, view flame graphs, and wire up a Slack alert via the Go client.'
+description: >-
+  Natalie Serrino walks through Pixie, the eBPF-powered Kubernetes observability
+  tool. We deploy Vizier with the etcd operator, explore PxL scripts, trace HTTP
+  and gRPC traffic, view flame graphs, and wire up a Slack alert via the Go
+  client.
 publishedAt: 2021-07-08T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-pixie.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-pixie.md
@@ -2,7 +2,7 @@
 id: ymhs0sxdh5vb6uwi88xcfiuw
 slug: hands-on-introduction-to-pixie
 title: Hands-on Introduction to Pixie
-description: 'In this episode, we take a look at observability within Kubernetes with Pixie.'
+description: 'Natalie Serrino walks through Pixie, the eBPF-powered Kubernetes observability tool. We deploy Vizier with the etcd operator, explore PxL scripts, trace HTTP and gRPC traffic, view flame graphs, and wire up a Slack alert via the Go client.'
 publishedAt: 2021-07-08T17:00:00.000Z
 type: live
 category: tutorial
@@ -96,17 +96,21 @@ duration: 4066
 guests:
   - natalie-serrino
 resources:
-  - title: Pixie supported protocols documentation
+  - title: Pixie supported data sources documentation
     type: url
+    url: 'https://docs.px.dev/about-pixie/data-sources/'
     category: documentation
   - title: Pixie Grafana data source plugin
     type: url
+    url: 'https://github.com/pixie-io/grafana-plugin'
     category: code
   - title: Pixie Slack alert tutorial
     type: url
+    url: 'https://docs.px.dev/tutorials/integrations/slackbot-alert/'
     category: documentation
-  - title: PixieScript operators reference documentation
+  - title: PxL operators reference documentation
     type: url
+    url: 'https://docs.px.dev/reference/pxl/operators/'
     category: documentation
   - title: Pixie Socks Shop demo
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-promscale.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-promscale.md
@@ -3,13 +3,20 @@ id: ua00ojunaspa1sus0ykiqxxr
 slug: hands-on-introduction-to-promscale
 title: Hands-on Introduction to Promscale
 description: >-
-  In this episode, Vineeth and Mat will teach us everything we need to know to
-  get started with Promscale.
+  Mat and Vineeth from Timescale show how Promscale stores Prometheus metrics
+  in TimescaleDB, then deploy it on Kubernetes with TOBS and query the data
+  using both PromQL and SQL in Grafana.
 publishedAt: 2021-05-20T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - promscale
+  - timescale
+  - prometheus
+  - grafana
+  - postgresql
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -89,6 +96,7 @@ resources:
   - title: Getting started with Promscale doc
     type: url
     category: documentation
+    url: 'https://promscale-legacy-docs.timescale.com/'
   - title: Dan Liu post about getting more value from metrics
     type: url
     category: other

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-promscale.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-promscale.md
@@ -3,9 +3,9 @@ id: ua00ojunaspa1sus0ykiqxxr
 slug: hands-on-introduction-to-promscale
 title: Hands-on Introduction to Promscale
 description: >-
-  Mat and Vineeth from Timescale show how Promscale stores Prometheus metrics
-  in TimescaleDB, then deploy it on Kubernetes with TOBS and query the data
-  using both PromQL and SQL in Grafana.
+  Mat and Vineeth from Timescale show how Promscale stores Prometheus metrics in
+  TimescaleDB, then deploy it on Kubernetes with TOBS and query the data using
+  both PromQL and SQL in Grafana.
 publishedAt: 2021-05-20T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-sigstore.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-sigstore.md
@@ -3,13 +3,19 @@ id: q6rdfil6z5qc6sx4jvomp320
 slug: hands-on-introduction-to-sigstore
 title: Hands-on Introduction to sigstore
 description: >-
-  In this episode, Dan guides us through everything we need to get started with
-  Project sigstore.
+  Dan Lorenc walks through sigstore: signing and verifying container images
+  with cosign, keyless signing via OIDC, querying the Rekor transparency log,
+  in-toto build attestations, and enforcing signed images at admission with
+  Kyverno.
 publishedAt: 2021-08-04T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - sigstore
+  - tuf
+  - in-toto
+  - kyverno
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -88,9 +94,11 @@ guests:
 resources:
   - title: The Update Framework
     type: url
+    url: 'https://theupdateframework.io/'
     category: documentation
   - title: Verifiable supply chain metadata for Tekton
     type: url
+    url: 'https://github.com/tektoncd/chains'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-sigstore.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-sigstore.md
@@ -3,10 +3,9 @@ id: q6rdfil6z5qc6sx4jvomp320
 slug: hands-on-introduction-to-sigstore
 title: Hands-on Introduction to sigstore
 description: >-
-  Dan Lorenc walks through sigstore: signing and verifying container images
-  with cosign, keyless signing via OIDC, querying the Rekor transparency log,
-  in-toto build attestations, and enforcing signed images at admission with
-  Kyverno.
+  Dan Lorenc walks through sigstore: signing and verifying container images with
+  cosign, keyless signing via OIDC, querying the Rekor transparency log, in-toto
+  build attestations, and enforcing signed images at admission with Kyverno.
 publishedAt: 2021-08-04T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-skaffold.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-skaffold.md
@@ -3,13 +3,18 @@ id: amlf5sohn10i3vuzoqcmzm0a
 slug: hands-on-introduction-to-skaffold
 title: Hands-on Introduction to Skaffold
 description: >-
-  In this episode, Vic will guide us through everything we need to know to get
-  started developing for #Kubernetes, locally, with Skaffold.
+  Vic Iglesias guides Rawkode through Skaffold, Google's tool that automates
+  the build, push, and deploy loop for Kubernetes. Hands-on demos cover Go
+  microservices, TypeScript file sync, Buildpacks with Python, Helm,
+  multi-config modules, and React hot module reload.
 publishedAt: 2021-04-28T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - skaffold
+  - kubernetes
+  - helm
+  - buildpacks
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -116,12 +121,15 @@ guests:
 resources:
   - title: Skaffold microservices example
     type: url
+    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/microservices'
     category: demos
   - title: Skaffold React reload example
     type: url
+    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/react-reload'
     category: demos
   - title: Skaffold custom test example
     type: url
+    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/custom-tests'
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-skaffold.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-skaffold.md
@@ -3,8 +3,8 @@ id: amlf5sohn10i3vuzoqcmzm0a
 slug: hands-on-introduction-to-skaffold
 title: Hands-on Introduction to Skaffold
 description: >-
-  Vic Iglesias guides Rawkode through Skaffold, Google's tool that automates
-  the build, push, and deploy loop for Kubernetes. Hands-on demos cover Go
+  Vic Iglesias guides Rawkode through Skaffold, Google's tool that automates the
+  build, push, and deploy loop for Kubernetes. Hands-on demos cover Go
   microservices, TypeScript file sync, Buildpacks with Python, Helm,
   multi-config modules, and React hot module reload.
 publishedAt: 2021-04-28T17:00:00.000Z
@@ -121,15 +121,18 @@ guests:
 resources:
   - title: Skaffold microservices example
     type: url
-    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/microservices'
+    url: >-
+      https://github.com/GoogleContainerTools/skaffold/tree/main/examples/microservices
     category: demos
   - title: Skaffold React reload example
     type: url
-    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/react-reload'
+    url: >-
+      https://github.com/GoogleContainerTools/skaffold/tree/main/examples/react-reload
     category: demos
   - title: Skaffold custom test example
     type: url
-    url: 'https://github.com/GoogleContainerTools/skaffold/tree/main/examples/custom-tests'
+    url: >-
+      https://github.com/GoogleContainerTools/skaffold/tree/main/examples/custom-tests
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-snyk.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-snyk.md
@@ -2,7 +2,11 @@
 id: xbfhkuz66nc3g08axlx7zffb
 slug: hands-on-introduction-to-snyk
 title: Hands-on Introduction to Snyk
-description: Matt Jarvis walks through Snyk hands-on, from importing a GitHub repo into the web UI and fixing dependency vulnerabilities via automated PRs, through Snyk Code data-flow analysis and VS Code, to container image scans, the CLI, and Kubernetes YAML IaC scanning.
+description: >-
+  Matt Jarvis walks through Snyk hands-on, from importing a GitHub repo into the
+  web UI and fixing dependency vulnerabilities via automated PRs, through Snyk
+  Code data-flow analysis and VS Code, to container image scans, the CLI, and
+  Kubernetes YAML IaC scanning.
 publishedAt: 2021-07-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -88,11 +92,11 @@ guests:
 resources:
   - title: n8n workflow automation project
     type: url
-    url: https://github.com/n8n-io/n8n
+    url: 'https://github.com/n8n-io/n8n'
     category: code
   - title: CNCF Cloud Native Security Whitepaper
     type: url
-    url: https://github.com/cncf/tag-security/tree/main/security-whitepaper
+    url: 'https://github.com/cncf/tag-security/tree/main/security-whitepaper'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-snyk.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-snyk.md
@@ -2,7 +2,7 @@
 id: xbfhkuz66nc3g08axlx7zffb
 slug: hands-on-introduction-to-snyk
 title: Hands-on Introduction to Snyk
-description: ".\n\n\n\U0001F37F Rawkode Live\n\nHosted by David McKay / \U0001F426 https://twitter.com/rawkode\nWebsite: https://rawkode.live\nDiscord Chat: https://rawkode.live/chat\n\n#RawkodeLive\n\n\U0001F570 Timeline\n\n00:00 - Holding Screen\n01:20 - Introductions\n04:40 - What is Snyk?\n13:40 - Adding a Repository to Snyk Web UI\n16:00 - Dependency Security Alerts\n34:00 - Code Analysis\n41:30 - Container Image Scanning\n59:00 - Snyk CLI\n01:07:00 - Kubernetes YAML Scanning\n\n\U0001F465 About the Guests\n\nMatt Jarvis\n\n  Senior Developer Advocate @snyksec. Co-founder Cloud Native Manchester, Co-founder Cloud Native Edinburgh. Ex-OpenStacker\n\n\n\U0001F426 https://twitter.com/mattj_io\n\U0001F9E9 https://github.com/snyk-matt\n\n\n\n\U0001F528 About the Technologies\n\nSnyk\n\nSnyk helps you find, fix and monitor known vulnerabilities in open source \n\n\U0001F30F https://snyk.io/\n\U0001F426 https://twitter.com/snyksec\n\U0001F9E9 https://github.com/snyk/snyk"
+description: Matt Jarvis walks through Snyk hands-on, from importing a GitHub repo into the web UI and fixing dependency vulnerabilities via automated PRs, through Snyk Code data-flow analysis and VS Code, to container image scans, the CLI, and Kubernetes YAML IaC scanning.
 publishedAt: 2021-07-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -88,9 +88,11 @@ guests:
 resources:
   - title: n8n workflow automation project
     type: url
+    url: https://github.com/n8n-io/n8n
     category: code
   - title: CNCF Cloud Native Security Whitepaper
     type: url
+    url: https://github.com/cncf/tag-security/tree/main/security-whitepaper
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-telepresence.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-telepresence.md
@@ -3,13 +3,15 @@ id: nkhgy2xrrgh6ljas65ds3nrd
 slug: hands-on-introduction-to-telepresence
 title: Hands-on Introduction to Telepresence
 description: >-
-  In this episode, we'll be guided through everything we need to get started
-  developing our applications with Kubernetes using Telepresence.
+  Daniel Bryant and Peter O'Neill from Ambassador Labs walk through Telepresence:
+  installing the CLI, connecting to a remote cluster, intercepting traffic to a
+  local service, and sharing preview URLs via Ambassador Cloud.
 publishedAt: 2021-05-18T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - telepresence
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -77,12 +79,15 @@ guests:
 resources:
   - title: Telepresence DNS resolution documentation
     type: url
+    url: 'https://telepresence.io/docs/reference/dns'
     category: documentation
   - title: Telepresence Docker for Intercepts documentation
     type: url
+    url: 'https://telepresence.io/docs/howtos/docker'
     category: documentation
   - title: Telepresence RBAC documentation
     type: url
+    url: 'https://telepresence.io/docs/reference/rbac'
     category: documentation
   - title: Telepresence and Linkerd documentation
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-telepresence.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-telepresence.md
@@ -3,9 +3,9 @@ id: nkhgy2xrrgh6ljas65ds3nrd
 slug: hands-on-introduction-to-telepresence
 title: Hands-on Introduction to Telepresence
 description: >-
-  Daniel Bryant and Peter O'Neill from Ambassador Labs walk through Telepresence:
-  installing the CLI, connecting to a remote cluster, intercepting traffic to a
-  local service, and sharing preview URLs via Ambassador Cloud.
+  Daniel Bryant and Peter O'Neill from Ambassador Labs walk through
+  Telepresence: installing the CLI, connecting to a remote cluster, intercepting
+  traffic to a local service, and sharing preview URLs via Ambassador Cloud.
 publishedAt: 2021-05-18T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-tyk.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-tyk.md
@@ -5,8 +5,8 @@ title: Hands-on Introduction to Tyk
 description: >-
   Andy Smith and Budha Bhattacharya from Tyk walk through the open-source API
   gateway: installing it on Kubernetes with Helm, configuring keyless and
-  API-key auth, rate limits, the Tyk Operator, and stitching REST sources into
-  a GraphQL universal data graph.
+  API-key auth, rate limits, the Tyk Operator, and stitching REST sources into a
+  GraphQL universal data graph.
 publishedAt: 2021-09-15T17:00:00.000Z
 type: live
 category: tutorial
@@ -139,7 +139,8 @@ resources:
     category: documentation
   - title: Tyk Operator httpbin sample manifest
     type: url
-    url: 'https://github.com/TykTechnologies/tyk-operator/blob/legacy/config/samples/httpbin.yaml'
+    url: >-
+      https://github.com/TykTechnologies/tyk-operator/blob/legacy/config/samples/httpbin.yaml
     category: code
   - title: JSONPlaceholder users API demo endpoint
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-tyk.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-tyk.md
@@ -3,8 +3,10 @@ id: shduj6ini35ebkqltlqfdagb
 slug: hands-on-introduction-to-tyk
 title: Hands-on Introduction to Tyk
 description: >-
-  In this episode, we'll be guided through everything we need to know to get
-  started with Tyk.
+  Andy Smith and Budha Bhattacharya from Tyk walk through the open-source API
+  gateway: installing it on Kubernetes with Helm, configuring keyless and
+  API-key auth, rate limits, the Tyk Operator, and stitching REST sources into
+  a GraphQL universal data graph.
 publishedAt: 2021-09-15T17:00:00.000Z
 type: live
 category: tutorial
@@ -129,15 +131,19 @@ guests:
 resources:
   - title: Tyk Getting Started guide
     type: url
+    url: 'https://tyk.io/docs/getting-started/'
     category: documentation
   - title: Tyk Operator installation guide
     type: url
+    url: 'https://tyk.io/docs/tyk-stack/tyk-operator/installing-tyk-operator/'
     category: documentation
   - title: Tyk Operator httpbin sample manifest
     type: url
+    url: 'https://github.com/TykTechnologies/tyk-operator/blob/legacy/config/samples/httpbin.yaml'
     category: code
   - title: JSONPlaceholder users API demo endpoint
     type: url
+    url: 'https://jsonplaceholder.typicode.com/users'
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-vcluster.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-vcluster.md
@@ -3,13 +3,17 @@ id: xv2v8qdigpu0kphaelrjmr5i
 slug: hands-on-introduction-to-vcluster
 title: Hands-on Introduction to vcluster
 description: >-
-  Curious about Kubernetes multi-tenancy? In this episode, we'll be guided
-  through everything we need to know about vcluster.
+  Rich Burroughs and Lukas Gentele from Loft Labs walk through vCluster, a
+  newly Kubernetes-certified distribution that runs a k3s control plane inside
+  a namespace and syncs workloads to the host, plus a live install via Helm.
 publishedAt: 2021-06-23T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - vcluster
+  - kubernetes
+  - k3s
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -79,9 +83,11 @@ guests:
 resources:
   - title: KubeCuddle podcast
     type: url
+    url: 'https://kubecuddle.com/'
     category: other
   - title: vCluster Getting Started Guide
     type: url
+    url: 'https://www.vcluster.com/docs/vcluster/'
     category: documentation
   - title: 'vCluster Operator Guide: Monitoring and Metrics'
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-vcluster.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-vcluster.md
@@ -3,9 +3,9 @@ id: xv2v8qdigpu0kphaelrjmr5i
 slug: hands-on-introduction-to-vcluster
 title: Hands-on Introduction to vcluster
 description: >-
-  Rich Burroughs and Lukas Gentele from Loft Labs walk through vCluster, a
-  newly Kubernetes-certified distribution that runs a k3s control plane inside
-  a namespace and syncs workloads to the host, plus a live install via Helm.
+  Rich Burroughs and Lukas Gentele from Loft Labs walk through vCluster, a newly
+  Kubernetes-certified distribution that runs a k3s control plane inside a
+  namespace and syncs workloads to the host, plus a live install via Helm.
 publishedAt: 2021-06-23T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-velero.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-velero.md
@@ -3,14 +3,16 @@ id: k85jwdt76e8iww8ljpoykkze
 slug: hands-on-introduction-to-velero
 title: Hands-on Introduction to Velero
 description: >-
-  In this episode, we'll get hands-on and teach you everything you need to know
-  to start leveraging the awesome powers of Velero in your Kubernetes
-  environments.
+  Velero maintainer Carlisia Thompson joins David to install Velero against a
+  MinIO S3 backend, back up Kubernetes objects and persistent volumes, then
+  simulate a disaster and restore the workload into a fresh namespace.
 publishedAt: 2021-04-20T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - velero
+  - kubernetes
+  - minio
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -68,13 +70,16 @@ resources:
   - title: The Podlets podcast
     type: url
     category: other
-  - title: Velero resource page
+  - title: Velero resources page
+    url: 'https://velero.io/resources/'
     type: url
     category: documentation
-  - title: Velero roadmap.md
+  - title: Velero ROADMAP.md
+    url: 'https://github.com/vmware-tanzu/velero/blob/main/ROADMAP.md'
     type: url
     category: code
   - title: Velero Tilt integration instructions
+    url: 'https://velero.io/docs/main/tilt/'
     type: url
     category: documentation
 ---

--- a/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-waypoint.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-introduction-to-waypoint.md
@@ -3,13 +3,18 @@ id: wm4rgxicr5rl3zm6m1109dh0
 slug: hands-on-introduction-to-waypoint
 title: Hands-on Introduction to Waypoint
 description: >-
-  In this episode, Taylor will guide us through everything we need to know to
-  get started with Waypoint
+  Taylor Dolezal walks through HashiCorp Waypoint's build, deploy, and release
+  model, showing the HCL config, GitOps workflow, the server and runner
+  architecture, and three demos deploying to AWS Lambda, Kubernetes, and a
+  Minecraft server.
 publishedAt: 2021-08-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - waypoint
+  - kubernetes
+  - docker
+  - terraform
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -114,15 +119,19 @@ guests:
 resources:
   - title: Waypoint GitOps repository
     type: url
+    url: 'https://github.com/onlydole/waypoint-gitops'
     category: code
   - title: EKS in Action repository
     type: url
+    url: 'https://github.com/onlydole/eks-in-action'
     category: code
   - title: Waypoint architecture.md
     type: url
+    url: 'https://github.com/hashicorp/waypoint/blob/main/ARCHITECTURE.md'
     category: documentation
   - title: Waypoint 0.6 GitHub milestone
     type: url
+    url: 'https://github.com/hashicorp/waypoint/milestone/17'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-buildkit-and-buildx.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-buildkit-and-buildx.md
@@ -2,7 +2,11 @@
 id: zybh1hw8655u5i7j6njntv59
 slug: hands-on-with-buildkit-and-buildx
 title: Hands-on with BuildKit & buildx
-description: BuildKit maintainer Tõnis Tiigi joins David to rebuild a Go Dockerfile from scratch, covering multi-stage builds, cache mounts, local binary outputs, multi-platform builds with QEMU, declarative bake files in HCL, and cross-compilation with native toolchains.
+description: >-
+  BuildKit maintainer Tõnis Tiigi joins David to rebuild a Go Dockerfile from
+  scratch, covering multi-stage builds, cache mounts, local binary outputs,
+  multi-platform builds with QEMU, declarative bake files in HCL, and
+  cross-compilation with native toolchains.
 publishedAt: 2021-08-25T17:00:00.000Z
 type: live
 category: tutorial
@@ -95,7 +99,8 @@ guests:
 resources:
   - title: 'Docker documentation: automatic platform ARGs in global scope'
     type: url
-    url: 'https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope'
+    url: >-
+      https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
     category: documentation
   - title: XX project
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-buildkit-and-buildx.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-buildkit-and-buildx.md
@@ -2,7 +2,7 @@
 id: zybh1hw8655u5i7j6njntv59
 slug: hands-on-with-buildkit-and-buildx
 title: Hands-on with BuildKit & buildx
-description: "In this episode, we take a look at the multi-platform super caching BuildKit and buildx\n\n\n\U0001F37F Rawkode Live\n\nHosted by David McKay / \U0001F426 https://twitter.com/rawkode\nWebsite: https://rawkode.live\nDiscord Chat: https://rawkode.live/chat\n\n#RawkodeLive\n\n\U0001F570 Timeline\n\n00:00 - Holding screen\n00:50 - Introductions\n10:00 - Building a Go Project with Docker\n27:00 - Build caching with mounts\n43:00 - Local Outputs\n51:00 - Multi Platform Builds\n1:04:00 - Bake with HCL\n1:12:00 - Cross-compilation with native toolchains\n\n\U0001F465 About the Guests\n\nTõnis Tiigi\n\n  .\n\n\n\U0001F426 https://twitter.com/tonistiigi\n\U0001F9E9 https://github.com/tonistiigi\n\n\n\n\U0001F528 About the Technologies\n\nDocker\n\nDocker is a set of platform as a service (PaaS) products that use OS-level virtualization to deliver software in packages called containers. Containers are isolated from one another and bundle their own software, libraries and configuration files; they can communicate with each other through well-defined channels. Because all of the containers share the services of a single operating system kernel, they use fewer resources than virtual machines.\nThe service has both free and premium tiers. The software that hosts the containers is called Docker Engine. It was first started in 2013 and is developed by Docker, Inc.\n\n\U0001F30F https://docker.com\n\U0001F426 https://twitter.com/docker\n\U0001F9E9 https://github.com/docker\n\n#Docker #Containers"
+description: BuildKit maintainer Tõnis Tiigi joins David to rebuild a Go Dockerfile from scratch, covering multi-stage builds, cache mounts, local binary outputs, multi-platform builds with QEMU, declarative bake files in HCL, and cross-compilation with native toolchains.
 publishedAt: 2021-08-25T17:00:00.000Z
 type: live
 category: tutorial
@@ -95,12 +95,15 @@ guests:
 resources:
   - title: 'Docker documentation: automatic platform ARGs in global scope'
     type: url
+    url: 'https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope'
     category: documentation
   - title: XX project
     type: url
+    url: 'https://github.com/tonistiigi/xx'
     category: code
   - title: bin format project
     type: url
+    url: 'https://github.com/tonistiigi/binfmt'
     category: code
   - title: Rawkode.chat Discord server
     type: url

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-litmus-2-0.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-litmus-2-0.md
@@ -3,15 +3,16 @@ id: r6seigg9ay2yn6pwr591hbln
 slug: hands-on-with-litmus-2-0
 title: Hands-on with Litmus 2.0
 description: >-
-  Karthik Satchitanand is one of the maintainers of the CNCF sandbox project
-  LitmusChaos and a Co-Founder at ChaosNative. He is passionate about all things
-  Kubernetes, and is generally interested in DevOps, storage
-  performance/benchmarking & chaos engineering.
+  Litmus maintainer Karthik Satchitanand previews Litmus 2.0: the new ChaosCenter portal, public and private ChaosHubs, resilience scoring, GitOps sync, and probes. Demos chain chaos workflows against Bank of Anthos on Kubernetes and EC2 failure against Sock Shop.
 publishedAt: 2021-07-28T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - litmus
+  - kubernetes
+  - argo
+  - prometheus
+  - grafana
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -112,17 +113,21 @@ duration: 5279
 guests:
   - karthik-satchitanand
 resources:
-  - title: Litmus documentation master version on Netlify
+  - title: Litmus documentation
     type: url
+    url: https://docs.litmuschaos.io/
     category: documentation
   - title: Bank of Anthos demo application
     type: url
+    url: https://github.com/GoogleCloudPlatform/bank-of-anthos
     category: demos
   - title: Weaveworks Sock Shop microservices application
     type: url
+    url: https://github.com/microservices-demo/microservices-demo
     category: demos
   - title: Principles of Chaos
     type: url
+    url: https://principlesofchaos.org/
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-litmus-2-0.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-litmus-2-0.md
@@ -3,7 +3,10 @@ id: r6seigg9ay2yn6pwr591hbln
 slug: hands-on-with-litmus-2-0
 title: Hands-on with Litmus 2.0
 description: >-
-  Litmus maintainer Karthik Satchitanand previews Litmus 2.0: the new ChaosCenter portal, public and private ChaosHubs, resilience scoring, GitOps sync, and probes. Demos chain chaos workflows against Bank of Anthos on Kubernetes and EC2 failure against Sock Shop.
+  Litmus maintainer Karthik Satchitanand previews Litmus 2.0: the new
+  ChaosCenter portal, public and private ChaosHubs, resilience scoring, GitOps
+  sync, and probes. Demos chain chaos workflows against Bank of Anthos on
+  Kubernetes and EC2 failure against Sock Shop.
 publishedAt: 2021-07-28T17:00:00.000Z
 type: live
 category: tutorial
@@ -115,19 +118,19 @@ guests:
 resources:
   - title: Litmus documentation
     type: url
-    url: https://docs.litmuschaos.io/
+    url: 'https://docs.litmuschaos.io/'
     category: documentation
   - title: Bank of Anthos demo application
     type: url
-    url: https://github.com/GoogleCloudPlatform/bank-of-anthos
+    url: 'https://github.com/GoogleCloudPlatform/bank-of-anthos'
     category: demos
   - title: Weaveworks Sock Shop microservices application
     type: url
-    url: https://github.com/microservices-demo/microservices-demo
+    url: 'https://github.com/microservices-demo/microservices-demo'
     category: demos
   - title: Principles of Chaos
     type: url
-    url: https://principlesofchaos.org/
+    url: 'https://principlesofchaos.org/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-policy-reporter.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-policy-reporter.md
@@ -3,14 +3,20 @@ id: o91kaudm4lsng4edd88nanlr
 slug: hands-on-with-policy-reporter
 title: Hands-on with Policy Reporter
 description: >-
-  In this episode, we take a look at a new open source project: Policy Reporter.
-  Policy Reporter brings visibility into Kyverno policy enforcement.
+  Frank Jogeleit joins to walk through Policy Reporter, the open source tool
+  that turns Kyverno PolicyReports into Prometheus metrics, a UI dashboard, and
+  notifications. We install it via Helm alongside kube-prometheus and explore
+  Grafana dashboards for policy violations.
 publishedAt: 2021-04-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - falco
+  - grafana
+  - helm
   - kyverno
   - policy-reporter
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -57,11 +63,13 @@ duration: 2831
 guests:
   - frank-jogeleit
 resources:
-  - title: Falco Sidekick UI
+  - title: Falcosidekick UI
     type: url
+    url: 'https://github.com/falcosecurity/falcosidekick-ui'
     category: code
   - title: Kyverno Pod Security Policy replacement policies
     type: url
+    url: 'https://kyverno.io/policies/pod-security/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-rust-async-await.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-rust-async-await.md
@@ -3,8 +3,9 @@ id: f85p38gkhu1pxtu1bnnixglq
 slug: hands-on-with-rust-async-await
 title: 'Hands-on with Rust: Async / Await'
 description: >-
-  In this episode, Senyo and I will gets hands-on with Rust's async/await
-  features.
+  Senyo Simpson joins David to dig into Rust's async/await. They cover lazy
+  futures, the Tokio executor, spawn and join, then build a custom Future,
+  executor, and Waker from scratch to show what happens under the hood.
 publishedAt: 2021-08-18T17:00:00.000Z
 type: live
 category: tutorial
@@ -78,12 +79,17 @@ duration: 5063
 guests:
   - senyo-simpson
 resources:
-  - title: Tokio Async in Depth tutorial
+  - title: Tokio
     type: url
-    url: 'https://tokio.rs/tokio/tutorial/async'
+    url: 'https://tokio.rs/'
     category: documentation
-  - title: Complete Guide to InfluxDB course
+  - title: reqwest HTTP client
     type: url
-    category: other
+    url: 'https://docs.rs/reqwest/'
+    category: documentation
+  - title: Async Book (Rust)
+    type: url
+    url: 'https://rust-lang.github.io/async-book/'
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/hands-on-with-rust-lifetimes-and-ownership.md
+++ b/content/videos/shows/rawkode-live/2021/hands-on-with-rust-lifetimes-and-ownership.md
@@ -3,10 +3,9 @@ id: nrszh83p0vnfftsmbpfjinkw
 slug: hands-on-with-rust-lifetimes-and-ownership
 title: 'Hands-on with Rust: Lifetimes & Ownership'
 description: >-
-  Ana is a hacker working in the Rust and Nix ecosystems. She's from Lək̓ʷəŋən
-  territory in the Pacific Northwest, and holds a B.Sc. in Computer Science from
-  the University of Victoria. She takes care of a golden retriever named Nami
-  with her partner.
+  Ana Hobden joins David to work through Rust's borrow checker and lifetime
+  system using the Rustlings move-semantics exercises, covering ownership,
+  mutable references, scope, and when to reach for Box, Rc, and Arc.
 publishedAt: 2021-06-10T17:00:00.000Z
 type: live
 category: tutorial
@@ -71,6 +70,14 @@ chapters:
 duration: 3448
 guests:
   - ana-hobden
-resources: []
+resources:
+  - type: url
+    title: Rustlings
+    url: 'https://github.com/rust-lang/rustlings'
+    category: code
+  - type: url
+    title: 'The Rust Programming Language: Understanding Ownership'
+    url: 'https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html'
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2021/how-to-write-a-kubectl-plugin-from-scratch.md
+++ b/content/videos/shows/rawkode-live/2021/how-to-write-a-kubectl-plugin-from-scratch.md
@@ -4,8 +4,8 @@ slug: how-to-write-a-kubectl-plugin-from-scratch
 title: How to Write a kubectl Plugin from Scratch
 description: >-
   Matt Turner joins to write a kubectl plugin in Bash that swaps kubectl's
-  verb-noun ordering to noun-verb, then packages it for distribution through
-  the Krew plugin manager with a crew.yaml manifest and GitHub releases.
+  verb-noun ordering to noun-verb, then packages it for distribution through the
+  Krew plugin manager with a crew.yaml manifest and GitHub releases.
 publishedAt: 2021-01-13T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/how-to-write-a-kubectl-plugin-from-scratch.md
+++ b/content/videos/shows/rawkode-live/2021/how-to-write-a-kubectl-plugin-from-scratch.md
@@ -3,8 +3,9 @@ id: c1hn6xaw51c7lj22g4p4q93k
 slug: how-to-write-a-kubectl-plugin-from-scratch
 title: How to Write a kubectl Plugin from Scratch
 description: >-
-  In this episode, we build a kubectl plugin from scratch. We aim to solve the
-  biggest problem in Kubernetes ... noun/verb ordering.
+  Matt Turner joins to write a kubectl plugin in Bash that swaps kubectl's
+  verb-noun ordering to noun-verb, then packages it for distribution through
+  the Krew plugin manager with a crew.yaml manifest and GitHub releases.
 publishedAt: 2021-01-13T17:00:00.000Z
 type: live
 category: tutorial
@@ -66,12 +67,15 @@ guests:
 resources:
   - title: Kubernetes kubectl plugins documentation
     type: url
+    url: 'https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/'
     category: documentation
   - title: Krew kubectl plugin manager
     type: url
+    url: 'https://krew.sigs.k8s.io/'
     category: other
   - title: Krew plugin index repository
     type: url
+    url: 'https://github.com/kubernetes-sigs/krew-index'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/infrastructure-as-code-and-gitops.md
+++ b/content/videos/shows/rawkode-live/2021/infrastructure-as-code-and-gitops.md
@@ -3,12 +3,15 @@ id: yfaj0ov3z8zu0sv4lp8songu
 slug: infrastructure-as-code-and-gitops
 title: Infrastructure as Code & GitOps
 description: >-
-  In this episode, we'll take a look at the lifecycle of our Infrastructure as
-  Code (IaC) automation, focusing on the first-pass / bootstrapping.
+  Bootstrap a Kubernetes cluster on Equinix Metal with Pulumi, then hand workloads over to FluxCD. Covers Pulumi project layout, stacks vs Terraform workspaces, Flux install, Helm releases, and a live GitOps namespace demo.
 publishedAt: 2021-02-25T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - pulumi
+  - fluxcd
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2021/infrastructure-as-code-and-gitops.md
+++ b/content/videos/shows/rawkode-live/2021/infrastructure-as-code-and-gitops.md
@@ -3,7 +3,9 @@ id: yfaj0ov3z8zu0sv4lp8songu
 slug: infrastructure-as-code-and-gitops
 title: Infrastructure as Code & GitOps
 description: >-
-  Bootstrap a Kubernetes cluster on Equinix Metal with Pulumi, then hand workloads over to FluxCD. Covers Pulumi project layout, stacks vs Terraform workspaces, Flux install, Helm releases, and a live GitOps namespace demo.
+  Bootstrap a Kubernetes cluster on Equinix Metal with Pulumi, then hand
+  workloads over to FluxCD. Covers Pulumi project layout, stacks vs Terraform
+  workspaces, Flux install, Helm releases, and a live GitOps namespace demo.
 publishedAt: 2021-02-25T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/introduction-to-c.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-c.md
@@ -3,8 +3,9 @@ id: g3x1yu2xp7s1d9u19lp2rcoa
 slug: introduction-to-c
 title: Introduction to C++
 description: >-
-  In this episode, Sy will guide us through the basics of C++ by helping David
-  complete some exercises on Exercism.io.
+  Sy Brand walks David through modern C++ via Exercism's Hello World and Isogram
+  exercises, covering Catch2 tests, CMake builds, namespaces, std::string vs
+  string_view, std::unordered_set, range-based for loops, auto, and references.
 publishedAt: 2021-07-13T17:00:00.000Z
 type: live
 category: tutorial
@@ -98,15 +99,19 @@ guests:
 resources:
   - title: Exercism language tracks
     type: url
+    url: 'https://exercism.org/tracks'
     category: other
   - title: Catch2 testing framework
     type: url
+    url: 'https://github.com/catchorg/Catch2'
     category: code
   - title: C++ Patterns
     type: url
+    url: 'https://cpppatterns.com/'
     category: documentation
   - title: '#include <C++> Discord'
     type: url
+    url: 'https://www.includecpp.org/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-fluentd-and-fluent-bit.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-fluentd-and-fluent-bit.md
@@ -11,6 +11,8 @@ category: tutorial
 technologies:
   - fluent-bit
   - fluentd
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2021/introduction-to-kapitan.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-kapitan.md
@@ -3,13 +3,15 @@ id: ez0cfnojsmfa5wwlgwzwu0kg
 slug: introduction-to-kapitan
 title: Introduction to Kapitan
 description: >-
-  In this episode, we take a look at the Kapitan project; a tool to help manage
-  the complexity of deploying with Kubernetes, Terraform, and other things.
+  Alessandro de Maria and Ricardo Amaro walk through Kapitan's inventory model,
+  targets and classes, the Kubernetes manifest generator, secret references, and
+  the kapitan-reference repository for getting started.
 publishedAt: 2021-02-05T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kapitan
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -85,12 +87,15 @@ guests:
 resources:
   - title: Kapitan Reference Repository
     type: url
+    url: 'https://github.com/kapicorp/kapitan-reference'
     category: code
   - title: Kapitan Manifest Generator Documentation
     type: url
+    url: 'https://generators.kapitan.dev/'
     category: documentation
   - title: Weaveworks Sock Shop Example
     type: url
+    url: 'https://github.com/microservices-demo/microservices-demo'
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-keptn-part-ii.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-keptn-part-ii.md
@@ -3,13 +3,21 @@ id: ej38e2ppxfi1xzbwvoy3o4o2
 slug: introduction-to-keptn-part-ii
 title: Introduction to Keptn (Part II)
 description: >-
-  In this episode, we will continue with our look into Keptn; including
-  automatic remediation.
+  Juergen Etzlstorfer returns to walk through Keptn quality gates backed by
+  Prometheus SLIs, deploy to Kubernetes via Helm, then trigger automatic
+  remediation that scales pods on a response-time breach. Includes Litmus and
+  k3s notes.
 publishedAt: 2021-01-28T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - keptn
+  - prometheus
+  - kubernetes
+  - k3s
+  - litmus
+  - helm
+  - grafana
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -84,16 +92,19 @@ guests:
 resources:
   - title: Google SRE Book
     type: url
-    category: other
+    url: 'https://sre.google/sre-book/table-of-contents/'
+    category: documentation
   - title: Keptn Tutorial
     type: url
     url: 'https://tutorials.keptn.sh'
     category: documentation
   - title: Keptn Service Template
     type: url
+    url: 'https://github.com/keptn-sandbox/keptn-service-template-go'
     category: code
   - title: Keptn Sandbox
     type: url
+    url: 'https://github.com/keptn-sandbox'
     category: code
   - title: Keptn Slack
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-kubeflow.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-kubeflow.md
@@ -61,10 +61,10 @@ resources:
   - title: Grokking Deep Learning
     type: url
     category: other
-    url: https://www.manning.com/books/grokking-deep-learning
+    url: 'https://www.manning.com/books/grokking-deep-learning'
   - title: Kaggle Chest X-Ray Pneumonia Dataset by Paul Timothy Mooney
     type: url
     category: other
-    url: https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia
+    url: 'https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-kubeflow.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-kubeflow.md
@@ -3,9 +3,10 @@ id: mgrp2hpv2alb27fi2sqj1ck4
 slug: introduction-to-kubeflow
 title: Introduction to Kubeflow
 description: >-
-  In this episode, Michael will introduce us to Kubeflow's new features,
-  shipping in Kubeflow 1.3, and guide us through everything we need to get
-  started running our data science workloads on Kubernetes with Kubeflow.
+  Michael Tanenbaum walks through Kubeflow 1.3, covering the architecture,
+  Notebooks, and Pipelines, then trains an image classification model on the
+  Kaggle chest X-ray pneumonia dataset and automates the workflow with Kale,
+  Katib, and KFServing.
 publishedAt: 2021-03-30T17:00:00.000Z
 type: live
 category: tutorial
@@ -60,8 +61,10 @@ resources:
   - title: Grokking Deep Learning
     type: url
     category: other
+    url: https://www.manning.com/books/grokking-deep-learning
   - title: Kaggle Chest X-Ray Pneumonia Dataset by Paul Timothy Mooney
     type: url
-    category: demos
+    category: other
+    url: https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-kyverno.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-kyverno.md
@@ -3,13 +3,17 @@ id: wpypzqdx7xd2yns85cx0daty
 slug: introduction-to-kyverno
 title: Introduction to Kyverno
 description: >-
-  In this episode, we'll get you up to speed with everything you need to get
-  started with Kyverno.
+  Jim Bugwadia and Shuting Zhao explain how Kyverno brings Kubernetes-native
+  policy management via validate, mutate, and generate rules. Covers the
+  admission controller, policy reports, comparisons with PodSecurityPolicies and
+  OPA Gatekeeper, and hands-on policy demos.
 publishedAt: 2021-02-19T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kyverno
+  - kubernetes
+  - opa
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -99,17 +103,22 @@ resources:
   - title: Kubernetes Pod Security Standards documentation
     type: url
     category: documentation
+    url: 'https://kubernetes.io/docs/concepts/security/pod-security-standards/'
   - title: Bishop Fox Bad Pods repository
     type: url
     category: demos
+    url: 'https://github.com/BishopFox/badPods'
   - title: kyverno/policies repository
     type: url
     category: code
+    url: 'https://github.com/kyverno/policies'
   - title: OPA Gatekeeper
     type: url
     category: code
+    url: 'https://github.com/open-policy-agent/gatekeeper'
   - title: kubectl neat
     type: url
     category: other
+    url: 'https://github.com/itaysk/kubectl-neat'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-litmus-chaos.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-litmus-chaos.md
@@ -3,13 +3,21 @@ id: oua0v79haem7e7klh0bwydsw
 slug: introduction-to-litmus-chaos
 title: Introduction to Litmus Chaos
 description: >-
-  In this episode, we'll be guided through everything we need to know to get
-  started with Litmus Chaos.
+  Uma and Kartik from the Chaos Native team walk through Litmus, a
+  Kubernetes-native chaos engineering project. They cover the ChaosCenter
+  portal, workflows and probes, then demo Kafka chaos with Grafana and
+  AWS EC2 termination.
 publishedAt: 2021-03-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - litmus
+  - kubernetes
+  - kafka
+  - argo
+  - helm
+  - grafana
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -111,9 +119,11 @@ guests:
 resources:
   - title: litmuschaos/litmus-helm repository
     type: url
+    url: 'https://github.com/litmuschaos/litmus-helm'
     category: code
   - title: Litmus probe documentation
     type: url
+    url: 'https://docs.litmuschaos.io/docs/concepts/probes'
     category: documentation
   - title: Chaos Carnival Kafka bootcamp demo steps
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-litmus-chaos.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-litmus-chaos.md
@@ -5,8 +5,8 @@ title: Introduction to Litmus Chaos
 description: >-
   Uma and Kartik from the Chaos Native team walk through Litmus, a
   Kubernetes-native chaos engineering project. They cover the ChaosCenter
-  portal, workflows and probes, then demo Kafka chaos with Grafana and
-  AWS EC2 termination.
+  portal, workflows and probes, then demo Kafka chaos with Grafana and AWS EC2
+  termination.
 publishedAt: 2021-03-03T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/introduction-to-meilisearch.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-meilisearch.md
@@ -3,8 +3,9 @@ id: sgekw05ckjl1lweoumx4kkp9
 slug: introduction-to-meilisearch
 title: Introduction to Meilisearch
 description: >-
-  In this episode, we'll get you up to speed with everything you need to know
-  about Meilisearch
+  Frédéric Harper and Carolina Ferreira from the Meilisearch team walk through
+  the Rust-based search engine: REST API, indexes, typo tolerance, ranking
+  rules, synonyms, faceted search, and deployment.
 publishedAt: 2021-02-17T17:00:00.000Z
 type: live
 category: tutorial
@@ -81,15 +82,19 @@ guests:
 resources:
   - title: 'Meilisearch documentation: Comparison to alternatives'
     type: url
+    url: 'https://www.meilisearch.com/docs/resources/comparisons/alternatives'
     category: documentation
   - title: 'Meilisearch documentation: API reference settings'
     type: url
+    url: 'https://www.meilisearch.com/docs/reference/api/settings/list-all-settings'
     category: documentation
   - title: 'Meilisearch documentation: Ranking rules relevancy guide'
     type: url
+    url: 'https://www.meilisearch.com/docs/capabilities/full_text_search/relevancy/ranking_rules'
     category: documentation
   - title: 'Meilisearch documentation: Official SDK libraries'
     type: url
+    url: 'https://www.meilisearch.com/docs/resources/help/sdks'
     category: documentation
   - title: movies.json sample dataset
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-meilisearch.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-meilisearch.md
@@ -90,7 +90,8 @@ resources:
     category: documentation
   - title: 'Meilisearch documentation: Ranking rules relevancy guide'
     type: url
-    url: 'https://www.meilisearch.com/docs/capabilities/full_text_search/relevancy/ranking_rules'
+    url: >-
+      https://www.meilisearch.com/docs/capabilities/full_text_search/relevancy/ranking_rules
     category: documentation
   - title: 'Meilisearch documentation: Official SDK libraries'
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-second-state.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-second-state.md
@@ -2,12 +2,14 @@
 id: affci60zjdq4xb6e1l6yklau
 slug: introduction-to-second-state
 title: Introduction to Second State
-description: 'In this episode, we take a look at the Second State project.'
+description: 'Tim McCallum joins to demo Second State''s serverless WebAssembly function-as-a-service. We write Rust, compile to Wasm, deploy via SSVM up, call functions through a Postman-documented REST API, hot-swap versions, and run an OCR / TensorFlow demo.'
 publishedAt: 2021-02-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - second-state
+  - webassembly
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2021/introduction-to-second-state.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-second-state.md
@@ -2,7 +2,11 @@
 id: affci60zjdq4xb6e1l6yklau
 slug: introduction-to-second-state
 title: Introduction to Second State
-description: 'Tim McCallum joins to demo Second State''s serverless WebAssembly function-as-a-service. We write Rust, compile to Wasm, deploy via SSVM up, call functions through a Postman-documented REST API, hot-swap versions, and run an OCR / TensorFlow demo.'
+description: >-
+  Tim McCallum joins to demo Second State's serverless WebAssembly
+  function-as-a-service. We write Rust, compile to Wasm, deploy via SSVM up,
+  call functions through a Postman-documented REST API, hot-swap versions, and
+  run an OCR / TensorFlow demo.
 publishedAt: 2021-02-03T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/introduction-to-suborbital.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-suborbital.md
@@ -3,8 +3,9 @@ id: aqa3padkfm9asmv94ky774rc
 slug: introduction-to-suborbital
 title: Introduction to Suborbital
 description: >-
-  In this episode, we'll be taking at look at getting started with Suborbital; a
-  WebAssembly based functions runtime.
+  Connor Hicks walks through Suborbital's ATMO runtime, writing Rust functions
+  compiled to WebAssembly, composing them via the Directive YAML, and chaining
+  workflows with HTTP and cache access through the subo CLI.
 publishedAt: 2021-01-27T17:00:00.000Z
 type: live
 category: tutorial
@@ -92,6 +93,10 @@ duration: 5020
 guests:
   - connor-hicks
 resources:
+  - title: Suborbital on GitHub
+    type: url
+    url: https://github.com/suborbital
+    category: code
   - title: Atmo documentation
     type: url
     category: documentation

--- a/content/videos/shows/rawkode-live/2021/introduction-to-suborbital.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-suborbital.md
@@ -95,7 +95,7 @@ guests:
 resources:
   - title: Suborbital on GitHub
     type: url
-    url: https://github.com/suborbital
+    url: 'https://github.com/suborbital'
     category: code
   - title: Atmo documentation
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-timescale.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-timescale.md
@@ -3,13 +3,17 @@ id: rla2vnoi2ylmmpf1bjsb4djg
 slug: introduction-to-timescale
 title: Introduction to Timescale
 description: >-
-  In this episode, we'll be covering everything you need to know to get started
-  with Timescale.
+  Avthar Sewrathan explains how TimescaleDB packages Postgres with hypertables,
+  compression, and continuous aggregates. We launch a Forge instance, load NYC
+  taxi data with parallel copy, then run geospatial queries and visualize in
+  Grafana.
 publishedAt: 2021-02-09T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - timescale
+  - postgresql
+  - grafana
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -71,6 +75,7 @@ resources:
     category: documentation
   - title: TimescaleDB Parallel Copy
     type: url
+    url: 'https://github.com/timescale/timescaledb-parallel-copy'
     category: code
   - title: Setting automated retention policies
     type: url

--- a/content/videos/shows/rawkode-live/2021/introduction-to-tremor.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-tremor.md
@@ -3,8 +3,9 @@ id: iujjbzvjr482rvlakapnby4u
 slug: introduction-to-tremor
 title: Introduction to Tremor
 description: >-
-  In this episode, we'll introduce you and teach you everything you need to get
-  started with the CNCF's sandbox project: Tremor
+  The Tremor team walk through the Rust-based event processing engine born at
+  Wayfair for load shedding at scale, then live-code a Discord bot using YAML
+  pipelines, the Trickle query language, and a custom UDP source.
 publishedAt: 2021-03-24T17:00:00.000Z
 type: live
 category: tutorial
@@ -89,17 +90,20 @@ guests:
   - heinz-gies
   - matthias-wahl
 resources:
-  - title: Equinix Metal products
+  - title: Equinix Metal
     type: url
+    url: 'https://deploy.equinix.com/'
     category: other
   - title: Matthias Wahl's Bobconf SIMD talk
     type: url
     category: other
   - title: Tremor RFC for Troy deployment language
     type: url
+    url: 'https://github.com/tremor-rs/tremor-rfcs'
     category: documentation
   - title: Vector project
     type: url
+    url: 'https://vector.dev/'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/introduction-to-vitess.md
+++ b/content/videos/shows/rawkode-live/2021/introduction-to-vitess.md
@@ -3,13 +3,15 @@ id: lksy7dn1gol1tpatlye4oh6b
 slug: introduction-to-vitess
 title: Introduction to Vitess
 description: >-
-  In this episode, we'll teach and guide you through everything you need to know
-  to get started with Vitess.
+  Vitess maintainers Deepthi Sigireddi and Alkin Tezuysal from PlanetScale walk
+  through the architecture (VTGate, VTTablet, topology), then deploy a sharded
+  MySQL cluster on Kubernetes with the operator and connect WordPress.
 publishedAt: 2021-02-26T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - vitess
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -84,9 +86,11 @@ guests:
 resources:
   - title: Vitess Operator
     type: url
+    url: 'https://github.com/planetscale/vitess-operator'
     category: code
   - title: Vitess Kubernetes Quick Start
     type: url
+    url: 'https://vitess.io/docs/get-started/kubernetes/'
     category: documentation
   - title: Vitess Point-in-Time Recovery documentation
     type: url

--- a/content/videos/shows/rawkode-live/2021/kubernetes-security-lab.md
+++ b/content/videos/shows/rawkode-live/2021/kubernetes-security-lab.md
@@ -5,8 +5,8 @@ title: Kubernetes Security Lab
 description: >-
   Rory McCune walks through a hands-on Kubernetes security lab built on kind,
   attacking five deliberately vulnerable clusters: insecure API server port,
-  unauthenticated kubelet, unauthenticated etcd, privileged pod escape, and
-  Helm 2's Tiller.
+  unauthenticated kubelet, unauthenticated etcd, privileged pod escape, and Helm
+  2's Tiller.
 publishedAt: 2021-04-15T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/kubernetes-security-lab.md
+++ b/content/videos/shows/rawkode-live/2021/kubernetes-security-lab.md
@@ -3,15 +3,18 @@ id: abih5lxnfz58vl1ariozmar5
 slug: kubernetes-security-lab
 title: Kubernetes Security Lab
 description: >-
-  Kubernetes is a portable, extensible, open-source platform for managing
-  containerized workloads and services, that facilitates both declarative
-  configuration and automation. It has a large, rapidly growing ecosystem.
-  Kubernetes services, support, and tools are widely
+  Rory McCune walks through a hands-on Kubernetes security lab built on kind,
+  attacking five deliberately vulnerable clusters: insecure API server port,
+  unauthenticated kubelet, unauthenticated etcd, privileged pod escape, and
+  Helm 2's Tiller.
 publishedAt: 2021-04-15T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubernetes
+  - docker
+  - helm
+  - etcd
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -160,15 +163,19 @@ guests:
 resources:
   - title: kind (Kubernetes in Docker)
     type: url
-    category: code
+    url: 'https://kind.sigs.k8s.io/'
+    category: documentation
   - title: CIS Benchmarks
     type: url
+    url: 'https://www.cisecurity.org/cis-benchmarks'
     category: documentation
   - title: Kube Hunter
     type: url
+    url: 'https://github.com/aquasecurity/kube-hunter'
     category: code
   - title: CyberArk kubeletctl
     type: url
+    url: 'https://github.com/cyberark/kubeletctl'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/kubernetes-services.md
+++ b/content/videos/shows/rawkode-live/2021/kubernetes-services.md
@@ -3,8 +3,9 @@ id: t6z7vbrzz03zq1xvwlugnyoz
 slug: kubernetes-services
 title: Kubernetes Services
 description: >-
-  In this episode, we take a look at the different types of service provided by
-  Kubernetes and how they work under the hood.
+  Anaïs Urlichs and Philipp Strube join David to break down Kubernetes Services:
+  ClusterIP, NodePort, port versus targetPort, selectors and endpoints,
+  DNS-based service discovery, and load balancing across pods.
 publishedAt: 2021-01-13T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2021/laravel-on-kubernetes-into-production.md
+++ b/content/videos/shows/rawkode-live/2021/laravel-on-kubernetes-into-production.md
@@ -3,9 +3,10 @@ id: ufjrlupsc2rko3zckf49bwv6
 slug: laravel-on-kubernetes-into-production
 title: 'Laravel on Kubernetes: Into Production'
 description: >-
-  In this episode, we'll explore the "What next?" question that is often left in
-  developers heads after they've deployed their Laravel application to
-  Kubernetes.
+  Alex Bowers joins David to take a Laravel app from a basic deploy to a
+  production-grade Kubernetes setup, wiring up MariaDB via Helm, ConfigMaps and
+  Secrets, init-container migrations, CronJob schedulers, queue worker
+  Deployments, and update strategies.
 publishedAt: 2021-01-23T17:00:00.000Z
 type: live
 category: tutorial
@@ -13,6 +14,11 @@ technologies:
   - kubernetes
   - laravel
   - php
+  - docker
+  - helm
+  - artifacthub
+  - sops
+  - kapitan
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -98,15 +104,19 @@ resources:
     category: code
   - title: Artifact Hub MariaDB Helm chart
     type: url
+    url: 'https://artifacthub.io/'
     category: other
   - title: Mozilla SOPS
     type: url
+    url: 'https://github.com/getsops/sops'
     category: code
   - title: Sealed Secrets
     type: url
+    url: 'https://github.com/bitnami-labs/sealed-secrets'
     category: code
   - title: Kapitan project
     type: url
+    url: 'https://kapitan.dev/'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes-part-ii.md
+++ b/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes-part-ii.md
@@ -3,15 +3,18 @@ id: wth5h0zbyz34gd904nuiuauu
 slug: monitoring-and-scaling-laravel-on-kubernetes-part-ii
 title: Monitoring & Scaling Laravel on Kubernetes (Part II)
 description: >-
-  In this episode, we'll take a look at auto-scaling our Laravel application
-  based on metrics.
+  Leo joins Alex and David to wire Prometheus middleware into Laravel, scrape
+  the metrics endpoint, deploy the Prometheus Adapter, and drive a Horizontal
+  Pod Autoscaler with custom metrics under load from Siege.
 publishedAt: 2021-03-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - docker
   - kubernetes
   - laravel
   - php
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -72,6 +75,18 @@ duration: 4580
 guests:
   - alex-bowers
   - leo-sjoberg
-resources: []
+resources:
+  - title: Prometheus Adapter for Kubernetes Metrics APIs
+    type: url
+    category: code
+    url: 'https://github.com/kubernetes-sigs/prometheus-adapter'
+  - title: Horizontal Pod Autoscaler
+    type: url
+    category: documentation
+    url: 'https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/'
+  - title: Siege HTTP load tester
+    type: url
+    category: code
+    url: 'https://github.com/JoeDog/siege'
 ---
 

--- a/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes.md
@@ -3,8 +3,10 @@ id: aby09ynwn40wa8dtsvxwf7ho
 slug: monitoring-and-scaling-laravel-on-kubernetes
 title: Monitoring & Scaling Laravel on Kubernetes
 description: >-
-  In this episode, we'll take a look at auto-scaling our Laravel application
-  based on metrics.
+  Continuing the Laravel-on-Kubernetes series, David is joined by Alex Bowers
+  and Ciaran McNulty to load-test with Siege, wire up a CPU-based HPA via
+  metrics-server, then layer Linkerd sidecars, Grafana dashboards, and a
+  Prometheus ServiceMonitor for custom application metrics.
 publishedAt: 2021-02-24T17:00:00.000Z
 type: live
 category: tutorial
@@ -12,6 +14,9 @@ technologies:
   - kubernetes
   - laravel
   - php
+  - linkerd
+  - prometheus
+  - grafana
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -89,18 +94,23 @@ guests:
 resources:
   - title: JoeDog Siege
     type: url
+    url: https://www.joedog.org/
     category: other
   - title: Prometheus Operator quick start bundle
     type: url
+    url: https://github.com/prometheus-operator/kube-prometheus
     category: documentation
   - title: Prometheus Adapter
     type: url
+    url: https://github.com/kubernetes-sigs/prometheus-adapter
     category: documentation
   - title: Sean Hood OpenTelemetry package
     type: url
+    url: https://github.com/SeanHood/laravel-opentelemetry
     category: code
   - title: Alex Bowers Laravel example project
     type: url
+    url: https://github.com/alexbowers/laravel-example-project
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2021/monitoring-and-scaling-laravel-on-kubernetes.md
@@ -94,23 +94,23 @@ guests:
 resources:
   - title: JoeDog Siege
     type: url
-    url: https://www.joedog.org/
+    url: 'https://www.joedog.org/'
     category: other
   - title: Prometheus Operator quick start bundle
     type: url
-    url: https://github.com/prometheus-operator/kube-prometheus
+    url: 'https://github.com/prometheus-operator/kube-prometheus'
     category: documentation
   - title: Prometheus Adapter
     type: url
-    url: https://github.com/kubernetes-sigs/prometheus-adapter
+    url: 'https://github.com/kubernetes-sigs/prometheus-adapter'
     category: documentation
   - title: Sean Hood OpenTelemetry package
     type: url
-    url: https://github.com/SeanHood/laravel-opentelemetry
+    url: 'https://github.com/SeanHood/laravel-opentelemetry'
     category: code
   - title: Alex Bowers Laravel example project
     type: url
-    url: https://github.com/alexbowers/laravel-example-project
+    url: 'https://github.com/alexbowers/laravel-example-project'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/pulumi-multi-language-packages.md
+++ b/content/videos/shows/rawkode-live/2021/pulumi-multi-language-packages.md
@@ -3,14 +3,16 @@ id: vuv2ktqhud7ol49f7cm9t9ex
 slug: pulumi-multi-language-packages
 title: 'Pulumi: Multi Language Packages'
 description: >-
-  In this episode, Lee will guide us through the latest changes in Pulumi that
-  allows building components in your language of choice and consuming them in
-  any other supported language.
+  Lee Briggs walks through Pulumi's multi-language component packages: writing a
+  schema.json, implementing a Kubernetes deployment component in Go from the
+  pulumi-component-provider-go-boilerplate, then generating and consuming SDKs
+  from TypeScript.
 publishedAt: 2021-05-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - pulumi
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -71,12 +73,14 @@ guests:
 resources:
   - title: Pulumi Go boilerplate provider
     type: url
+    url: 'https://github.com/pulumi/pulumi-component-provider-go-boilerplate'
     category: code
   - title: Rawkode Pulumi production app
     type: url
     category: code
   - title: Pulumi Python boilerplate provider
     type: url
+    url: 'https://github.com/pulumi/pulumi-component-provider-py-boilerplate'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/should-we-still-be-using-docker-compose-for-local-development.md
+++ b/content/videos/shows/rawkode-live/2021/should-we-still-be-using-docker-compose-for-local-development.md
@@ -3,8 +3,9 @@ id: xe94jp57r2l5615gqo6xu5ql
 slug: should-we-still-be-using-docker-compose-for-local-development
 title: Should we still be using docker-compose for local development?
 description: >-
-  In this episode, Bret is going to guide us through everything we need to know
-  about Docker Compose v2
+  Bret Fisher walks through Docker Compose v2 and the new Compose Spec: the
+  rewritten Go CLI as a Docker plugin, profiles for grouping services,
+  depends_on with healthchecks, convert, contexts, and deploying to ECS and ACI.
 publishedAt: 2021-09-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -91,16 +92,18 @@ guests:
 resources:
   - title: Compose CLI repository
     type: url
+    url: 'https://github.com/docker/compose-cli'
     category: code
   - title: Podman Compose project
     type: url
+    url: 'https://github.com/containers/podman-compose'
     category: code
   - title: Bret Fisher shell setup page
     type: url
-    url: 'https://brettfisher.com/shell'
     category: documentation
   - title: SpaceVim editor distribution
     type: url
+    url: 'https://spacevim.org/'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/writing-a-kubernetes-controller.md
+++ b/content/videos/shows/rawkode-live/2021/writing-a-kubernetes-controller.md
@@ -2,7 +2,7 @@
 id: wm654x7yh3u93du0p8g2vfd3
 slug: writing-a-kubernetes-controller
 title: Writing a Kubernetes Controller
-description: 'In this episode, we''re going to explore writing our own Kubernetes controller.'
+description: 'Suhail Patel joins Rawkode to build a Kubernetes mutating admission webhook in Go that rewrites pod image tags expressed as semver constraints into concrete versions, with TLS certs generated via CFSSL and the Kubernetes CSR API.'
 publishedAt: 2021-02-10T17:00:00.000Z
 type: live
 category: tutorial
@@ -104,12 +104,15 @@ guests:
 resources:
   - title: Kubernetes Admission Controllers documentation
     type: url
+    url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
     category: documentation
-  - title: Kubernetes AdmissionReview API reference
+  - title: Dynamic Admission Control (mutating and validating webhooks)
     type: url
+    url: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
     category: documentation
   - title: Cloudflare CFSSL
     type: url
+    url: https://github.com/cloudflare/cfssl
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2021/writing-a-kubernetes-controller.md
+++ b/content/videos/shows/rawkode-live/2021/writing-a-kubernetes-controller.md
@@ -2,7 +2,10 @@
 id: wm654x7yh3u93du0p8g2vfd3
 slug: writing-a-kubernetes-controller
 title: Writing a Kubernetes Controller
-description: 'Suhail Patel joins Rawkode to build a Kubernetes mutating admission webhook in Go that rewrites pod image tags expressed as semver constraints into concrete versions, with TLS certs generated via CFSSL and the Kubernetes CSR API.'
+description: >-
+  Suhail Patel joins Rawkode to build a Kubernetes mutating admission webhook in
+  Go that rewrites pod image tags expressed as semver constraints into concrete
+  versions, with TLS certs generated via CFSSL and the Kubernetes CSR API.
 publishedAt: 2021-02-10T17:00:00.000Z
 type: live
 category: tutorial
@@ -104,15 +107,17 @@ guests:
 resources:
   - title: Kubernetes Admission Controllers documentation
     type: url
-    url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+    url: >-
+      https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
     category: documentation
   - title: Dynamic Admission Control (mutating and validating webhooks)
     type: url
-    url: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+    url: >-
+      https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
     category: documentation
   - title: Cloudflare CFSSL
     type: url
-    url: https://github.com/cloudflare/cfssl
+    url: 'https://github.com/cloudflare/cfssl'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2022/acing-the-devops-interview.md
+++ b/content/videos/shows/rawkode-live/2022/acing-the-devops-interview.md
@@ -3,75 +3,22 @@ id: tl0buwq41h0dywtit9z7tdz7
 slug: acing-the-devops-interview
 title: Acing the DevOps Interview
 description: >-
-  New to DevOps? Today is another day for you to get started.
-
-
-  Meet Rohit Ghumare, Founder of Keep Up, a community providing free training,
-  Live and Recorded webinars, and various other educational resources across
-  platforms like LinkedIn, Job portals, e-learning platforms and Developer
-  communities for encouraging learning among enthusiastic learners with
-  financial difficulties. He is also the Developer Advocate at solo.io, a
-  company delivering application networking software that simplifies and unifies
-  the configuration, operation and visibility of the network traffic within
-  distributed applications.
-
-
-  In conversation with David, Rohit discusses his journey to DevOps after
-  graduating with a degree in Computer Engineering. He reveals exploring data
-  science, machine learning, and Java product development before bumping into
-  Cloud and DevOps. Data Science, ML, and Java, though interesting areas, failed
-  to interest him significantly.
-
-
-  Then, Cloud and DevOps happened. Rohit recollects how he loved learning about
-  the different cloud technologies – hybrid multi cloud, AWS and GCP cloud
-  providers felt fun. Gradually, MLOps happened too.
-
-
-  Rohit loves learning and research and continues making the best of his time
-  teaching, learning, and creating. He’s worked with different companies, has a
-  considerable follower base for his learning community, and has knowledge about
-  many technologies - a feat he’s achieved in less than two years of his
-  professional journey.
-
-
-  Some things you’ll learn in this episode:
-
-  ● What is DevOps? How does it work? (You’ll have a comprehensive learning
-  today)
-
-  ● How to use Coursera’s financial aid to get free course certifications?
-
-  ● The importance of industry knowledge for a computer engineer
-
-  ● Walkthrough of different software tools – Terraform, Pulumi, Docker,
-  Kubernetes
-
-  ● What is a CI/CD pipeline?
-
-  ● How to land remote DevOps jobs as a fresher?
-
-  ● How important is knowing DSA (Data Structures and Algorithms) for a job
-  interview?
-
-  ● MLOps for merging various machine learning models easily
-
-  ● Easy and accessible resources for help in your coding journey
-
-
-  Resources and Useful links:
-
-
-  ● Rohit Ghumare on GitHub @ https://github.com/rohitg00/Rohit-ghumare
-
-  ● Rohit Ghumare on Twitter @ https://twitter.com/ghumare64
-
-
-  ● Find me on Twitter @ https://twitter.com/rawkode
+  Rohit Ghumare maps out a DevOps learning roadmap with Rawkode: Linux and
+  networking, containers, Kubernetes, cloud, CI/CD, infrastructure as code and
+  monitoring, plus advice on landing remote DevOps roles, DSA prep, and a look
+  at MLOps.
 publishedAt: 2022-08-11T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - docker
+  - kubernetes
+  - terraform
+  - pulumi
+  - crossplane
+  - prometheus
+  - grafana
+  - istio
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -148,12 +95,14 @@ guests:
 resources:
   - title: TechWorld with Nana YouTube channel
     type: url
+    url: https://www.youtube.com/@TechWorldwithNana
     category: other
   - title: Coursera Financial Aid
     type: url
     category: other
   - title: solo.io Academy
     type: url
+    url: https://www.solo.io/academy
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2022/acing-the-devops-interview.md
+++ b/content/videos/shows/rawkode-live/2022/acing-the-devops-interview.md
@@ -95,14 +95,14 @@ guests:
 resources:
   - title: TechWorld with Nana YouTube channel
     type: url
-    url: https://www.youtube.com/@TechWorldwithNana
+    url: 'https://www.youtube.com/@TechWorldwithNana'
     category: other
   - title: Coursera Financial Aid
     type: url
     category: other
   - title: solo.io Academy
     type: url
-    url: https://www.solo.io/academy
+    url: 'https://www.solo.io/academy'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-acorn.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-acorn.md
@@ -3,10 +3,10 @@ id: c3p1ypeqfmorfwwy2ypcrigm
 slug: hands-on-introduction-to-acorn
 title: Hands-on Introduction to Acorn
 description: >-
-  Acorn is an application packaging and deployment framework that simplifies
-  running apps on Kubernetes. Acorn is able to package up all of an applications
-  Docker images, configuration, and deployment specifications into a single
-  Acorn image artifact.
+  Darren Shepherd, chief architect at Acorn Labs and creator of k3s, walks
+  through Acorn: an Acornfile-driven way to package containers, secrets, and
+  ingress into an OCI artifact and deploy to Kubernetes without writing Helm
+  charts or raw YAML.
 publishedAt: 2022-08-25T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devspace.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devspace.md
@@ -90,15 +90,15 @@ guests: []
 resources:
   - type: url
     title: DevSpace website
-    url: https://devspace.sh/
+    url: 'https://devspace.sh/'
     category: documentation
   - type: url
     title: DevSpace documentation
-    url: https://devspace.sh/docs/getting-started/introduction
+    url: 'https://devspace.sh/docs/getting-started/introduction'
     category: documentation
   - type: url
-    title: DevSpace Slack (kubernetes.slack.com #devspace)
-    url: https://kubernetes.slack.com/messages/devspace
+    title: DevSpace Slack (kubernetes.slack.com
+    url: 'https://kubernetes.slack.com/messages/devspace'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devspace.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devspace.md
@@ -3,32 +3,18 @@ id: p573rqpaddgcyckqamxoe83g
 slug: hands-on-introduction-to-devspace
 title: Hands-on Introduction to DevSpace
 description: >-
-  DevSpace is a client-only, open-source developer tool for Kubernetes:
-
-
-  - Build, test and debug applications directly inside Kubernetes
-
-  - Develop with hot reloading: updates your running containers without
-  rebuilding images or restarting containers
-
-  - Unify deployment workflows within your team and across dev, staging and
-  production
-
-  - Automate repetitive tasks for image building and deployment
-
-
-  How does it work?
-
-
-  DevSpace runs as a single binary CLI tool directly on your computer and
-  ideally, you use it straight from the terminal within your IDE. DevSpace does
-  not require a server-side component as it communicates directly to your
-  Kubernetes cluster using your kube-context, just like kubectl.
+  Leon from Loft joins David for a hands-on tour of DevSpace. They initialise a
+  Node.js project, deploy it to Kubernetes with a Helm chart, swap into dev
+  mode, watch file sync and hot reloading via nodemon, and explore pipelines,
+  dependencies, and the VS Code remote SSH integration.
 publishedAt: 2022-09-17T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - devspace
+  - kubernetes
+  - helm
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -101,6 +87,18 @@ chapters:
     title: Conclusion
 duration: 4017
 guests: []
-resources: []
+resources:
+  - type: url
+    title: DevSpace website
+    url: https://devspace.sh/
+    category: documentation
+  - type: url
+    title: DevSpace documentation
+    url: https://devspace.sh/docs/getting-started/introduction
+    category: documentation
+  - type: url
+    title: DevSpace Slack (kubernetes.slack.com #devspace)
+    url: https://kubernetes.slack.com/messages/devspace
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devstand.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devstand.md
@@ -4,8 +4,8 @@ slug: hands-on-introduction-to-devstand
 title: Hands-on Introduction to DevStand
 description: >-
   Max shows how DevStand lowers the Kubernetes barrier for application
-  developers, with a visual editor and VS Code extension that authors
-  manifests, ingress, and dependencies like Minio storage.
+  developers, with a visual editor and VS Code extension that authors manifests,
+  ingress, and dependencies like Minio storage.
 publishedAt: 2022-10-08T17:00:00.000Z
 type: live
 category: tutorial
@@ -95,7 +95,7 @@ guests: []
 resources:
   - type: url
     title: DevStand website
-    url: https://devstand.app
+    url: 'https://devstand.app'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devstand.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-devstand.md
@@ -3,13 +3,15 @@ id: ns56m0h117hrt9hyszmvahv8
 slug: hands-on-introduction-to-devstand
 title: Hands-on Introduction to DevStand
 description: >-
-  Free and open source canvas to visualize dependencies between microservice
-  configurations.
+  Max shows how DevStand lowers the Kubernetes barrier for application
+  developers, with a visual editor and VS Code extension that authors
+  manifests, ingress, and dependencies like Minio storage.
 publishedAt: 2022-10-08T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - devstand
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 162
@@ -90,6 +92,10 @@ chapters:
     title: Conclusion & Future Outlook
 duration: 3781
 guests: []
-resources: []
+resources:
+  - type: url
+    title: DevStand website
+    url: https://devstand.app
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-dockerslim.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-dockerslim.md
@@ -3,14 +3,17 @@ id: s7ne8fr53irbz5wmwl6biim8
 slug: hands-on-introduction-to-dockerslim
 title: Hands-on Introduction to DockerSlim
 description: >-
-  DockerSlim is a tool for developers that provides a set of commands (build,
-  xray, lint and others) to simplify and optimize your developer experience with
-  containers. It makes your containers betters, smaller and more secure.
+  Martin Wimpress and Ivan Velichko join David to walk through DockerSlim's
+  build, xray, and probing workflow, then live-slim a CentOS+curl image and a
+  Node.js HTTP API before optimising a workload running on a kind Kubernetes
+  cluster.
 publishedAt: 2022-09-01T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - slim-toolkit
+  - docker
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -79,6 +82,14 @@ duration: 5261
 guests:
   - kyle-quest
   - ivan-velichko
-resources: []
+resources:
+  - title: Slim Toolkit (formerly DockerSlim)
+    type: url
+    url: 'https://slimtoolkit.org'
+    category: documentation
+  - title: slimtoolkit/slim on GitHub
+    type: url
+    url: 'https://github.com/slimtoolkit/slim'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-gitea.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-gitea.md
@@ -3,8 +3,9 @@ id: ytmz11lcuyrxd14ykxqb4wu2
 slug: hands-on-introduction-to-gitea
 title: Hands-on Introduction to Gitea
 description: >-
-  In this session, we take a look at Gitea - a self-hosted, pain-less, Git
-  solution.
+  David is joined by Matti (project owner) to install Gitea from binary on an
+  Equinix Metal Ubuntu box, walk the web installer with SQLite, then tour repos,
+  SSH signing, migrations, CI options, and the API.
 publishedAt: 2022-09-03T17:00:00.000Z
 type: live
 category: tutorial
@@ -136,16 +137,19 @@ guests:
 resources:
   - title: Gitea from binary installation guide
     type: url
+    url: 'https://docs.gitea.com/installation/install-from-binary'
     category: documentation
   - title: Gitea Helm chart
     type: url
+    url: 'https://gitea.com/gitea/helm-gitea'
     category: code
   - title: Gitea comparison document
     type: url
+    url: 'https://docs.gitea.com/installation/comparison'
     category: documentation
-  - title: Gitea CLI t repository
+  - title: Gitea tea CLI repository
     type: url
-    url: 'https://gitea.com/gitea/t'
+    url: 'https://gitea.com/gitea/tea'
     category: code
   - title: Codeberg
     type: url

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-helm-dashboard.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-helm-dashboard.md
@@ -3,10 +3,10 @@ id: lcz9j59zo663yngesf8a0k1m
 slug: hands-on-introduction-to-helm-dashboard
 title: Hands-on Introduction to helm-dashboard
 description: >-
-  Andre Pokhilko from Komodor walks David through Helm Dashboard, an open
-  source Helm plugin that puts a focused web UI over the Helm CLI. The demo
-  covers release history, manifest and values diffs, rollbacks, reconfigure,
-  and Trivy/Checkov scanner integration.
+  Andre Pokhilko from Komodor walks David through Helm Dashboard, an open source
+  Helm plugin that puts a focused web UI over the Helm CLI. The demo covers
+  release history, manifest and values diffs, rollbacks, reconfigure, and
+  Trivy/Checkov scanner integration.
 publishedAt: 2022-10-27T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-helm-dashboard.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-helm-dashboard.md
@@ -3,15 +3,17 @@ id: lcz9j59zo663yngesf8a0k1m
 slug: hands-on-introduction-to-helm-dashboard
 title: Hands-on Introduction to helm-dashboard
 description: >-
-  The Helm Dashboard plugin offers a UI-driven way to view the installed Helm
-  charts, see their revision history and corresponding k8s resources. Also, you
-  can perform simple actions like roll back to a revision or upgrade to newer
-  version.
+  Andre Pokhilko from Komodor walks David through Helm Dashboard, an open
+  source Helm plugin that puts a focused web UI over the Helm CLI. The demo
+  covers release history, manifest and values diffs, rollbacks, reconfigure,
+  and Trivy/Checkov scanner integration.
 publishedAt: 2022-10-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - helm-dashboard
+  - helm
+  - kubernetes
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -77,6 +79,26 @@ chapters:
 duration: 3498
 guests:
   - andrei-pokhilko
-resources: []
+resources:
+  - type: url
+    category: code
+    title: helm-dashboard on GitHub
+    url: 'https://github.com/komodorio/helm-dashboard'
+  - type: url
+    category: documentation
+    title: Helm
+    url: 'https://helm.sh/'
+  - type: url
+    category: other
+    title: Komodor
+    url: 'https://komodor.com/'
+  - type: url
+    category: other
+    title: Trivy
+    url: 'https://github.com/aquasecurity/trivy'
+  - type: url
+    category: other
+    title: Checkov
+    url: 'https://www.checkov.io/'
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kamaji.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kamaji.md
@@ -2,7 +2,10 @@
 id: iu73cnmo4xit3a5g7olhizfo
 slug: hands-on-introduction-to-kamaji
 title: Hands-on Introduction to Kamaji
-description: Adriano Pezzuto walks through Kamaji, running tenant Kubernetes control planes as pods inside a management cluster, then provisions a tenant and joins AWS worker nodes via kubeadm and Cluster API conventions.
+description: >-
+  Adriano Pezzuto walks through Kamaji, running tenant Kubernetes control planes
+  as pods inside a management cluster, then provisions a tenant and joins AWS
+  worker nodes via kubeadm and Cluster API conventions.
 publishedAt: 2022-08-13T17:00:00.000Z
 type: live
 category: tutorial
@@ -99,10 +102,10 @@ resources:
   - title: Kamaji
     type: url
     category: documentation
-    url: https://kamaji.clastix.io/
+    url: 'https://kamaji.clastix.io/'
   - title: Clastix Capsule
     type: url
     category: code
-    url: https://github.com/projectcapsule/capsule
+    url: 'https://github.com/projectcapsule/capsule'
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kamaji.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kamaji.md
@@ -2,12 +2,16 @@
 id: iu73cnmo4xit3a5g7olhizfo
 slug: hands-on-introduction-to-kamaji
 title: Hands-on Introduction to Kamaji
-description: Build and operate Kubernetes at scale with a fraction of operational burden.
+description: Adriano Pezzuto walks through Kamaji, running tenant Kubernetes control planes as pods inside a management cluster, then provisions a tenant and joins AWS worker nodes via kubeadm and Cluster API conventions.
 publishedAt: 2022-08-13T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kamaji
+  - kubernetes
+  - etcd
+  - cluster-api
+  - capsule
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -92,8 +96,13 @@ duration: 4433
 guests:
   - adriano-pezzuto
 resources:
+  - title: Kamaji
+    type: url
+    category: documentation
+    url: https://kamaji.clastix.io/
   - title: Clastix Capsule
     type: url
     category: code
+    url: https://github.com/projectcapsule/capsule
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kluctl.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kluctl.md
@@ -3,15 +3,18 @@ id: nif2kkr7kig9n82jxsjyd2ds
 slug: hands-on-introduction-to-kluctl
 title: Hands-on Introduction to kluctl
 description: >-
-  Kluctl is the missing glue that puts together your (and any third-party)
-  deployments into one large declarative Kubernetes deployment, while making it
-  fully manageable (deploy, diff, prune, delete, ...) via one unified command
-  line interface.
+  Alexander Block, creator of Kluctl, walks through the deployment problems it
+  was built to solve and demos targets, templated vars, and a diff-first
+  deploy/prune workflow that composes Helm charts and Kustomize on a kind
+  cluster.
 publishedAt: 2022-10-20T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kluctl
+  - kubernetes
+  - helm
+  - fluxcd
 show: rawkode-live
 chapters:
   - startTime: 161
@@ -106,9 +109,11 @@ guests:
 resources:
   - title: podinfo Helm chart
     type: url
+    url: 'https://github.com/stefanprodan/podinfo'
     category: demos
   - title: Flux Kluctl controller
     type: url
+    url: 'https://github.com/kluctl/flux-kluctl-controller'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kpt.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kpt.md
@@ -3,15 +3,17 @@ id: cbeascecdg8e9r04gjnagspj
 slug: hands-on-introduction-to-kpt
 title: Hands-on Introduction to kpt
 description: >-
-  kpt is a package-centric toolchain that enables a WYSIWYG configuration
-  authoring, automation, and delivery experience, which simplifies managing
-  Kubernetes platforms and KRM-driven infrastructure at scale by manipulating
-  declarative Configuration as Data, separated from the cod…
+  Brian Grant and Justin Santa Barbara from Google walk through kpt hands-on:
+  installing the CLI and Porch, registering blueprint and deployment Git repos,
+  authoring a namespace package with KRM functions, and driving it all from the
+  Backstage-based Config as Data UI.
 publishedAt: 2022-07-15T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kpt
+  - kubernetes
+  - backstage
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -174,9 +176,11 @@ guests:
 resources:
   - title: kpt namespace provisioning UI guide
     type: url
+    url: 'https://kpt.dev/guides/namespace-provisioning-ui'
     category: documentation
   - title: kpt channel on the Kubernetes Slack
     type: url
+    url: 'https://kubernetes.slack.com/messages/kpt'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubescape.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubescape.md
@@ -113,7 +113,8 @@ resources:
   - title: NSA CISA Kubernetes hardening framework
     type: url
     category: documentation
-    url: 'https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF'
+    url: >-
+      https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
   - title: Kubescape Rego library project
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubescape.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubescape.md
@@ -3,14 +3,17 @@ id: c2q3win8puhpdiozuaenozl0
 slug: hands-on-introduction-to-kubescape
 title: Hands-on Introduction to Kubescape
 description: >-
-  Kubescape is a K8s open-source tool providing a multi-cloud K8s single pane of
-  glass, including risk analysis, security compliance, RBAC visualizer and image
-  vulnerabilities scanning.
+  Ben Hirschberg from ARMO walks through Kubescape, scanning clusters and YAML
+  against the NSA/CISA hardening framework, writing controls in Rego on OPA,
+  shifting left with the VS Code extension and GitHub Action, and the RBAC
+  visualizer in the hosted UI.
 publishedAt: 2022-02-22T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubescape
+  - kubernetes
+  - opa
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -110,17 +113,22 @@ resources:
   - title: NSA CISA Kubernetes hardening framework
     type: url
     category: documentation
+    url: 'https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF'
   - title: Kubescape Rego library project
     type: url
     category: code
+    url: 'https://github.com/kubescape/regolibrary'
   - title: Kubescape GitHub Action
     type: url
     category: code
+    url: 'https://github.com/kubescape/github-action'
   - title: Kubescape Visual Studio Code extension
     type: url
     category: code
+    url: 'https://github.com/kubescape/vscode-extension'
   - title: Kubescape host sensor
     type: url
     category: code
+    url: 'https://github.com/kubescape/host-scanner'
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubevious.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-kubevious.md
@@ -3,13 +3,16 @@ id: nyxygq8akdwhroctp7hnmjnw
 slug: hands-on-introduction-to-kubevious
 title: Hands-on Introduction to Kubevious
 description: >-
-  Find Kubernetes challenging to understand? Ruben Hakopian and his team might
-  have found you a solution!
+  Ruben Hakopian walks through Kubevious, installing it via Helm and exploring
+  the application-centric UI, time machine, custom rules, and the Guard CLI for
+  catching Kubernetes misconfigurations before they hit the cluster.
 publishedAt: 2022-08-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kubevious
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -85,6 +88,18 @@ chapters:
 duration: 5432
 guests:
   - ruben-hakopian
-resources: []
+resources:
+  - type: url
+    title: Kubevious
+    url: 'https://kubevious.io/'
+    category: documentation
+  - type: url
+    title: Kubevious documentation
+    url: 'https://kubevious.io/docs/'
+    category: documentation
+  - type: url
+    title: kubevious/kubevious on GitHub
+    url: 'https://github.com/kubevious/kubevious'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-namespace.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-namespace.md
@@ -3,12 +3,18 @@ id: cjjyrounj8qpdyd9addol7py
 slug: hands-on-introduction-to-namespace
 title: Hands-on Introduction to Namespace
 description: >-
-  The all-in-one developer platform: Namespace provides a unified experience
-  from development to production.
+  Hugo Santos walks through Namespace, an end-to-end application platform built
+  on Kubernetes. We bootstrap a local K3s cluster, define services in CUE, build
+  images with BuildKit, wire in MinIO, and explore module-based dependencies.
 publishedAt: 2022-12-01T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - buildkit
+  - cue
+  - k3s
+  - kubernetes
+  - minio
   - namespace
 show: rawkode-live
 chapters:
@@ -78,6 +84,7 @@ guests:
 resources:
   - title: Cash App Hermit
     type: url
+    url: 'https://github.com/cashapp/hermit'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-openunison.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-openunison.md
@@ -3,10 +3,10 @@ id: bxlvg3jfdk6jqbfck4nmrcas
 slug: hands-on-introduction-to-openunison
 title: Hands-on Introduction to OpenUnison
 description: >-
-  Marc Boorshtein walks through OpenUnison as an identity portal for
-  Kubernetes, covering SSO into the dashboard and kubectl, the ou-control
-  deployer, the ou-login plugin, multi-cluster satellites, and Namespace and
-  Virtual Cluster as a Service demos.
+  Marc Boorshtein walks through OpenUnison as an identity portal for Kubernetes,
+  covering SSO into the dashboard and kubectl, the ou-control deployer, the
+  ou-login plugin, multi-cluster satellites, and Namespace and Virtual Cluster
+  as a Service demos.
 publishedAt: 2022-09-03T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-openunison.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-openunison.md
@@ -3,21 +3,15 @@ id: bxlvg3jfdk6jqbfck4nmrcas
 slug: hands-on-introduction-to-openunison
 title: Hands-on Introduction to OpenUnison
 description: >-
-  OpenUnison combines the common identity management functions needed by most
-  applications including:
-
-
-  - SSO
-
-  - User Provisioning (with Workflows)
-
-  - Federation
-
-  - Web Services
+  Marc Boorshtein walks through OpenUnison as an identity portal for
+  Kubernetes, covering SSO into the dashboard and kubectl, the ou-control
+  deployer, the ou-login plugin, multi-cluster satellites, and Namespace and
+  Virtual Cluster as a Service demos.
 publishedAt: 2022-09-03T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - kubernetes
   - openunison
 show: rawkode-live
 chapters:
@@ -70,6 +64,7 @@ resources:
     type: url
     category: other
   - title: Fairwinds RBAC Manager
+    url: 'https://github.com/FairwindsOps/rbac-manager'
     type: url
     category: code
 ---

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-parca.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-parca.md
@@ -3,14 +3,17 @@ id: fvez8xw9it644rtfzl5xclpd
 slug: hands-on-introduction-to-parca
 title: Hands-on Introduction to Parca
 description: >-
-  In this episode, we show you how to start continuously profiling your
-  applications with Parca; an open-source project from the team at Polar
-  Signals.
+  Frederic Branczyk of Polar Signals joins to install Parca on a fresh
+  Kubernetes cluster, walk through the eBPF agent and server, and explore flame
+  graphs, profile comparisons, and pprof scraping for continuous profiling at
+  roughly one percent overhead.
 publishedAt: 2022-01-26T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - parca
+  - kubernetes
+  - ebpf
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -125,11 +128,13 @@ guests:
 resources:
   - title: Parca in Kubernetes tutorial
     type: url
+    url: 'https://www.parca.dev/docs/kubernetes/'
     category: documentation
   - title: >-
       KubeCon Barcelona 2019 observability keynote by Frederic Branczyk and Tom
       Wilkie
     type: url
+    url: 'https://www.youtube.com/watch?v=MkSdvPdS1oA'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-portainer.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-portainer.md
@@ -3,8 +3,10 @@ id: hea5aobhyt84z99fvl9m92t6
 slug: hands-on-introduction-to-portainer
 title: Hands-on Introduction to Portainer
 description: >-
-  Easily deploy, configure and secure containers in minutes on Docker,
-  Kubernetes, Swarm and Nomad in any cloud, datacenter or device.
+  Co-founder Neil Cresswell joins David to demo Portainer as a universal
+  manager for Kubernetes, Docker, Swarm, and Nomad. Covers namespace policies,
+  OPA Gatekeeper integration, GitOps, edge compute, and lowering the barrier
+  from VMs to containers.
 publishedAt: 2022-10-15T17:00:00.000Z
 type: live
 category: tutorial
@@ -72,6 +74,7 @@ guests:
 resources:
   - title: CNCF Landscape
     type: url
+    url: 'https://landscape.cncf.io/'
     category: other
   - title: Sosivio
     type: url

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-portainer.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-portainer.md
@@ -3,10 +3,10 @@ id: hea5aobhyt84z99fvl9m92t6
 slug: hands-on-introduction-to-portainer
 title: Hands-on Introduction to Portainer
 description: >-
-  Co-founder Neil Cresswell joins David to demo Portainer as a universal
-  manager for Kubernetes, Docker, Swarm, and Nomad. Covers namespace policies,
-  OPA Gatekeeper integration, GitOps, edge compute, and lowering the barrier
-  from VMs to containers.
+  Co-founder Neil Cresswell joins David to demo Portainer as a universal manager
+  for Kubernetes, Docker, Swarm, and Nomad. Covers namespace policies, OPA
+  Gatekeeper integration, GitOps, edge compute, and lowering the barrier from
+  VMs to containers.
 publishedAt: 2022-10-15T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-schemahero.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-schemahero.md
@@ -3,13 +3,18 @@ id: qatht83waplqejze8yf2865b
 slug: hands-on-introduction-to-schemahero
 title: Hands-on Introduction to SchemaHero
 description: >-
-  In this episode, we take a look at making your database migrations declarative
-  and cloud native with Kubernetes.
+  Mark Campbell from Replicated joins to demo SchemaHero, a Kubernetes operator
+  that turns database schemas into declarative custom resources. We install it
+  via Krew, run it against Postgres and MariaDB, review generated migrations,
+  and wire it into a Flux GitOps workflow.
 publishedAt: 2022-01-28T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - schemahero
+  - kubernetes
+  - postgresql
+  - fluxcd
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -180,6 +185,7 @@ resources:
     category: documentation
   - title: SchemaHero channel on Kubernetes Slack
     type: url
+    url: 'https://kubernetes.slack.com/messages/schemahero'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-spin-webassembly-microservices.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-spin-webassembly-microservices.md
@@ -3,14 +3,16 @@ id: jqetzwc4xdsjsvd2dg58hgpw
 slug: hands-on-introduction-to-spin-webassembly-microservices
 title: 'Hands-on Introduction to Spin: WebAssembly Microservices'
 description: >-
-  In this live stream, David will be onboarding himself with Fermyon's Spin
-  project, a WebAssembly framework for building microservices in your language
-  of choice.
+  David explores Fermyon's Spin, comparing its Nomad-based runtime to Kubernetes
+  via Krustlet, then builds a Rust HTTP microservice backed by Prisma and
+  CockroachDB, running it locally before deploying to Fermyon Cloud.
 publishedAt: 2022-11-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - spin
+  - webassembly
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 162
@@ -38,13 +40,14 @@ chapters:
 duration: 2981
 guests: []
 resources:
-  - title: Fermion official co-founders interview about Spin and Nomad
+  - title: Fermyon co-founders interview about Spin and Nomad
     type: url
     category: other
-  - title: Fermion Spin examples directory
+  - title: Spin examples directory
     type: url
+    url: 'https://github.com/spinframework/spin/tree/main/examples'
     category: code
-  - title: Fermion Platform open source repository
+  - title: Fermyon Platform open source repository
     type: url
     category: code
 ---

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-trivy.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-trivy.md
@@ -3,14 +3,19 @@ id: gstsdlvy9sstecquu9q1vf7f
 slug: hands-on-introduction-to-trivy
 title: Hands-on Introduction to Trivy
 description: >-
-  In this episode, we'll be taking a look at continuously scanning for
-  misconfiguration and vulnerabilities within your container images with Aqua's
-  open source project, Trivy.
+  Rory McCune joins to demo Trivy, Aqua Security's scanner for container
+  images, filesystems, Git repos, Kubernetes manifests, and Terraform.
+  Hands-on installation, image scanning, IaC checks, plus a GitHub Actions
+  pipeline that signs builds with cosign.
 publishedAt: 2022-02-05T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - trivy
+  - docker
+  - kubernetes
+  - terraform
+  - sigstore
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -96,12 +101,15 @@ resources:
   - title: Trivy Getting Started documentation
     type: url
     category: documentation
+    url: https://trivy.dev/docs/
   - title: Kubernetes Pod Security Standards
     type: url
     category: documentation
+    url: https://kubernetes.io/docs/concepts/security/pod-security-standards/
   - title: Trivy GitHub Action
     type: url
     category: code
+    url: https://github.com/aquasecurity/trivy-action
   - title: Honeypop proof of concept exploit code
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-trivy.md
+++ b/content/videos/shows/rawkode-live/2022/hands-on-introduction-to-trivy.md
@@ -3,10 +3,10 @@ id: gstsdlvy9sstecquu9q1vf7f
 slug: hands-on-introduction-to-trivy
 title: Hands-on Introduction to Trivy
 description: >-
-  Rory McCune joins to demo Trivy, Aqua Security's scanner for container
-  images, filesystems, Git repos, Kubernetes manifests, and Terraform.
-  Hands-on installation, image scanning, IaC checks, plus a GitHub Actions
-  pipeline that signs builds with cosign.
+  Rory McCune joins to demo Trivy, Aqua Security's scanner for container images,
+  filesystems, Git repos, Kubernetes manifests, and Terraform. Hands-on
+  installation, image scanning, IaC checks, plus a GitHub Actions pipeline that
+  signs builds with cosign.
 publishedAt: 2022-02-05T17:00:00.000Z
 type: live
 category: tutorial
@@ -101,15 +101,15 @@ resources:
   - title: Trivy Getting Started documentation
     type: url
     category: documentation
-    url: https://trivy.dev/docs/
+    url: 'https://trivy.dev/docs/'
   - title: Kubernetes Pod Security Standards
     type: url
     category: documentation
-    url: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+    url: 'https://kubernetes.io/docs/concepts/security/pod-security-standards/'
   - title: Trivy GitHub Action
     type: url
     category: code
-    url: https://github.com/aquasecurity/trivy-action
+    url: 'https://github.com/aquasecurity/trivy-action'
   - title: Honeypop proof of concept exploit code
     type: url
     category: code

--- a/content/videos/shows/rawkode-live/2022/introducing-apko-and-melange.md
+++ b/content/videos/shows/rawkode-live/2022/introducing-apko-and-melange.md
@@ -3,9 +3,9 @@ id: f7rvx2rb04zl2vhgoltwedf5
 slug: introducing-apko-and-melange
 title: Introducing apko & melange
 description: >-
-  Joined by Ariadne from Chainguard, we introduce the world to apko + melange -
-  a toolset for building distroless container images in a declarative fashion
-  with Alpine's APK.
+  Ariadne Conill, primary author of apko and melange, walks through assembling
+  distroless OCI images from APK packages: building an NGINX image with apko,
+  packaging GNU hello with melange, signing keys, SBOMs, and GitHub Actions.
 publishedAt: 2022-03-17T17:00:00.000Z
 type: live
 category: tutorial
@@ -72,15 +72,19 @@ guests:
 resources:
   - title: Google's Distroless project
     type: url
+    url: https://github.com/GoogleContainerTools/distroless
     category: code
   - title: GNU hello world program
     type: url
+    url: https://www.gnu.org/software/hello/
     category: code
-  - title: apko examples/NGINX.yaml
+  - title: apko examples/nginx.yaml
     type: url
+    url: https://github.com/chainguard-dev/apko/blob/main/examples/nginx.yaml
     category: demos
-  - title: melange examples/GNU hello.yaml
+  - title: melange examples/gnu-hello.yaml
     type: url
+    url: https://github.com/chainguard-dev/melange/blob/main/examples/gnu-hello.yaml
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2022/introducing-apko-and-melange.md
+++ b/content/videos/shows/rawkode-live/2022/introducing-apko-and-melange.md
@@ -72,19 +72,20 @@ guests:
 resources:
   - title: Google's Distroless project
     type: url
-    url: https://github.com/GoogleContainerTools/distroless
+    url: 'https://github.com/GoogleContainerTools/distroless'
     category: code
   - title: GNU hello world program
     type: url
-    url: https://www.gnu.org/software/hello/
+    url: 'https://www.gnu.org/software/hello/'
     category: code
   - title: apko examples/nginx.yaml
     type: url
-    url: https://github.com/chainguard-dev/apko/blob/main/examples/nginx.yaml
+    url: 'https://github.com/chainguard-dev/apko/blob/main/examples/nginx.yaml'
     category: demos
   - title: melange examples/gnu-hello.yaml
     type: url
-    url: https://github.com/chainguard-dev/melange/blob/main/examples/gnu-hello.yaml
+    url: >-
+      https://github.com/chainguard-dev/melange/blob/main/examples/gnu-hello.yaml
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2022/monitoring-kubernetes-with-prometheus-and-robusta.md
+++ b/content/videos/shows/rawkode-live/2022/monitoring-kubernetes-with-prometheus-and-robusta.md
@@ -3,13 +3,17 @@ id: e88n95c3276uqeoi7per1v6r
 slug: monitoring-kubernetes-with-prometheus-and-robusta
 title: Monitoring Kubernetes with Prometheus & Robusta
 description: >-
-  Let’s take a look at some of the new features in Robusta that take your
-  Kubernetes and Prometheus monitoring to the next level.
+  Natan Yellin and Eric return to walk through Robusta's playbooks and
+  enrichers, demoing CrashLoopBackOff and OOMKill alerts, custom Stack Overflow
+  enrichment, and the Robusta SaaS platform on top of Prometheus and Kubernetes.
 publishedAt: 2022-12-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - robusta
+  - prometheus
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 168
@@ -52,9 +56,11 @@ guests:
 resources:
   - title: Kube Watch
     type: url
+    url: 'https://github.com/robusta-dev/kubewatch'
     category: code
   - title: Robusta custom automation tutorial
     type: url
+    url: 'https://docs.robusta.dev/master/playbook-reference/index.html'
     category: documentation
   - title: Robusta Stack Overflow enricher source code
     type: url

--- a/content/videos/shows/rawkode-live/2023/cncf-glossary-and-linkerd-with-catherine-paganini-and-jason-morgan.md
+++ b/content/videos/shows/rawkode-live/2023/cncf-glossary-and-linkerd-with-catherine-paganini-and-jason-morgan.md
@@ -3,10 +3,10 @@ id: vxnm3rycgt9l71t5svvca8s5
 slug: cncf-glossary-and-linkerd-with-catherine-paganini-and-jason-morgan
 title: CNCF Glossary & Linkerd with Catherine Paganini & Jason Morgan
 description: >-
-  The Cloud Native Glossary is a comprehensive list of terms related to
-  Kubernetes and Cloud Native concepts, translated into multiple languages. It
-  was created to make the concepts more accessible for both technical and
-  non-technical people.
+  Catherine Paganini and Jason Morgan explain how the vendor-neutral CNCF Cloud
+  Native Glossary makes cloud native terms accessible (and localised) for
+  non-technical audiences, then dig into Linkerd, service mesh trade-offs, and
+  Gateway API adoption.
 publishedAt: 2023-03-07T17:00:00.000Z
 type: live
 category: tutorial
@@ -51,19 +51,23 @@ guests:
 resources:
   - title: Cloud Native Glossary
     type: url
+    url: 'https://glossary.cncf.io/'
     category: documentation
   - title: Cloud Native Maturity Model
     type: url
+    url: 'https://maturitymodel.cncf.io/'
     category: documentation
   - title: Linkerd Slack
     type: url
-    url: 'https://slack.linkerd.io'
+    url: 'https://slack.linkerd.io/'
     category: other
   - title: Linkerd Getting Started Guide
     type: url
+    url: 'https://linkerd.io/2/getting-started/'
     category: documentation
   - title: Service Mesh Academy
     type: url
-    category: demos
+    url: 'https://buoyant.io/service-mesh-academy'
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2023/feature-flags-via-gitops-with-flipt.md
+++ b/content/videos/shows/rawkode-live/2023/feature-flags-via-gitops-with-flipt.md
@@ -3,13 +3,18 @@ id: nzngv0j5wn5xgxps9qrg2i2i
 slug: feature-flags-via-gitops-with-flipt
 title: Feature Flags via GitOps with Flipt
 description: >-
-  Flipt is an open-source, self-hosted feature flag application that allows you
-  to run experiments across services in your environment.
+  Mark Phelps and George MacRorie show how Flipt manages feature flags as code,
+  syncing flag state from a Git repository (Gitea) and OCI registries. Demo
+  covers variants, stickiness, gRPC and REST SDKs (Node, Python), and bundling
+  flags with ttl.sh.
 publishedAt: 2023-11-18T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - flipt
+  - gitea
+  - grpc
+  - docker-compose
 show: rawkode-live
 chapters:
   - startTime: 31
@@ -59,12 +64,15 @@ guests:
 resources:
   - title: Flipt Labs repository
     type: url
+    url: 'https://github.com/flipt-io/labs'
     category: code
   - title: Flipt Labs chatbot demo
     type: url
+    url: 'https://github.com/flipt-io/labs/tree/main/chatbot'
     category: demos
   - title: ttl.sh ephemeral registry
     type: url
+    url: 'https://ttl.sh'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-dapr.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-dapr.md
@@ -2,7 +2,11 @@
 id: jmjdponjje5ueukwqlprmcbq
 slug: hands-on-introduction-to-dapr
 title: Hands-on Introduction to Dapr
-description: "Hands-on tour of Dapr's distributed application runtime: building blocks and sidecar pattern, state management with the JavaScript SDK and Redis, outbox pattern, then deploying the demo app to a Kind Kubernetes cluster with the Dapr control plane installed via Helm."
+description: >-
+  Hands-on tour of Dapr's distributed application runtime: building blocks and
+  sidecar pattern, state management with the JavaScript SDK and Redis, outbox
+  pattern, then deploying the demo app to a Kind Kubernetes cluster with the
+  Dapr control plane installed via Helm.
 publishedAt: 2023-12-14T17:00:00.000Z
 type: live
 category: tutorial
@@ -98,15 +102,18 @@ resources:
     category: other
   - title: Dapr State Management JavaScript Quickstart
     type: url
-    url: 'https://github.com/dapr/quickstarts/tree/master/state_management/javascript/sdk'
+    url: >-
+      https://github.com/dapr/quickstarts/tree/master/state_management/javascript/sdk
     category: code
   - title: Dapr Outbox Pattern Documentation
     type: url
-    url: 'https://docs.dapr.io/developing-applications/building-blocks/state-management/howto-outbox/'
+    url: >-
+      https://docs.dapr.io/developing-applications/building-blocks/state-management/howto-outbox/
     category: documentation
   - title: Dapr State Stores Component Reference
     type: url
-    url: 'https://docs.dapr.io/reference/components-reference/supported-state-stores/'
+    url: >-
+      https://docs.dapr.io/reference/components-reference/supported-state-stores/
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-dapr.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-dapr.md
@@ -2,12 +2,14 @@
 id: jmjdponjje5ueukwqlprmcbq
 slug: hands-on-introduction-to-dapr
 title: Hands-on Introduction to Dapr
-description: Video content coming soon.
+description: "Hands-on tour of Dapr's distributed application runtime: building blocks and sidecar pattern, state management with the JavaScript SDK and Redis, outbox pattern, then deploying the demo app to a Kind Kubernetes cluster with the Dapr control plane installed via Helm."
 publishedAt: 2023-12-14T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - dapr
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 108
@@ -92,15 +94,19 @@ guests:
 resources:
   - title: Platform Engineering on Kubernetes
     type: url
+    url: 'https://www.manning.com/books/platform-engineering-on-kubernetes'
     category: other
   - title: Dapr State Management JavaScript Quickstart
     type: url
-    category: documentation
+    url: 'https://github.com/dapr/quickstarts/tree/master/state_management/javascript/sdk'
+    category: code
   - title: Dapr Outbox Pattern Documentation
     type: url
+    url: 'https://docs.dapr.io/developing-applications/building-blocks/state-management/howto-outbox/'
     category: documentation
   - title: Dapr State Stores Component Reference
     type: url
+    url: 'https://docs.dapr.io/reference/components-reference/supported-state-stores/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitgat.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitgat.md
@@ -3,10 +3,10 @@ id: ziso8d5pctrrqhxqeqbgvkfo
 slug: hands-on-introduction-to-gitgat
 title: Hands-on Introduction to GitGat
 description: >-
-  SCM (Source Control Management) security is of high importance as it serves as
-  an entry point to the whole CI/CD pipeline. This repository contains policies
-  that verify SCM (currently GitHub's) organization/repositories/user accounts
-  security.
+  Barak Brudo from Scribe Security walks through GitGat, an open source tool
+  written in Rego on OPA that audits GitHub security posture: 2FA, branch
+  protection, signed commits, deploy and SSH keys. Runs locally or on a
+  schedule via GitHub Actions.
 publishedAt: 2023-03-09T17:00:00.000Z
 type: live
 category: tutorial
@@ -106,6 +106,10 @@ duration: 4281
 guests:
   - barak-brudo
 resources:
+  - title: GitGat on GitHub
+    type: url
+    url: 'https://github.com/scribe-public/gitgat'
+    category: code
   - title: 'Linux Foundation LFS122x: GitHub Supply Chain Security using GitGat'
     type: url
     category: documentation

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitgat.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitgat.md
@@ -5,8 +5,8 @@ title: Hands-on Introduction to GitGat
 description: >-
   Barak Brudo from Scribe Security walks through GitGat, an open source tool
   written in Rego on OPA that audits GitHub security posture: 2FA, branch
-  protection, signed commits, deploy and SSH keys. Runs locally or on a
-  schedule via GitHub Actions.
+  protection, signed commits, deploy and SSH keys. Runs locally or on a schedule
+  via GitHub Actions.
 publishedAt: 2023-03-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitops-with-gimlet.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-gitops-with-gimlet.md
@@ -3,13 +3,18 @@ id: ddivo405dfsxz4vrvlr3xgmy
 slug: hands-on-introduction-to-gitops-with-gimlet
 title: Hands-on Introduction to GitOps with Gimlet
 description: >-
-  Adopting Kubernetes is a big endevaur. But it is the deployment platform
-  today.
+  Laszlo Fogas walks through Gimlet, a GitOps developer platform that pairs Flux
+  with the OneChart Helm chart and a UI. We install it on k3d, wire up GitHub,
+  deploy an app with Buildpacks, and add NGINX from the marketplace.
 publishedAt: 2023-08-26T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - gimlet
+  - fluxcd
+  - kubernetes
+  - helm
+  - buildpacks
 show: rawkode-live
 chapters:
   - startTime: 108
@@ -45,6 +50,7 @@ resources:
     category: documentation
   - title: Gimlet OneChart Helm chart
     type: url
+    url: 'https://github.com/gimlet-io/onechart'
     category: code
   - title: Gimlet GitHub Action
     type: url

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-krr-kubernetes-resource-recommendations.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-krr-kubernetes-resource-recommendations.md
@@ -3,15 +3,18 @@ id: fd5l8yd2xbh033dpnkvftg35
 slug: hands-on-introduction-to-krr-kubernetes-resource-recommendations
 title: Hands-on Introduction to KRR (Kubernetes Resource Recommendations)
 description: >-
-  Robusta KRR (Kubernetes Resource Recommender) is a CLI tool for optimizing
-  resource allocation in Kubernetes clusters. It gathers pod usage data from
-  Prometheus and recommends requests and limits for CPU and memory. This reduces
-  costs and improves performance.
+  Natan Yellin from Robusta walks David through KRR, a CLI that queries existing
+  Prometheus data to recommend CPU and memory requests and limits for Kubernetes
+  workloads. They compare it to the VPA, demo the simple strategy, and discuss
+  future directions.
 publishedAt: 2023-05-25T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - krr
+  - robusta
+  - kubernetes
+  - prometheus
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -79,6 +82,18 @@ chapters:
 duration: 3267
 guests:
   - natan-yellin
-resources: []
+resources:
+  - type: url
+    title: Robusta KRR on GitHub
+    category: code
+    url: 'https://github.com/robusta-dev/krr'
+  - type: url
+    title: Robusta
+    category: documentation
+    url: 'https://robusta.dev/'
+  - type: url
+    title: Prometheus
+    category: documentation
+    url: 'https://prometheus.io/'
 ---
 

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-kwasm.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-kwasm.md
@@ -3,14 +3,19 @@ id: a3fgm13ik7jug2x4xzh7w7sb
 slug: hands-on-introduction-to-kwasm
 title: Hands-on Introduction to KWasm
 description: >-
-  Kwasm is a Kubernetes Operator that adds WebAssembly support to your
-  Kubernetes nodes. It does so by using a container image that contains binaries
-  and configuration variables needed to run pure WebAssembly images.
+  Christopher and Sven from Liquid Reply walk through KWasm, the operator that
+  installs containerd Wasm shims onto nodes via annotations. We deploy it to a
+  kind cluster and a bare metal kubeadm cluster, then run WasmEdge and Spin
+  workloads.
 publishedAt: 2023-03-18T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - containerd
+  - kubernetes
   - kwasm
+  - spin
+  - wasm-edge-runtime
 show: rawkode-live
 chapters:
   - startTime: 163

--- a/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-wundergraph.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-introduction-to-wundergraph.md
@@ -3,19 +3,9 @@ id: xn11gt75dscahop47hm3hznw
 slug: hands-on-introduction-to-wundergraph
 title: Hands-on Introduction to WunderGraph
 description: >-
-  WunderGraph is an open source framework that allows you to
-
-  quickly build end-to-end typesafe APIs on any backend.
-
-
-  WunderGraph combines your data sources and services into a unified graph.
-  Query and stitch together your data using GraphQL or TypeScript and create
-  great experiences for developers and customers across all platforms.
-
-
-  Transform your databases, services, file storage, identity providers and 3rd
-  party APIs into your own Firebase-like Developer Toolkit in seconds, without
-  getting locked into a specific vendor.
+  Jens Neuse joins David for a hands-on tour of WunderGraph, introspecting data
+  sources, defining GraphQL and TypeScript operations, generating type-safe
+  clients, and demoing cross-API joins, input validation, and RBAC directives.
 publishedAt: 2023-01-21T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2023/hands-on-overview-of-komodor.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-overview-of-komodor.md
@@ -2,12 +2,14 @@
 id: l7vd0dst1evod87rrxy0zc1c
 slug: hands-on-overview-of-komodor
 title: Hands-on Overview of Komodor
-description: "Turn hours of K8s management & troubleshooting into minutes. Trusted by Ops \U0001F609 Loved by Devs ❤️"
+description: Hands-on tour of Komodor for Kubernetes troubleshooting. Installing the agent via Helm, browsing service and event timelines, best-practice checks, config-change diffs, deployment monitors to Slack, and log redaction with regex.
 publishedAt: 2023-02-09T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - komodor
+  - kubernetes
+  - helm
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2023/hands-on-overview-of-komodor.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-overview-of-komodor.md
@@ -2,7 +2,11 @@
 id: l7vd0dst1evod87rrxy0zc1c
 slug: hands-on-overview-of-komodor
 title: Hands-on Overview of Komodor
-description: Hands-on tour of Komodor for Kubernetes troubleshooting. Installing the agent via Helm, browsing service and event timelines, best-practice checks, config-change diffs, deployment monitors to Slack, and log redaction with regex.
+description: >-
+  Hands-on tour of Komodor for Kubernetes troubleshooting. Installing the agent
+  via Helm, browsing service and event timelines, best-practice checks,
+  config-change diffs, deployment monitors to Slack, and log redaction with
+  regex.
 publishedAt: 2023-02-09T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-mirrord.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-mirrord.md
@@ -2,7 +2,10 @@
 id: eyps5shz1242dx4h4oovg9jk
 slug: hands-on-tutorial-of-mirrord
 title: Hands-on Tutorial of mirrord
-description: Aviram and Tal from MetalBear show how mirrord runs a local process inside a remote Kubernetes pod's context, mirroring traffic, env vars and files, then demo the VS Code extension, mirrord teams operator and L7 filtering.
+description: >-
+  Aviram and Tal from MetalBear show how mirrord runs a local process inside a
+  remote Kubernetes pod's context, mirroring traffic, env vars and files, then
+  demo the VS Code extension, mirrord teams operator and L7 filtering.
 publishedAt: 2023-07-20T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-mirrord.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-mirrord.md
@@ -2,12 +2,14 @@
 id: eyps5shz1242dx4h4oovg9jk
 slug: hands-on-tutorial-of-mirrord
 title: Hands-on Tutorial of mirrord
-description: Hands-on introduction to local Kubernetes development with mirrord
+description: Aviram and Tal from MetalBear show how mirrord runs a local process inside a remote Kubernetes pod's context, mirroring traffic, env vars and files, then demo the VS Code extension, mirrord teams operator and L7 filtering.
 publishedAt: 2023-07-20T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - mirrord
+  - kubernetes
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 168
@@ -68,6 +70,22 @@ duration: 3571
 guests:
   - eyal-bukchin
   - tal-zwick
-resources: []
+resources:
+  - title: mirrord website
+    type: url
+    url: 'https://metalbear.com/mirrord/'
+    category: documentation
+  - title: mirrord documentation
+    type: url
+    url: 'https://metalbear.com/mirrord/docs'
+    category: documentation
+  - title: mirrord source on GitHub
+    type: url
+    url: 'https://github.com/metalbear-co/mirrord'
+    category: code
+  - title: MetalBear Discord community
+    type: url
+    url: 'https://discord.com/invite/pSKEdmNZcK'
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-project-sveltos.md
+++ b/content/videos/shows/rawkode-live/2023/hands-on-tutorial-of-project-sveltos.md
@@ -3,14 +3,20 @@ id: vctezk0aahkq0ey2o0pvftdg
 slug: hands-on-tutorial-of-project-sveltos
 title: Hands-on Tutorial of Project Sveltos
 description: >-
-  Sveltos Kubernetes add-on controller simplifies the deployment and management
-  of add-ons across numerous Kubernetes clusters. It offers support for Helm
-  charts, YAMLs, and Kustomize.
+  Live tutorial with Gianluca Mardente on Project Sveltos. He walks through
+  ClusterProfile add-on deployment, the classifier with Lua filters, dry-run and
+  event-driven framework, then demos rolling out Helm charts and Kustomize
+  across a Cluster API fleet alongside Flux and Argo CD.
 publishedAt: 2023-08-05T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - sveltos
+  - kubernetes
+  - helm
+  - cluster-api
+  - fluxcd
+  - argo
 show: rawkode-live
 chapters:
   - startTime: 108
@@ -59,8 +65,10 @@ guests:
 resources:
   - title: Project Sveltos installation documentation
     type: url
+    url: 'https://projectsveltos.io/getting_started/install/install/'
     category: documentation
   - title: Project Sveltos register cluster documentation
+    url: 'https://projectsveltos.io/register/register-cluster/'
     type: url
     category: documentation
 ---

--- a/content/videos/shows/rawkode-live/2023/kluctl-new-features-and-updates.md
+++ b/content/videos/shows/rawkode-live/2023/kluctl-new-features-and-updates.md
@@ -2,7 +2,7 @@
 id: nnnb1s0hvh5ypbwavjppy3ze
 slug: kluctl-new-features-and-updates
 title: Kluctl New Features & Updates
-description: Alexander Block returns to walk through what's new in Kluctl: the GitOps controller for pull-based deploys alongside the CLI, the WebUI for visibility, and a live demo bootstrapping a kind cluster and handing off to GitOps.
+description: 'Alexander Block returns to walk through what''s new in Kluctl: the GitOps controller for pull-based deploys alongside the CLI, the WebUI for visibility, and a live demo bootstrapping a kind cluster and handing off to GitOps.'
 publishedAt: 2023-09-27T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2023/kluctl-new-features-and-updates.md
+++ b/content/videos/shows/rawkode-live/2023/kluctl-new-features-and-updates.md
@@ -2,12 +2,14 @@
 id: nnnb1s0hvh5ypbwavjppy3ze
 slug: kluctl-new-features-and-updates
 title: Kluctl New Features & Updates
-description: Kluctl is the missing glue to put together large Kubernetes deployments.
+description: Alexander Block returns to walk through what's new in Kluctl: the GitOps controller for pull-based deploys alongside the CLI, the WebUI for visibility, and a live demo bootstrapping a kind cluster and handing off to GitOps.
 publishedAt: 2023-09-27T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - kluctl
+  - helm
+  - fluxcd
 show: rawkode-live
 chapters:
   - startTime: 108
@@ -65,6 +67,22 @@ chapters:
 duration: 4744
 guests:
   - alexander-block
-resources: []
+resources:
+  - type: url
+    title: Kluctl documentation
+    url: 'https://kluctl.io/docs/'
+    category: documentation
+  - type: url
+    title: Kluctl on GitHub
+    url: 'https://github.com/kluctl/kluctl'
+    category: code
+  - type: url
+    title: Kluctl GitOps controller
+    url: 'https://kluctl.io/docs/gitops/'
+    category: documentation
+  - type: url
+    title: Kluctl Template Controller
+    url: 'https://github.com/kluctl/template-controller'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2023/live-demo-of-devpod.md
+++ b/content/videos/shows/rawkode-live/2023/live-demo-of-devpod.md
@@ -3,13 +3,15 @@ id: kkrf9s0hptal6q3nvtpy75bk
 slug: live-demo-of-devpod
 title: Live Demo of DevPod
 description: >-
-  DevPod is infrastructure-independent and client-only, which makes it
-  incredibly easy to get started with.
+  Lukas Gentele from Loft Labs demos DevPod, walking through the UI and CLI,
+  the Docker provider, spinning up a workspace on Google Cloud, custom YAML
+  providers, devcontainer.json compatibility, and the inactivity timeout.
 publishedAt: 2023-05-24T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - devpod
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 0

--- a/content/videos/shows/rawkode-live/2023/live-demo-of-devpod.md
+++ b/content/videos/shows/rawkode-live/2023/live-demo-of-devpod.md
@@ -3,8 +3,8 @@ id: kkrf9s0hptal6q3nvtpy75bk
 slug: live-demo-of-devpod
 title: Live Demo of DevPod
 description: >-
-  Lukas Gentele from Loft Labs demos DevPod, walking through the UI and CLI,
-  the Docker provider, spinning up a workspace on Google Cloud, custom YAML
+  Lukas Gentele from Loft Labs demos DevPod, walking through the UI and CLI, the
+  Docker provider, spinning up a workspace on Google Cloud, custom YAML
   providers, devcontainer.json compatibility, and the inactivity timeout.
 publishedAt: 2023-05-24T17:00:00.000Z
 type: live

--- a/content/videos/shows/rawkode-live/2023/timoni-cue-powered-package-management-for-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2023/timoni-cue-powered-package-management-for-kubernetes.md
@@ -2,13 +2,16 @@
 id: ogaami9wop6jhog6miiplwgd
 slug: timoni-cue-powered-package-management-for-kubernetes
 title: 'Timoni: CUE Powered Package Management for Kubernetes'
-description: Video content coming soon.
+description: Stefan Prodan joins to introduce Timoni, a Kubernetes package manager built on CUE and OCI artifacts. Modules and bundles replace Helm charts and YAML templating, distributed via container registries with Cosign signing and SOPS-encrypted values.
 publishedAt: 2023-11-17T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - cue
   - timoni
+  - kubernetes
+  - helm
+  - sops
 show: rawkode-live
 duration: 7580
 guests:
@@ -16,15 +19,19 @@ guests:
 resources:
   - title: Timoni comparison with Helm page
     type: url
+    url: 'https://timoni.sh/comparison/'
     category: documentation
   - title: Podinfo demo application
     type: url
+    url: 'https://github.com/stefanprodan/podinfo'
     category: demos
-  - title: Timoni multi-cluster deployments proposal
+  - title: Timoni multi-cluster deployments
     type: url
-    category: other
+    url: 'https://timoni.sh/bundle-multi-cluster/'
+    category: documentation
   - title: SOPS usage documentation for Timoni secrets
     type: url
+    url: 'https://timoni.sh/bundle-secrets/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2023/timoni-cue-powered-package-management-for-kubernetes.md
+++ b/content/videos/shows/rawkode-live/2023/timoni-cue-powered-package-management-for-kubernetes.md
@@ -2,7 +2,11 @@
 id: ogaami9wop6jhog6miiplwgd
 slug: timoni-cue-powered-package-management-for-kubernetes
 title: 'Timoni: CUE Powered Package Management for Kubernetes'
-description: Stefan Prodan joins to introduce Timoni, a Kubernetes package manager built on CUE and OCI artifacts. Modules and bundles replace Helm charts and YAML templating, distributed via container registries with Cosign signing and SOPS-encrypted values.
+description: >-
+  Stefan Prodan joins to introduce Timoni, a Kubernetes package manager built on
+  CUE and OCI artifacts. Modules and bundles replace Helm charts and YAML
+  templating, distributed via container registries with Cosign signing and
+  SOPS-encrypted values.
 publishedAt: 2023-11-17T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2024/building-a-real-application-with-guidepad.md
+++ b/content/videos/shows/rawkode-live/2024/building-a-real-application-with-guidepad.md
@@ -2,12 +2,13 @@
 id: lkg0k1i6xj1a738ziwwhsw0f
 slug: building-a-real-application-with-guidepad
 title: Building a Real Application with Guidepad
-description: Video content coming soon.
+description: 'Reggie Wilkerson and Matt Citarella, the founders of Guidepad, join David to build a real application on the platform: an AWS Lambda replacement that runs Node.js operations, walking through services, state plans, artifacts, and public interfaces.'
 publishedAt: 2024-07-12T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - guidepad
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 117

--- a/content/videos/shows/rawkode-live/2024/building-a-real-application-with-guidepad.md
+++ b/content/videos/shows/rawkode-live/2024/building-a-real-application-with-guidepad.md
@@ -2,7 +2,11 @@
 id: lkg0k1i6xj1a738ziwwhsw0f
 slug: building-a-real-application-with-guidepad
 title: Building a Real Application with Guidepad
-description: 'Reggie Wilkerson and Matt Citarella, the founders of Guidepad, join David to build a real application on the platform: an AWS Lambda replacement that runs Node.js operations, walking through services, state plans, artifacts, and public interfaces.'
+description: >-
+  Reggie Wilkerson and Matt Citarella, the founders of Guidepad, join David to
+  build a real application on the platform: an AWS Lambda replacement that runs
+  Node.js operations, walking through services, state plans, artifacts, and
+  public interfaces.
 publishedAt: 2024-07-12T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2024/development-environments-with-devenv.md
+++ b/content/videos/shows/rawkode-live/2024/development-environments-with-devenv.md
@@ -3,8 +3,10 @@ id: mmc8esyg7i2qkrni256w8t5s
 slug: development-environments-with-devenv
 title: Development Environments with Devenv
 description: >-
-  Fast, Declarative, Reproducible and Composable Developer Environments using
-  Nix
+  Domen Kozar joins to walk through Devenv, the Nix-based tool for declarative
+  per-project dev environments. We cover devenv.nix structure, Rust language
+  support, running Postgres and Temporal as services, custom scripts, and
+  building containers.
 publishedAt: 2024-06-14T17:00:00.000Z
 type: live
 category: tutorial
@@ -68,9 +70,11 @@ guests:
 resources:
   - title: Process Compose
     type: url
+    url: 'https://github.com/F1bonacc1/process-compose'
     category: code
   - title: Devenv fly.io example
     type: url
+    url: 'https://github.com/cachix/devenv/tree/main/examples/fly.io'
     category: demos
 ---
 

--- a/content/videos/shows/rawkode-live/2024/docker-build-cloud.md
+++ b/content/videos/shows/rawkode-live/2024/docker-build-cloud.md
@@ -2,13 +2,15 @@
 id: qz1c7g1dlbmnpf2ubudxvf2v
 slug: docker-build-cloud
 title: Docker Build Cloud
-description: Video content coming soon.
+description: Michael Irwin demos Docker Build Cloud, covering managed builders, context transfer, shared cache, collaborative debugging via Docker Desktop, native multi-architecture builds for AMD64 and ARM64, CI integration with GitHub Actions, and pricing tiers.
 publishedAt: 2024-03-06T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - docker
   - docker-build-cloud
+  - docker-compose
+  - buildkit
 show: rawkode-live
 chapters:
   - startTime: 5
@@ -58,6 +60,22 @@ chapters:
 duration: 2397
 guests:
   - michael-irwin
-resources: []
+resources:
+  - type: url
+    title: Docker Build Cloud
+    category: documentation
+    url: 'https://www.docker.com/products/build-cloud/'
+  - type: url
+    title: Docker Build Cloud documentation
+    category: documentation
+    url: 'https://docs.docker.com/build-cloud/'
+  - type: url
+    title: BuildKit
+    category: documentation
+    url: 'https://docs.docker.com/build/buildkit/'
+  - type: url
+    title: Docker name generator (moby)
+    category: code
+    url: 'https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go'
 ---
 

--- a/content/videos/shows/rawkode-live/2024/docker-build-cloud.md
+++ b/content/videos/shows/rawkode-live/2024/docker-build-cloud.md
@@ -2,7 +2,11 @@
 id: qz1c7g1dlbmnpf2ubudxvf2v
 slug: docker-build-cloud
 title: Docker Build Cloud
-description: Michael Irwin demos Docker Build Cloud, covering managed builders, context transfer, shared cache, collaborative debugging via Docker Desktop, native multi-architecture builds for AMD64 and ARM64, CI integration with GitHub Actions, and pricing tiers.
+description: >-
+  Michael Irwin demos Docker Build Cloud, covering managed builders, context
+  transfer, shared cache, collaborative debugging via Docker Desktop, native
+  multi-architecture builds for AMD64 and ARM64, CI integration with GitHub
+  Actions, and pricing tiers.
 publishedAt: 2024-03-06T17:00:00.000Z
 type: live
 category: tutorial
@@ -76,6 +80,7 @@ resources:
   - type: url
     title: Docker name generator (moby)
     category: code
-    url: 'https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go'
+    url: >-
+      https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-docker-build-cloud.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-docker-build-cloud.md
@@ -3,15 +3,17 @@ id: n75jis3j9h700q4ltfja62ek
 slug: hands-on-introduction-to-docker-build-cloud
 title: Hands-on Introduction to Docker Build Cloud
 description: >-
-  Docker Build Cloud is a service that lets you build your container images
-  faster, both locally and in CI. Builds run on cloud infrastructure optimally
-  dimensioned for your workloads, no configuration required.
+  Michael Irwin from Docker walks David through Docker Build Cloud, a hosted
+  BuildKit service. They cover the shared remote cache, native AMD64/ARM64
+  builders, and wire it up with Buildx and Docker Compose on a React demo app.
 publishedAt: 2024-03-06T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - buildkit
   - docker
   - docker-build-cloud
+  - docker-compose
 show: rawkode-live
 chapters:
   - startTime: 89

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-gitea-actions.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-gitea-actions.md
@@ -3,9 +3,9 @@ id: xfzsftp8rjujzki3y0iaw75e
 slug: hands-on-introduction-to-gitea-actions
 title: Hands-on Introduction to Gitea Actions
 description: >-
-  Gitea is a painless self-hosted all-in-one software development service, it
-  includes Git hosting, code review, team collaboration, package registry and
-  CI/CD. It is similar to GitHub, Bitbucket and GitLab.
+  Matti Ranta joins David to walk through Gitea Actions end-to-end: installing
+  act-runner, registering it against Gitea Cloud, and writing a workflow for a
+  Go project. Also covers GitHub Actions compatibility, packages, and triggers.
 publishedAt: 2024-01-18T17:00:00.000Z
 type: live
 category: tutorial
@@ -87,8 +87,21 @@ duration: 3066
 guests:
   - matti-ranta
 resources:
-  - title: Tarte dot dev
+  - title: Gitea Actions documentation
     type: url
+    url: 'https://docs.gitea.com/usage/actions/overview'
+    category: documentation
+  - title: act_runner
+    type: url
+    url: 'https://gitea.com/gitea/act_runner'
     category: code
+  - title: nektos/act
+    type: url
+    url: 'https://github.com/nektos/act'
+    category: code
+  - title: Tart
+    type: url
+    url: 'https://tart.run/'
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-grafbase.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-grafbase.md
@@ -3,10 +3,10 @@ id: jufccm4nmljpvfjbskmoc03s
 slug: hands-on-introduction-to-grafbase
 title: Hands-on Introduction to Grafbase
 description: >-
-  Hands-on with Grafbase and founder Fredrik Bjork. We build standalone
-  GraphQL subgraphs with the TypeScript SDK, compose products and reviews
-  into a federated graph, extend types across teams, and deploy via the
-  Grafbase Cloud GitHub integration.
+  Hands-on with Grafbase and founder Fredrik Bjork. We build standalone GraphQL
+  subgraphs with the TypeScript SDK, compose products and reviews into a
+  federated graph, extend types across teams, and deploy via the Grafbase Cloud
+  GitHub integration.
 publishedAt: 2024-02-21T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-grafbase.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-grafbase.md
@@ -3,9 +3,10 @@ id: jufccm4nmljpvfjbskmoc03s
 slug: hands-on-introduction-to-grafbase
 title: Hands-on Introduction to Grafbase
 description: >-
-  Grafbase provides a modern developer experience to build and deploy high
-  performance GraphQL APIs close to your users. Compose and connect data sources
-  across microservices using GraphQL Federation.
+  Hands-on with Grafbase and founder Fredrik Bjork. We build standalone
+  GraphQL subgraphs with the TypeScript SDK, compose products and reviews
+  into a federated graph, extend types across teams, and deploy via the
+  Grafbase Cloud GitHub integration.
 publishedAt: 2024-02-21T17:00:00.000Z
 type: live
 category: tutorial
@@ -51,12 +52,15 @@ guests:
 resources:
   - title: grafbase/grafbase GitHub releases
     type: url
+    url: 'https://github.com/grafbase/grafbase/releases'
     category: code
-  - title: Grafbase Getting Started guide
+  - title: Grafbase Quickstart guide
     type: url
+    url: 'https://grafbase.com/docs/quickstart'
     category: documentation
   - title: Grafbase Resolvers documentation
     type: url
+    url: 'https://grafbase.com/docs/resolvers'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-infisical.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-infisical.md
@@ -3,8 +3,10 @@ id: vovcpubi5o3rsa0o2niw7hob
 slug: hands-on-introduction-to-infisical
 title: Hands-on Introduction to Infisical
 description: >-
-  ♾ Infisical is the open-source secret management platform: Sync secrets across
-  your team/infrastructure and prevent secret leaks.
+  Vlad Matsiiako gives a hands-on tour of Infisical, the open-source secrets
+  manager: projects, environments and folders, RBAC and approval policies,
+  versioning and audit logs, the Kubernetes operator and agent sidecar, secret
+  scanning, and self-hosting.
 publishedAt: 2024-03-01T17:00:00.000Z
 type: live
 category: tutorial
@@ -72,6 +74,7 @@ guests:
 resources:
   - title: Infisical self-hosting instructions
     type: url
+    url: 'https://infisical.com/docs/self-hosting/overview'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-quickwit.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-quickwit.md
@@ -3,13 +3,20 @@ id: iu23nk9tr6alciejrlbxmto1
 slug: hands-on-introduction-to-quickwit
 title: Hands-on Introduction to Quickwit
 description: >-
-  Quickwit is the first engine to execute complex search and analytics queries
-  directly on cloud storage with sub-second latency.
+  Francois Massot walks through Quickwit hands-on: spinning up an index,
+  ingesting logs and OpenTelemetry traces on Kubernetes, querying via the UI
+  and CLI, and exploring the Grafana plugin plus Jaeger integration over 500M+
+  spans.
 publishedAt: 2024-01-20T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - quickwit
+  - kubernetes
+  - opentelemetry
+  - grafana
+  - jaeger
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 74
@@ -82,15 +89,19 @@ guests:
 resources:
   - title: Quickwit Quick Start Guide
     type: url
+    url: 'https://quickwit.io/docs/get-started/quickstart'
     category: documentation
   - title: Quickwit Common Crawl demo
     type: url
+    url: 'https://common-crawl.quickwit.io/'
     category: demos
   - title: Quickwit Helm chart
     type: url
+    url: 'https://github.com/quickwit-oss/helm-charts'
     category: code
   - title: Quickwit Grafana plugin
     type: url
+    url: 'https://github.com/quickwit-oss/quickwit-datasource'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-quickwit.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-quickwit.md
@@ -4,8 +4,8 @@ slug: hands-on-introduction-to-quickwit
 title: Hands-on Introduction to Quickwit
 description: >-
   Francois Massot walks through Quickwit hands-on: spinning up an index,
-  ingesting logs and OpenTelemetry traces on Kubernetes, querying via the UI
-  and CLI, and exploring the Grafana plugin plus Jaeger integration over 500M+
+  ingesting logs and OpenTelemetry traces on Kubernetes, querying via the UI and
+  CLI, and exploring the Grafana plugin plus Jaeger integration over 500M+
   spans.
 publishedAt: 2024-01-20T17:00:00.000Z
 type: live

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-restate.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-restate.md
@@ -3,13 +3,15 @@ id: i5nzkd2k3rgebh7w1o233lgn
 slug: hands-on-introduction-to-restate
 title: Hands-on Introduction to Restate
 description: >-
-  Restate is the platform for building resilient applications that tolerate all
-  infrastructure faults w/o the need for a PhD.
+  Jack Kleeman walks through Restate, a single-binary durable execution engine
+  written in Rust. We cover context.run, keyed state, suspending and resuming
+  workflows, context.promise, and live code a TypeScript write handler.
 publishedAt: 2024-09-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - restate
+  - rust
 show: rawkode-live
 chapters:
   - startTime: 153
@@ -55,6 +57,18 @@ chapters:
 duration: 5470
 guests:
   - jack-kleeman
-resources: []
+resources:
+  - type: url
+    title: Restate
+    url: 'https://restate.dev/'
+    category: other
+  - type: url
+    title: Restate Documentation
+    url: 'https://docs.restate.dev/'
+    category: documentation
+  - type: url
+    title: Restate Examples
+    url: 'https://github.com/restatedev/examples'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-zitadel.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-introduction-to-zitadel.md
@@ -3,9 +3,10 @@ id: enzppzcpuou2qem5iy98z2sf
 slug: hands-on-introduction-to-zitadel
 title: Hands-on Introduction to Zitadel
 description: >-
-  Most applications require user identity for access control, secure data
-  storage in the cloud, and to provide a consistent, personalized experience
-  across all of a user's devices.
+  Florian Forster, CEO and cofounder of Zitadel, walks through self-hosting the
+  identity platform with Docker Compose, wiring up an OAuth proxy, and the
+  event-sourced architecture behind audit trails, domain discovery, and
+  passkeys.
 publishedAt: 2024-01-31T17:00:00.000Z
 type: live
 category: tutorial
@@ -99,12 +100,15 @@ guests:
 resources:
   - title: Zitadel Docker Compose self-hosting guide
     type: url
+    url: 'https://zitadel.com/docs/self-hosting/deploy/compose'
     category: documentation
-  - title: OAuth Proxy
+  - title: OAuth2 Proxy
     type: url
+    url: 'https://github.com/oauth2-proxy/oauth2-proxy'
     category: code
-  - title: Zitadel Domain Discovery documentation
+  - title: Zitadel Domain Discovery guide
     type: url
+    url: 'https://zitadel.com/docs/guides/solution-scenarios/domain-discovery'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-daytona.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-daytona.md
@@ -2,7 +2,11 @@
 id: inel7yn0hye5yshls8n7o6n1
 slug: hands-on-with-daytona
 title: Hands-on with Daytona
-description: Ivan Burazin demos Daytona, the open source dev environment manager. One `daytona create` spins up a workspace from a Git repo and devcontainer, running in local Docker or remote DigitalOcean with the same flow, plus public port forwarding via a reverse proxy.
+description: >-
+  Ivan Burazin demos Daytona, the open source dev environment manager. One
+  `daytona create` spins up a workspace from a Git repo and devcontainer,
+  running in local Docker or remote DigitalOcean with the same flow, plus public
+  port forwarding via a reverse proxy.
 publishedAt: 2024-09-25T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-daytona.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-daytona.md
@@ -2,12 +2,13 @@
 id: inel7yn0hye5yshls8n7o6n1
 slug: hands-on-with-daytona
 title: Hands-on with Daytona
-description: Daytona is a radically simple open source development environment manager.
+description: Ivan Burazin demos Daytona, the open source dev environment manager. One `daytona create` spins up a workspace from a Git repo and devcontainer, running in local Docker or remote DigitalOcean with the same flow, plus public port forwarding via a reverse proxy.
 publishedAt: 2024-09-25T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
   - daytona
+  - docker
 show: rawkode-live
 chapters:
   - startTime: 0
@@ -57,6 +58,18 @@ chapters:
 duration: 3360
 guests:
   - ivan-burazin
-resources: []
+resources:
+  - title: Daytona on GitHub
+    type: url
+    url: 'https://github.com/daytonaio/daytona'
+    category: code
+  - title: Development Containers specification
+    type: url
+    url: 'https://containers.dev/'
+    category: documentation
+  - title: Headscale (open source Tailscale control server)
+    type: url
+    url: 'https://github.com/juanfont/headscale'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-qovery.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-qovery.md
@@ -5,8 +5,8 @@ title: Hands-on with Qovery
 description: >-
   David goes hands-on with Qovery and CEO Romaric Philogene, deploying
   applications to a Kubernetes cluster on AWS. They explore the Rust-based
-  engine, install the CLI, deploy services, run a Grafana Helm chart, and
-  export the environment to Terraform.
+  engine, install the CLI, deploy services, run a Grafana Helm chart, and export
+  the environment to Terraform.
 publishedAt: 2024-10-11T17:00:00.000Z
 type: live
 category: tutorial
@@ -66,15 +66,15 @@ guests:
 resources:
   - title: Qovery getting started guide
     type: url
-    url: https://www.qovery.com/docs/getting-started/introduction
+    url: 'https://www.qovery.com/docs/getting-started/introduction'
     category: documentation
   - title: Qovery AI agent on GitHub
     type: url
-    url: https://github.com/Qovery/qovery-skills
+    url: 'https://github.com/Qovery/qovery-skills'
     category: code
   - title: Grafana Helm chart
     type: url
-    url: https://github.com/grafana/helm-charts
+    url: 'https://github.com/grafana/helm-charts'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-qovery.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-qovery.md
@@ -3,14 +3,21 @@ id: ejdg797b14vzlcxalspzht7o
 slug: hands-on-with-qovery
 title: Hands-on with Qovery
 description: >-
-  Qovery Engine is an open-source abstraction layer library that turns easy
-  application deployment on AWS, GCP, Azure, and other Cloud providers in just a
-  few minutes.
+  David goes hands-on with Qovery and CEO Romaric Philogene, deploying
+  applications to a Kubernetes cluster on AWS. They explore the Rust-based
+  engine, install the CLI, deploy services, run a Grafana Helm chart, and
+  export the environment to Terraform.
 publishedAt: 2024-10-11T17:00:00.000Z
 type: live
 category: tutorial
 technologies:
+  - docker
+  - grafana
+  - helm
+  - kubernetes
   - qovery
+  - rust
+  - terraform
 show: rawkode-live
 chapters:
   - startTime: 166
@@ -59,12 +66,15 @@ guests:
 resources:
   - title: Qovery getting started guide
     type: url
+    url: https://www.qovery.com/docs/getting-started/introduction
     category: documentation
   - title: Qovery AI agent on GitHub
     type: url
+    url: https://github.com/Qovery/qovery-skills
     category: code
   - title: Grafana Helm chart
     type: url
+    url: https://github.com/grafana/helm-charts
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-runme.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-runme.md
@@ -3,10 +3,10 @@ id: quiidc7e2t4pu03cgvxtkxmi
 slug: hands-on-with-runme
 title: Hands-on with RUNME
 description: >-
-  Runme is a tool that makes runbooks actually runnable, making it easier to
-  follow step-by-step instructions. Shell/bash, Python, Ruby,
-  Javascript/Typescript, Lua, PHP, Perl, and many other runtimes are supported
-  via Runme's shebang feature.
+  Sebastian Tiedtke, CTO of Stateful, gives a hands-on tour of Runme: turning
+  Markdown into runnable notebooks via the CLI and VS Code, mixing shell,
+  Python and Deno cells, navigating cloud resources, and reproducible envs
+  with dev containers and Dagger.
 publishedAt: 2024-10-04T17:00:00.000Z
 type: live
 category: tutorial
@@ -56,6 +56,7 @@ guests:
 resources:
   - title: Runme Getting Started page
     type: url
+    url: 'https://docs.runme.dev/getting-started/'
     category: documentation
   - title: Stateful
     type: url
@@ -66,6 +67,7 @@ resources:
     category: documentation
   - title: Dagger integration documentation
     type: url
+    url: 'https://docs.runme.dev/guide/dagger'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2024/hands-on-with-runme.md
+++ b/content/videos/shows/rawkode-live/2024/hands-on-with-runme.md
@@ -4,9 +4,9 @@ slug: hands-on-with-runme
 title: Hands-on with RUNME
 description: >-
   Sebastian Tiedtke, CTO of Stateful, gives a hands-on tour of Runme: turning
-  Markdown into runnable notebooks via the CLI and VS Code, mixing shell,
-  Python and Deno cells, navigating cloud resources, and reproducible envs
-  with dev containers and Dagger.
+  Markdown into runnable notebooks via the CLI and VS Code, mixing shell, Python
+  and Deno cells, navigating cloud resources, and reproducible envs with dev
+  containers and Dagger.
 publishedAt: 2024-10-04T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2025/building-ai-applications-with-webassembly-spin.md
+++ b/content/videos/shows/rawkode-live/2025/building-ai-applications-with-webassembly-spin.md
@@ -21,11 +21,11 @@ guests:
 resources:
   - title: Fermyon Developer Home
     type: url
-    url: https://developer.fermyon.com/
+    url: 'https://developer.fermyon.com/'
     category: documentation
   - title: SpinKube documentation
     type: url
-    url: https://www.spinkube.dev/docs/overview/
+    url: 'https://www.spinkube.dev/docs/overview/'
     category: documentation
   - title: Thorsten Hans examples repository
     type: url

--- a/content/videos/shows/rawkode-live/2025/building-ai-applications-with-webassembly-spin.md
+++ b/content/videos/shows/rawkode-live/2025/building-ai-applications-with-webassembly-spin.md
@@ -4,24 +4,28 @@ slug: building-ai-applications-with-webassembly-spin
 title: Building AI Applications with WebAssembly & Spin
 subtitle: "\U0001F525 Dive into the Future of Cloud Microservices with WebAssembly & Spin! \U0001F525"
 description: >-
-  Join us as we explore the cutting-edge world of WebAssembly microservices with
-  Thorsten Hans, Sr. Cloud Advocate at Fermyon! In this live session, we'll
-  demystify Spin, a CNCF sandbox project, and show you how to build fast,
-  secure, and composable cloud applications.
+  Thorsten Hans walks through Spin from scratch: a TypeScript hello-world, an
+  HTTP API with itty-router, persistence via the key-value store and SQLite,
+  then plugging in Ollama with DeepSeek r1 through Spin's LLM interface.
 publishedAt: 2025-03-19T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - spin
+  - spinkube
+  - webassembly
 show: rawkode-live
 duration: 6370
 guests:
   - thorsten-hans
 resources:
-  - title: Fermion Developer Home
+  - title: Fermyon Developer Home
     type: url
+    url: https://developer.fermyon.com/
     category: documentation
-  - title: SpinCube documentation
+  - title: SpinKube documentation
     type: url
+    url: https://www.spinkube.dev/docs/overview/
     category: documentation
   - title: Thorsten Hans examples repository
     type: url

--- a/content/videos/shows/rawkode-live/2025/cloud-native-buildpacks.md
+++ b/content/videos/shows/rawkode-live/2025/cloud-native-buildpacks.md
@@ -6,15 +6,27 @@ subtitle: >-
   Join Terence Lee, Heroku engineer and Cloud Native Buildpacks maintainer, for
   a practical session on CNBs. 
 description: >-
-  Join Terence Lee, Heroku engineer and Cloud Native Buildpacks maintainer, for
-  a practical session on CNBs.
+  Terence Lee, Heroku engineer and CNB maintainer, walks through Cloud Native
+  Buildpacks: turning source into OCI images without a Dockerfile, the lifecycle,
+  rebasing, and how pack fits into platform workflows.
 publishedAt: 2025-07-02T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - buildpacks
+  - heroku
 show: rawkode-live
 duration: 5583
 guests:
   - terence-lee
+resources:
+  - type: url
+    title: Cloud Native Buildpacks
+    url: 'https://buildpacks.io/'
+    category: documentation
+  - type: url
+    title: pack CLI
+    url: 'https://github.com/buildpacks/pack'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2025/cloud-native-buildpacks.md
+++ b/content/videos/shows/rawkode-live/2025/cloud-native-buildpacks.md
@@ -7,8 +7,8 @@ subtitle: >-
   a practical session on CNBs. 
 description: >-
   Terence Lee, Heroku engineer and CNB maintainer, walks through Cloud Native
-  Buildpacks: turning source into OCI images without a Dockerfile, the lifecycle,
-  rebasing, and how pack fits into platform workflows.
+  Buildpacks: turning source into OCI images without a Dockerfile, the
+  lifecycle, rebasing, and how pack fits into platform workflows.
 publishedAt: 2025-07-02T17:00:00.000Z
 type: live
 category: tutorial

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-lightpanda.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-lightpanda.md
@@ -3,8 +3,10 @@ id: xz2p2q4vt899p3n3gx5m3r43
 slug: hands-on-introduction-lightpanda
 title: Hands-on Introduction to lightpanda
 description: >-
-  Tired o10-11x faster while consuming 10x less RAM compared to Chrome headless,
-  coupled with near-instant startup times.
+  Pierre and Katie show LightPanda, a headless browser written in Zig that runs
+  JavaScript and exposes the final DOM without rendering. They benchmark it
+  against headless Chrome, demo CDP automation, and walk through real-world
+  limits like missing Web APIs.
 publishedAt: 2025-04-23T17:00:00.000Z
 type: live
 category: tutorial
@@ -18,11 +20,14 @@ resources:
   - title: LightPanda GitHub repository
     type: url
     category: code
+    url: https://github.com/lightpanda-io/browser
   - title: Vercel post on AI crawler traffic and JavaScript rendering
     type: url
     category: other
+    url: https://vercel.com/blog/the-rise-of-the-ai-crawler
   - title: Web Platform Tests
     type: url
     category: code
+    url: https://github.com/web-platform-tests/wpt
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-lightpanda.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-lightpanda.md
@@ -20,14 +20,14 @@ resources:
   - title: LightPanda GitHub repository
     type: url
     category: code
-    url: https://github.com/lightpanda-io/browser
+    url: 'https://github.com/lightpanda-io/browser'
   - title: Vercel post on AI crawler traffic and JavaScript rendering
     type: url
     category: other
-    url: https://vercel.com/blog/the-rise-of-the-ai-crawler
+    url: 'https://vercel.com/blog/the-rise-of-the-ai-crawler'
   - title: Web Platform Tests
     type: url
     category: code
-    url: https://github.com/web-platform-tests/wpt
+    url: 'https://github.com/web-platform-tests/wpt'
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-fermyon-wasm-functions.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-fermyon-wasm-functions.md
@@ -6,12 +6,16 @@ subtitle: >-
   In this session, we'll be diving into Fermyon Wasm Functions with Thorsten
   Hans, Sr. Cloud Advocate at Fermyon.
 description: >-
-  In this session, we'll be diving into Fermyon Wasm Functions with Thorsten
-  Hans, Sr. Cloud Advocate at Fermyon.
+  Thorsten Hans walks through Fermyon Wasm Functions, the new fully managed
+  service that runs Spin apps on Akamai's globally distributed network.
+  Covers the aka plugin, deploying via OCI registry, and the built-in key
+  value store.
 publishedAt: 2025-04-15T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - spin
+  - webassembly
 show: rawkode-live
 duration: 4849
 guests:
@@ -28,6 +32,7 @@ resources:
     category: documentation
   - title: Spin JavaScript SDK repository
     type: url
+    url: https://github.com/spinframework/spin-js-sdk
     category: code
   - title: Fermyon Wasm Functions samples repository
     type: url

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-fermyon-wasm-functions.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-fermyon-wasm-functions.md
@@ -7,9 +7,8 @@ subtitle: >-
   Hans, Sr. Cloud Advocate at Fermyon.
 description: >-
   Thorsten Hans walks through Fermyon Wasm Functions, the new fully managed
-  service that runs Spin apps on Akamai's globally distributed network.
-  Covers the aka plugin, deploying via OCI registry, and the built-in key
-  value store.
+  service that runs Spin apps on Akamai's globally distributed network. Covers
+  the aka plugin, deploying via OCI registry, and the built-in key value store.
 publishedAt: 2025-04-15T17:00:00.000Z
 type: live
 category: tutorial
@@ -32,7 +31,7 @@ resources:
     category: documentation
   - title: Spin JavaScript SDK repository
     type: url
-    url: https://github.com/spinframework/spin-js-sdk
+    url: 'https://github.com/spinframework/spin-js-sdk'
     category: code
   - title: Fermyon Wasm Functions samples repository
     type: url

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-k0rdent.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-k0rdent.md
@@ -4,12 +4,19 @@ slug: hands-on-introduction-to-k0rdent
 title: Hands-on Introduction to k0rdent
 subtitle: '**Hands-on Introduction to k0rdent**'
 description: >-
-  Join us live on Rawkode Academy for a practical, hands-on introduction to
-  k0rdent, the exciting Kubernetes project from Mirantis!
+  Martin Sadler and Karthik Satchitanand from Mirantis introduce k0rdent, a
+  template-driven platform built on k0s, Cluster API, and Sveltos that wraps
+  cluster provisioning, state, and observability into single YAML definitions.
 publishedAt: 2025-05-12T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
+  - cluster-api
+  - k0s
+  - sveltos
+  - helm
+  - fluxcd
 show: rawkode-live
 duration: 6422
 guests:
@@ -19,8 +26,10 @@ resources:
   - title: k0rdent Quick Starts documentation
     type: url
     category: documentation
+    url: 'https://docs.k0rdent.io/latest/quickstarts/'
   - title: k0rdent Catalog
     type: url
     category: code
+    url: 'https://github.com/k0rdent/catalog'
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-perses.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-perses.md
@@ -6,28 +6,36 @@ subtitle: >-
   Join us for a practical deep-dive into Perses, the open-source project that's
   revolutionizing how we manage dashboards and visualization through code.
 description: >-
-  Join us for a practical deep-dive into Perses, the open-source project that's
-  revolutionizing how we manage dashboards and visualization through code.
+  Nicolas Takashi walks through Perses, the CNCF sandbox dashboards-as-code
+  project. We author YAML dashboards against a Prometheus data source, validate
+  them with percli, and wire up GitHub Actions to lint and apply them on every
+  commit.
 publishedAt: 2025-07-21T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - perses
+  - prometheus
 show: rawkode-live
 duration: 4318
 guests:
   - nicolas-takashi
 resources:
   - title: Perses official documentation
+    url: https://perses.dev/perses/docs/
     type: url
     category: documentation
   - title: Perses community dashboards repository
+    url: https://github.com/perses/community-mixins
     type: url
     category: code
   - title: Perses dashboard as code GitHub Action
+    url: https://github.com/perses/cli-actions
     type: url
     category: code
   - title: Perses CLI
+    url: https://perses.dev/perses/docs/cli/
     type: url
-    category: code
+    category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-perses.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-perses.md
@@ -22,19 +22,19 @@ guests:
   - nicolas-takashi
 resources:
   - title: Perses official documentation
-    url: https://perses.dev/perses/docs/
+    url: 'https://perses.dev/perses/docs/'
     type: url
     category: documentation
   - title: Perses community dashboards repository
-    url: https://github.com/perses/community-mixins
+    url: 'https://github.com/perses/community-mixins'
     type: url
     category: code
   - title: Perses dashboard as code GitHub Action
-    url: https://github.com/perses/cli-actions
+    url: 'https://github.com/perses/cli-actions'
     type: url
     category: code
   - title: Perses CLI
-    url: https://perses.dev/perses/docs/cli/
+    url: 'https://perses.dev/perses/docs/cli/'
     type: url
     category: documentation
 ---

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-spicedb.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-spicedb.md
@@ -4,9 +4,10 @@ slug: hands-on-introduction-to-spicedb
 title: Hands-on Introduction to SpiceDB
 subtitle: "**\U0001F680 Hands-On SpiceDB Demo + Q&A with AuthZed CPO Jimmy Zelinskie \U0001F680**"
 description: >-
-  Ready to finally understand and implement powerful, scalable permissions in
-  your applications? Join us for a special live stream featuring Jimmy
-  Zelinskie, Chief Product Officer of AuthZed, the company behind SpiceDB!
+  Jimmy Zelinskie, AuthZed cofounder, walks through SpiceDB from the ground up:
+  why Google's Zanzibar paper reframes authorization, how to model schemas with
+  relations and permissions, caveats, and using the zed CLI and Playground to
+  test real applications.
 publishedAt: 2025-04-14T17:00:00.000Z
 type: live
 category: tutorial
@@ -19,18 +20,22 @@ duration: 5427
 resources:
   - title: Zanzibar paper
     type: url
+    url: 'https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/'
     category: other
   - title: GitHub permissions model video on AuthZed YouTube channel
     type: url
     category: other
   - title: AuthZed examples repository schemas directory
     type: url
+    url: 'https://github.com/authzed/examples/tree/main/schemas'
     category: code
   - title: AuthZed Playground
     type: url
+    url: 'https://play.authzed.com/'
     category: demos
   - title: SpiceDB Playground source
     type: url
+    url: 'https://github.com/authzed/playground'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-spicedb.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-introduction-to-spicedb.md
@@ -20,7 +20,8 @@ duration: 5427
 resources:
   - title: Zanzibar paper
     type: url
-    url: 'https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/'
+    url: >-
+      https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/
     category: other
   - title: GitHub permissions model video on AuthZed YouTube channel
     type: url

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-comtrya.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-comtrya.md
@@ -3,9 +3,10 @@ id: lo9o8fuuanvpurseh8sv6ef8
 slug: hands-on-with-comtrya
 title: Hands-on with Comtrya
 description: >-
-  Comtrya is a permissively licensed Open Source tool that is built 100% in
-  Rust. It allows you, as the user, to provision and configure your systems
-  through the use of simple configuration files using the YAML or TOML formats.
+  Todd Martin, primary maintainer of Comtrya, joins David to walk through this
+  Rust-based workstation configuration tool. They cover installation, writing
+  YAML/TOML manifests, dependencies, conditional logic, action variants, and
+  user, file, and git actions.
 publishedAt: 2025-01-08T17:00:00.000Z
 type: live
 category: tutorial
@@ -72,6 +73,14 @@ chapters:
 duration: 5414
 guests:
   - todd-martin
-resources: []
+resources:
+  - type: url
+    title: Comtrya documentation
+    url: 'https://comtrya.dev'
+    category: documentation
+  - type: url
+    title: Comtrya on GitHub
+    url: 'https://github.com/comtrya/comtrya'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-cyhernetes.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-cyhernetes.md
@@ -6,19 +6,27 @@ subtitle: >-
   Cyphernetes (Cypher for Kubernetes) is a new language and your next
   superpower.
 description: >-
-  Cyphernetes (Cypher for Kubernetes) is a new language and your next
-  superpower.
+  Avital Tamir demos Cyphernetes, a Cypher-inspired query language for
+  Kubernetes. Use ASCII-art graph patterns to match resources, traverse
+  relationships across kinds, and run CRUD operations from a shell, web client,
+  or operator that reconciles one-line queries.
 publishedAt: 2025-01-10T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
 show: rawkode-live
 duration: 4057
 guests:
   - avital-tamir
 resources:
+  - title: Cyphernetes on GitHub
+    type: url
+    url: 'https://github.com/AvitalTamir/cyphernetes'
+    category: code
   - title: Cyphernetes Operator
     type: url
+    url: 'https://github.com/AvitalTamir/cyphernetes/tree/main/operator'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-headlamp-the-kubernetes-ui.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-headlamp-the-kubernetes-ui.md
@@ -7,13 +7,21 @@ subtitle: >-
   We’ll walk through installing, configuring, customizing, and using it in real
   time.
 description: >-
-  Join us as we explore Headlamp — an extensible, user-friendly Kubernetes UI.
-  We’ll walk through installing, configuring, customizing, and using it in real
-  time.
+  Oleg and Will from Microsoft show how Headlamp's plugin model surfaces Flux,
+  Argo CD, Cilium Hubble, and Prometheus inside a Kubernetes UI, plus the new AI
+  assistant, OIDC auth, Artifact Hub plugin catalogue, and Backstage embedding.
 publishedAt: 2025-10-08T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - headlamp
+  - kubernetes
+  - fluxcd
+  - argo
+  - cilium
+  - backstage
+  - prometheus
+  - artifacthub
 show: rawkode-live
 duration: 3547
 guests:
@@ -26,12 +34,15 @@ resources:
     category: documentation
   - title: Headlamp documentation
     type: url
+    url: 'https://headlamp.dev/docs/latest/'
     category: documentation
   - title: Artifact Hub Headlamp plugin registry
     type: url
+    url: 'https://artifacthub.io/packages/search?kind=11'
     category: other
   - title: Headlamp contributor guide
     type: url
+    url: 'https://headlamp.dev/docs/latest/contributing/'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-kairos-edge-kubernetes-made-simple.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-kairos-edge-kubernetes-made-simple.md
@@ -7,13 +7,19 @@ subtitle: >-
   open-source project that's revolutionizing OS lifecycle management across
   edge, cloud, and bare metal environments!
 description: >-
-  Join us for an exclusive live stream as we dive deep into Kairos, the
-  open-source project that's revolutionizing OS lifecycle management across
-  edge, cloud, and bare metal environments!
+  Mauro Morales and Ettore Giacinto walk through Kairos, the CNCF sandbox
+  meta-Linux distribution for immutable edge systems. Live demo builds a
+  bootable image, installs the OS, and brings up a K3s cluster, then covers
+  AuroraBoot, bundles, and trusted boot.
 publishedAt: 2025-05-28T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kairos
+  - kubernetes
+  - k3s
+  - k0s
+  - cluster-api
 show: rawkode-live
 duration: 5369
 guests:
@@ -27,16 +33,19 @@ resources:
   - title: Kairos Quick Start Guide
     type: url
     category: documentation
-  - title: Aurora Boot documentation
+  - title: AuroraBoot documentation
     type: url
+    url: 'https://kairos.io/docs/reference/auroraboot/'
     category: documentation
   - title: Kairos community bundles repository
     type: url
+    url: 'https://github.com/kairos-io/community-bundles'
     category: code
   - title: >-
       Lennart Poettering article about fitting systemd technologies into an
       ideal Linux distribution
     type: url
+    url: 'https://0pointer.net/blog/fitting-everything-together.html'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-preq-community-driven-reliability-problem-detection.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-preq-community-driven-reliability-problem-detection.md
@@ -7,9 +7,10 @@ subtitle: >-
   the free and open-source tool that's revolutionizing how teams detect and
   prevent reliability issues before customers noti
 description: >-
-  Join us for an exclusive live stream as we explore Preq (pronounced "preek"),
-  the free and open-source tool that's revolutionizing how teams detect and
-  prevent reliability issues before customers notice!
+  Tony Meehan, CTO of Prequel, joins us to demo Preq: an open-source reliability
+  problem detector. We dig into Common Reliability Enumerations (CREs), running
+  community rules against logs and configs, and applying vulnerability-database
+  thinking to recurring software failures.
 publishedAt: 2025-06-04T17:00:00.000Z
 type: live
 category: tutorial
@@ -18,6 +19,18 @@ show: rawkode-live
 duration: 3847
 guests:
   - tony-meehan
-resources: []
+resources:
+  - type: url
+    title: preq on GitHub
+    url: https://github.com/prequel-dev/preq
+    category: code
+  - type: url
+    title: Prequel documentation
+    url: https://docs.prequel.dev/
+    category: documentation
+  - type: url
+    title: Prequel
+    url: https://prequel.dev/
+    category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2025/hands-on-with-preq-community-driven-reliability-problem-detection.md
+++ b/content/videos/shows/rawkode-live/2025/hands-on-with-preq-community-driven-reliability-problem-detection.md
@@ -22,15 +22,15 @@ guests:
 resources:
   - type: url
     title: preq on GitHub
-    url: https://github.com/prequel-dev/preq
+    url: 'https://github.com/prequel-dev/preq'
     category: code
   - type: url
     title: Prequel documentation
-    url: https://docs.prequel.dev/
+    url: 'https://docs.prequel.dev/'
     category: documentation
   - type: url
     title: Prequel
-    url: https://prequel.dev/
+    url: 'https://prequel.dev/'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2025/introducing-wassette-securing-mcp-with-webassembly.md
+++ b/content/videos/shows/rawkode-live/2025/introducing-wassette-securing-mcp-with-webassembly.md
@@ -6,12 +6,14 @@ subtitle: >-
   Microsoft just announced Wassette — a security-oriented runtime that bridges
   WebAssembly Components with the Model Context Protocol (MCP).
 description: >-
-  Microsoft just announced Wassette — a security-oriented runtime that bridges
-  WebAssembly Components with the Model Context Protocol (MCP).
+  Microsoft's Jiaxiao Zhou, Josh Duffney and Yosh Wuyts demo Wassette, an MCP
+  server that runs AI agent tools as sandboxed WebAssembly components with
+  per-tool permission policies, then compile a JS tool with jco and load it in.
 publishedAt: 2025-09-19T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - webassembly
 show: rawkode-live
 duration: 5559
 guests:
@@ -19,11 +21,17 @@ guests:
   - josh-duffney
   - yosh-wuyts
 resources:
+  - title: Wassette on GitHub
+    type: url
+    url: 'https://github.com/microsoft/wassette'
+    category: code
   - title: GitHub MCP registry
     type: url
+    url: 'https://github.com/mcp'
     category: other
   - title: awesome WASM components repository
     type: url
+    url: 'https://github.com/yoshuawuyts/awesome-wasm-components'
     category: code
   - title: QR code generator component
     type: url

--- a/content/videos/shows/rawkode-live/2025/manage-and-run-ai-ml-models-as-oci-artifacts-with-oras.md
+++ b/content/videos/shows/rawkode-live/2025/manage-and-run-ai-ml-models-as-oci-artifacts-with-oras.md
@@ -7,13 +7,17 @@ subtitle: >-
   video, we'll explore how to leverage ORAS and OCI to streamline your AI/ML
   workflows.
 description: >-
-  Dive deep into the world of cloud-native AI/ML model management! In this
-  video, we'll explore how to leverage ORAS and OCI to streamline your AI/ML
-  workflows.
+  Josh Duffney and Feynman Zhou from Microsoft show how to package AI/ML models
+  as OCI artifacts with ORAS, store them in any container registry, sign them
+  with Notation, and mount them into Kubernetes pods via OCI image volumes.
 publishedAt: 2025-03-21T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - oras
+  - notary
+  - kubernetes
+  - helm
 show: rawkode-live
 duration: 3995
 guests:
@@ -22,15 +26,19 @@ guests:
 resources:
   - title: Kubernetes blog post on OCI image volumes
     type: url
+    url: 'https://kubernetes.io/blog/2024/08/16/kubernetes-1-31-image-volume-source/'
     category: other
   - title: ORAS website
     type: url
+    url: 'https://oras.land/'
     category: documentation
   - title: Notation GitHub Action
     type: url
+    url: 'https://github.com/notaryproject/notation-action'
     category: code
   - title: Cloud Native AI Model Spec repository
     type: url
+    url: 'https://github.com/modelpack/model-spec'
     category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2025/mcp-servers-for-rust-developers.md
+++ b/content/videos/shows/rawkode-live/2025/mcp-servers-for-rust-developers.md
@@ -6,17 +6,21 @@ subtitle: >-
   Join us live as we explore three powerful MCP servers that will transform how
   you develop and deploy Rust applications!
 description: >-
-  Join us live as we explore three powerful MCP servers that will transform how
-  you develop and deploy Rust applications!
+  David Flanagan is joined by Kat Cosgrove and Justin to dig into the State of
+  Kubernetes Report 2025, correlating its findings on adoption, operations, and
+  pain points with their own hands-on experience running Kubernetes in
+  production.
 publishedAt: 2025-09-18T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - kubernetes
 show: rawkode-live
 duration: 5198
 resources:
   - title: State of Kubernetes Report 2025
     type: url
+    url: 'https://www.spectrocloud.com/state-of-kubernetes-2025'
     category: other
 ---
 

--- a/content/videos/shows/rawkode-live/2025/securing-cloud-native-workloads-hands-on-with-notary-project-oras-and-ratify.md
+++ b/content/videos/shows/rawkode-live/2025/securing-cloud-native-workloads-hands-on-with-notary-project-oras-and-ratify.md
@@ -9,12 +9,19 @@ subtitle: >-
   cloud-native workloads is essential. This session will provide real-world
   examples of how to use open-source tools Notary 
 description: >-
-  In the cloud-native ecosystem, maintaining a secure software supply chain for
-  cloud-native workloads is essential.
+  Yi Zha from Microsoft demos how Notary Project, ORAS, and Ratify secure the
+  container supply chain on Kubernetes: signing images with notation, storing
+  signatures as OCI artifacts, and enforcing trust at admission via Ratify and
+  OPA Gatekeeper.
 publishedAt: 2025-03-01T17:00:00.000Z
 type: live
 category: tutorial
-technologies: []
+technologies:
+  - notary
+  - oras
+  - ratify
+  - opa
+  - kubernetes
 show: rawkode-live
 duration: 5700
 guests:
@@ -22,18 +29,23 @@ guests:
 resources:
   - title: Notary Project
     type: url
-    category: code
+    url: 'https://notaryproject.dev/'
+    category: documentation
   - title: ORAS Project
     type: url
-    category: code
+    url: 'https://oras.land/'
+    category: documentation
   - title: Ratify Project
     type: url
-    category: code
+    url: 'https://ratify.dev/'
+    category: documentation
   - title: Notation CLI
     type: url
+    url: 'https://github.com/notaryproject/notation'
     category: code
   - title: Notary Project specification
     type: url
+    url: 'https://github.com/notaryproject/specifications'
     category: documentation
 ---
 

--- a/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
+++ b/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
@@ -4,9 +4,7 @@ slug: chevron7-2026-01-23
 title: Friday, January 23rd, 2026 - Chevron7
 subtitle: Rawkode Academy Office Hours
 description: |
-  Rawkode Academy Office Hours
-
-  Intar: https://github.com/intar-dev/intar-cli
+  Office hours session with icepuma covering Intar, a QEMU-based DevOps lab environment that runs HCL-defined scenarios in local virtual machines for reproducible infrastructure training and debugging exercises.
 publishedAt: 2026-01-24T00:46:23.000Z
 type: live
 category: editorial
@@ -16,4 +14,9 @@ show: rawkode-live
 duration: 2666
 guests:
   - icepuma
+resources:
+  - type: url
+    title: intar-cli on GitHub
+    url: https://github.com/intar-dev/intar-cli
+    category: code
 ---

--- a/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
+++ b/content/videos/shows/rawkode-live/2026/chevron7-2026-01-23.md
@@ -1,10 +1,12 @@
 ---
 id: p0ksv7fv60hxvhe7uo46cf29
 slug: chevron7-2026-01-23
-title: Friday, January 23rd, 2026 - Chevron7
+title: 'Friday, January 23rd, 2026 - Chevron7'
 subtitle: Rawkode Academy Office Hours
-description: |
-  Office hours session with icepuma covering Intar, a QEMU-based DevOps lab environment that runs HCL-defined scenarios in local virtual machines for reproducible infrastructure training and debugging exercises.
+description: >
+  Office hours session with icepuma covering Intar, a QEMU-based DevOps lab
+  environment that runs HCL-defined scenarios in local virtual machines for
+  reproducible infrastructure training and debugging exercises.
 publishedAt: 2026-01-24T00:46:23.000Z
 type: live
 category: editorial
@@ -17,6 +19,7 @@ guests:
 resources:
   - type: url
     title: intar-cli on GitHub
-    url: https://github.com/intar-dev/intar-cli
+    url: 'https://github.com/intar-dev/intar-cli'
     category: code
 ---
+

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
@@ -4,8 +4,9 @@ slug: hands-on-introduction-to-sympozium
 title: Hands-on Introduction to sympozium
 subtitle: 'Diving into Sympozium AI: The Future of Collaborative Intelligence'
 description: >-
-  In this live stream, we explore Sympozium, an ambitious open-source project
-  designed to bridge the gap between human collaboration and AI-driven insights.
+  Alex Jones joins to introduce Sympozium, a Kubernetes-native coordination
+  layer for multi-agent AI systems. We walk through modelling agents as pods
+  and using CRDs and jobs to orchestrate structured handoffs and shared context.
 publishedAt: 2026-04-17T05:38:22.000Z
 type: live
 category: tutorial
@@ -15,5 +16,18 @@ show: rawkode-live
 duration: 5510
 guests:
   - alex-jones
+resources:
+  - type: url
+    title: Sympozium
+    url: 'https://sympozium.ai/'
+    category: other
+  - type: url
+    title: Sympozium documentation
+    url: 'https://deploy.sympozium.ai/docs/'
+    category: documentation
+  - type: url
+    title: Sympozium on GitHub
+    url: 'https://github.com/sympozium-ai/sympozium'
+    category: code
 ---
 

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-sympozium.md
@@ -5,8 +5,8 @@ title: Hands-on Introduction to sympozium
 subtitle: 'Diving into Sympozium AI: The Future of Collaborative Intelligence'
 description: >-
   Alex Jones joins to introduce Sympozium, a Kubernetes-native coordination
-  layer for multi-agent AI systems. We walk through modelling agents as pods
-  and using CRDs and jobs to orchestrate structured handoffs and shared context.
+  layer for multi-agent AI systems. We walk through modelling agents as pods and
+  using CRDs and jobs to orchestrate structured handoffs and shared context.
 publishedAt: 2026-04-17T05:38:22.000Z
 type: live
 category: tutorial

--- a/content/videos/standalone/2021/part-1-lecture-1-introduction-to-time-series.md
+++ b/content/videos/standalone/2021/part-1-lecture-1-introduction-to-time-series.md
@@ -2,7 +2,11 @@
 id: gcyhdcr1fqccea0s1idebvw9
 slug: part-1-lecture-1-introduction-to-time-series
 title: 'Part 1 - Lecture 1: Introduction to Time Series'
-description: Lecture one of the InfluxDB 2 course. David traces the history of encoding and sharding from ancient Rome, defines time series data (metrics versus events), shows collection with Telegraf, and previews downsampling and Kubernetes monitoring with InfluxDB.
+description: >-
+  Lecture one of the InfluxDB 2 course. David traces the history of encoding and
+  sharding from ancient Rome, defines time series data (metrics versus events),
+  shows collection with Telegraf, and previews downsampling and Kubernetes
+  monitoring with InfluxDB.
 publishedAt: 2021-07-29T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2021/part-1-lecture-1-introduction-to-time-series.md
+++ b/content/videos/standalone/2021/part-1-lecture-1-introduction-to-time-series.md
@@ -2,25 +2,13 @@
 id: gcyhdcr1fqccea0s1idebvw9
 slug: part-1-lecture-1-introduction-to-time-series
 title: 'Part 1 - Lecture 1: Introduction to Time Series'
-description: |-
-  Subsequent videos are only available to Incubating members. Join now:
-
-
-  https://www.youtube.com/channel/UCrber_mFvp_FEF7D9u8PDEA/join
-
-
-  - What is time series data?
-  - Why do I need a time series database?
-  - What value does time series data bring?
-  - How do I work with time series data?
-
-
-  #InfluxDB #TimeSeries
+description: Lecture one of the InfluxDB 2 course. David traces the history of encoding and sharding from ancient Rome, defines time series data (metrics versus events), shows collection with Telegraf, and previews downsampling and Kubernetes monitoring with InfluxDB.
 publishedAt: 2021-07-29T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - influxdb
+  - telegraf
 chapters:
   - startTime: 0
     title: Introduction
@@ -127,12 +115,15 @@ guests: []
 resources:
   - title: The Lives of the Noble Grecians and Romans
     type: url
+    url: 'https://www.gutenberg.org/ebooks/674'
     category: other
   - title: Black Book of Admiralty
     type: url
+    url: 'https://archive.org/details/monumentajuridi00twisgoog'
     category: other
   - title: The Early History of Data Networks
     type: url
+    url: 'https://spinroot.com/gerard/hist.html'
     category: other
 ---
 

--- a/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
+++ b/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
@@ -3,8 +3,10 @@ id: pgrokuuhvovem0ajyew4tncu
 slug: part-2-tutorial-installing-teleport
 title: Part 2. Tutorial -  Installing Teleport
 description: >-
-  Learn how to install Teleport, as well as a high level overview of what
-  Teleport can do.
+  Three ways to install Teleport on Linux: the Debian APT repo, the Red Hat
+  YUM repo, and a curl script for other distros. Then start the server, create
+  the first user with tctl, set up 2FA, and try web SSH, the audit log, and
+  session replay.
 publishedAt: 2021-10-29T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -61,6 +63,10 @@ chapters:
     title: Conclusion and Next Steps (Workshop)
 duration: 842
 guests: []
-resources: []
+resources:
+  - type: url
+    category: documentation
+    title: Teleport documentation
+    url: 'https://goteleport.com/docs/'
 ---
 

--- a/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
+++ b/content/videos/standalone/2021/part-2-tutorial-installing-teleport.md
@@ -3,10 +3,10 @@ id: pgrokuuhvovem0ajyew4tncu
 slug: part-2-tutorial-installing-teleport
 title: Part 2. Tutorial -  Installing Teleport
 description: >-
-  Three ways to install Teleport on Linux: the Debian APT repo, the Red Hat
-  YUM repo, and a curl script for other distros. Then start the server, create
-  the first user with tctl, set up 2FA, and try web SSH, the audit log, and
-  session replay.
+  Three ways to install Teleport on Linux: the Debian APT repo, the Red Hat YUM
+  repo, and a curl script for other distros. Then start the server, create the
+  first user with tctl, set up 2FA, and try web SSH, the audit log, and session
+  replay.
 publishedAt: 2021-10-29T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2021/part-3-tutorial-running-teleport-with-docker.md
+++ b/content/videos/standalone/2021/part-3-tutorial-running-teleport-with-docker.md
@@ -3,20 +3,16 @@ id: wdrgonuy73469iogpfz4afx3
 slug: part-3-tutorial-running-teleport-with-docker
 title: Part 3. Tutorial - Running Teleport with Docker
 description: >-
-  Find out more at https://rawkode.live/teleport
-
-
-  Learn how to run Teleport with Docker and Docker Compose.
-
-
-
-  Code:
-  https://github.com/rawkode-academy/courses/tree/main/teleport-complete-guide/3-running-teleport-with-docker
+  Run Teleport in containers: inspect the official image, generate a config with
+  the configure subcommand, mount it alongside a named volume for state, and
+  expose ports 3023, 3025, and 3080. Then wire up a multi-node lab with Docker
+  Compose and create the first user.
 publishedAt: 2021-11-03T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - docker
+  - docker-compose
   - teleport
 chapters:
   - startTime: 0
@@ -83,5 +79,10 @@ resources:
   - title: 'Teleport documentation: Running Teleport with Docker'
     type: url
     category: documentation
+    url: 'https://goteleport.com/docs/installation/docker/'
+  - title: 'Course code: Running Teleport with Docker'
+    type: url
+    category: code
+    url: 'https://github.com/rawkode-academy/courses/tree/main/teleport-complete-guide/3-running-teleport-with-docker'
 ---
 

--- a/content/videos/standalone/2021/part-3-tutorial-running-teleport-with-docker.md
+++ b/content/videos/standalone/2021/part-3-tutorial-running-teleport-with-docker.md
@@ -83,6 +83,7 @@ resources:
   - title: 'Course code: Running Teleport with Docker'
     type: url
     category: code
-    url: 'https://github.com/rawkode-academy/courses/tree/main/teleport-complete-guide/3-running-teleport-with-docker'
+    url: >-
+      https://github.com/rawkode-academy/courses/tree/main/teleport-complete-guide/3-running-teleport-with-docker
 ---
 

--- a/content/videos/standalone/2021/part-4-workshop-server-access-with-teleport.md
+++ b/content/videos/standalone/2021/part-4-workshop-server-access-with-teleport.md
@@ -2,27 +2,7 @@
 id: hn0j9iu8ps7jaegq6iykq50c
 slug: part-4-workshop-server-access-with-teleport
 title: Part 4. Workshop - Server Access with Teleport
-description: |-
-  Find out more at https://rawkode.live/teleport
-
-  - Registering nodes with the cluster
-
-  - Using node labels
-
-  - Managing users
-   - Invites
-   - Roles
-   - Logins
-
-  - Using the Teleport Web UI
-   - SSH
-   - Sharing sessions
-   - Recorded sessions
-
-  - Using the Teleport CLI
-   - SSH
-   - Creating sessions
-   - Joining sessions
+description: Hands-on Teleport workshop covering agent node registration, static and dynamic labels, user and role management, eBPF enhanced session recording, and accessing servers through the Web UI and tsh CLI with shared and recorded sessions.
 publishedAt: 2021-11-05T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -96,16 +76,18 @@ guests: []
 resources:
   - title: Rawkode Academy courses repository
     type: url
-    url: 'https://github.com/rockwoodacademy/courses'
+    url: 'https://github.com/RawkodeAcademy/RawkodeAcademy'
     category: code
   - title: Teleport Linux get started guide
     type: url
     category: documentation
   - title: Teleport reference config file documentation
     type: url
+    url: 'https://goteleport.com/docs/reference/config'
     category: documentation
   - title: Teleport enhanced session recording documentation
     type: url
+    url: 'https://goteleport.com/docs/enroll-resources/server-access/guides/bpf-session-recording/'
     category: documentation
 ---
 

--- a/content/videos/standalone/2021/part-4-workshop-server-access-with-teleport.md
+++ b/content/videos/standalone/2021/part-4-workshop-server-access-with-teleport.md
@@ -2,7 +2,11 @@
 id: hn0j9iu8ps7jaegq6iykq50c
 slug: part-4-workshop-server-access-with-teleport
 title: Part 4. Workshop - Server Access with Teleport
-description: Hands-on Teleport workshop covering agent node registration, static and dynamic labels, user and role management, eBPF enhanced session recording, and accessing servers through the Web UI and tsh CLI with shared and recorded sessions.
+description: >-
+  Hands-on Teleport workshop covering agent node registration, static and
+  dynamic labels, user and role management, eBPF enhanced session recording, and
+  accessing servers through the Web UI and tsh CLI with shared and recorded
+  sessions.
 publishedAt: 2021-11-05T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -87,7 +91,8 @@ resources:
     category: documentation
   - title: Teleport enhanced session recording documentation
     type: url
-    url: 'https://goteleport.com/docs/enroll-resources/server-access/guides/bpf-session-recording/'
+    url: >-
+      https://goteleport.com/docs/enroll-resources/server-access/guides/bpf-session-recording/
     category: documentation
 ---
 

--- a/content/videos/standalone/2021/part-6-workshop-application-access-with-teleport.md
+++ b/content/videos/standalone/2021/part-6-workshop-application-access-with-teleport.md
@@ -2,12 +2,18 @@
 id: n7tneoc9na93g1cpnfz7cx6i
 slug: part-6-workshop-application-access-with-teleport
 title: Part 6. Workshop - Application Access with Teleport
-description: 'Find out more at https://rawkode.live/teleport'
+description: >-
+  Live workshop covering Teleport application access: configure auth/proxy with
+  ACME, join a worker node, then expose NGINX and Grafana as Teleport apps.
+  Includes JWT inspection, path-based restrictions, and TSH CLI access.
 publishedAt: 2021-11-18T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - teleport
+  - pulumi
+  - docker
+  - grafana
 chapters:
   - startTime: 0
     title: <Untitled Chapter 1>
@@ -80,6 +86,7 @@ resources:
     category: code
   - title: Teleport configuration file reference
     type: url
+    url: 'https://goteleport.com/docs/reference/config/'
     category: documentation
   - title: jwt.io JWT debugger
     type: url

--- a/content/videos/standalone/2021/whats-new-in-teleport-8.md
+++ b/content/videos/standalone/2021/whats-new-in-teleport-8.md
@@ -4,8 +4,8 @@ slug: whats-new-in-teleport-8
 title: What's New in Teleport 8?
 description: >-
   Steven Martin walks through what landed in Teleport 8: Windows desktop access
-  without RDP, single-port 443 connectivity, WebAuthn with Touch ID, EC2
-  node auto-join, dynamic app and database registration, and RDS auto-discovery.
+  without RDP, single-port 443 connectivity, WebAuthn with Touch ID, EC2 node
+  auto-join, dynamic app and database registration, and RDS auto-discovery.
 publishedAt: 2021-12-21T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -69,10 +69,12 @@ resources:
   - title: 'Teleport documentation: joining nodes'
     type: url
     category: documentation
-    url: 'https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/'
+    url: >-
+      https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/
   - title: 'Teleport documentation: AWS console access'
     type: url
     category: documentation
-    url: 'https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console/'
+    url: >-
+      https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console/
 ---
 

--- a/content/videos/standalone/2021/whats-new-in-teleport-8.md
+++ b/content/videos/standalone/2021/whats-new-in-teleport-8.md
@@ -3,8 +3,9 @@ id: usjlx0m96px21ont4ouar9a7
 slug: whats-new-in-teleport-8
 title: What's New in Teleport 8?
 description: >-
-  In this episode, we'll ne joined by Steve Martin from the Teleport team to
-  introduce us to all the new features in Teleport 8.
+  Steven Martin walks through what landed in Teleport 8: Windows desktop access
+  without RDP, single-port 443 connectivity, WebAuthn with Touch ID, EC2
+  node auto-join, dynamic app and database registration, and RDS auto-discovery.
 publishedAt: 2021-12-21T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -68,8 +69,10 @@ resources:
   - title: 'Teleport documentation: joining nodes'
     type: url
     category: documentation
+    url: 'https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/'
   - title: 'Teleport documentation: AWS console access'
     type: url
     category: documentation
+    url: 'https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console/'
 ---
 

--- a/content/videos/standalone/2022/advanced-kubernetes-scheduling.md
+++ b/content/videos/standalone/2022/advanced-kubernetes-scheduling.md
@@ -42,19 +42,23 @@ guests: []
 resources:
   - title: 'Kubernetes Documentation: PriorityClass'
     type: url
-    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/'
+    url: >-
+      https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
     category: documentation
   - title: 'Kubernetes Documentation: Pod Scheduling Readiness'
     type: url
-    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/'
+    url: >-
+      https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/
     category: documentation
   - title: 'Kubernetes Enhancement Proposal: Dynamic Resource Allocation'
     type: url
-    url: 'https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation'
+    url: >-
+      https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation
     category: documentation
   - title: 'Kubernetes Documentation: Topology Spread Constraints'
     type: url
-    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/'
+    url: >-
+      https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     category: documentation
 ---
 

--- a/content/videos/standalone/2022/advanced-kubernetes-scheduling.md
+++ b/content/videos/standalone/2022/advanced-kubernetes-scheduling.md
@@ -3,8 +3,10 @@ id: n3ub5yilclec48k398q64zi2
 slug: advanced-kubernetes-scheduling
 title: Advanced Kubernetes Scheduling
 description: >-
-  In this video, I guide you through some advanced Kubernetes scheduling
-  techniques; as well as covering a few of the basics.
+  A deep dive into Kubernetes pod scheduling, from nodeName and node selectors
+  through node and pod affinity, topology spread constraints, priority classes
+  and preemption, plus alpha features like scheduling gates and dynamic resource
+  allocation.
 publishedAt: 2022-12-22T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -40,15 +42,19 @@ guests: []
 resources:
   - title: 'Kubernetes Documentation: PriorityClass'
     type: url
+    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/'
     category: documentation
   - title: 'Kubernetes Documentation: Pod Scheduling Readiness'
     type: url
+    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/'
     category: documentation
   - title: 'Kubernetes Enhancement Proposal: Dynamic Resource Allocation'
     type: url
+    url: 'https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation'
     category: documentation
   - title: 'Kubernetes Documentation: Topology Spread Constraints'
     type: url
+    url: 'https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/'
     category: documentation
 ---
 

--- a/content/videos/standalone/2022/continuously-deploy-with-gitops.md
+++ b/content/videos/standalone/2022/continuously-deploy-with-gitops.md
@@ -3,14 +3,15 @@ id: xi7tekr74r3qfd7pv30lkp0s
 slug: continuously-deploy-with-gitops
 title: Continuously Deploy with GitOps
 description: >-
-  Welcome to the Portainer in Production course. In this video, I walk you
-  through continuously deploying your application from Git with Portainer
-  Stacks, using nothing more than a docker-compose.yml.
+  Bring GitOps to non-Kubernetes environments using Portainer Stacks backed by a
+  Git repository and a docker-compose.yml, with continuous delivery triggered by
+  either polling or GitHub webhooks.
 publishedAt: 2022-12-09T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - portainer
+  - docker-compose
 chapters:
   - startTime: 0
     title: Introduction
@@ -47,5 +48,13 @@ resources:
     type: url
     url: 'https://github.com/rawkode-academy/portainer-in-production'
     category: code
+  - title: Portainer Documentation
+    type: url
+    url: 'https://docs.portainer.io/'
+    category: documentation
+  - title: Docker Compose Documentation
+    type: url
+    url: 'https://docs.docker.com/compose/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2022/full-stack-webassembly-applications-with-spin.md
+++ b/content/videos/standalone/2022/full-stack-webassembly-applications-with-spin.md
@@ -2,7 +2,11 @@
 id: sx8a3ihcu4qum6du7ejlif7i
 slug: full-stack-webassembly-applications-with-spin
 title: Full Stack WebAssembly Applications with Spin
-description: 'Building a full-stack WebAssembly application with Spin: a Bartholomew CMS frontend plus two API components, a Rust addition service and a Grain subtraction service, all running locally with spin up and deployed to Fermyon Cloud.'
+description: >-
+  Building a full-stack WebAssembly application with Spin: a Bartholomew CMS
+  frontend plus two API components, a Rust addition service and a Grain
+  subtraction service, all running locally with spin up and deployed to Fermyon
+  Cloud.
 publishedAt: 2022-11-29T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/full-stack-webassembly-applications-with-spin.md
+++ b/content/videos/standalone/2022/full-stack-webassembly-applications-with-spin.md
@@ -2,12 +2,14 @@
 id: sx8a3ihcu4qum6du7ejlif7i
 slug: full-stack-webassembly-applications-with-spin
 title: Full Stack WebAssembly Applications with Spin
-description: Video content coming soon.
+description: 'Building a full-stack WebAssembly application with Spin: a Bartholomew CMS frontend plus two API components, a Rust addition service and a Grain subtraction service, all running locally with spin up and deployed to Fermyon Cloud.'
 publishedAt: 2022-11-29T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - rust
+  - webassembly
 chapters:
   - startTime: 44
     title: 'Introduction: Spin and Full Stack WebAssembly'
@@ -46,12 +48,15 @@ guests: []
 resources:
   - title: Grain Programming Language
     type: url
-    category: code
-  - title: Fermion Cloud
+    category: documentation
+    url: 'https://grain-lang.org/'
+  - title: Fermyon Cloud
     type: url
     category: other
+    url: 'https://www.fermyon.com/cloud'
   - title: Spin SDK
     type: url
     category: code
+    url: 'https://github.com/spinframework/spin'
 ---
 

--- a/content/videos/standalone/2022/github-authentication.md
+++ b/content/videos/standalone/2022/github-authentication.md
@@ -3,8 +3,10 @@ id: gz1nbyatbi6h3q1usddwkdqh
 slug: github-authentication
 title: GitHub Authentication
 description: >-
-  In this live demo, David will walk you through adding GitHub authentication to
-  your Teleport cluster.
+  Live walkthrough of configuring single sign on against GitHub teams and
+  organizations for an existing Teleport cluster: creating the OAuth app,
+  writing the GitHub connector YAML, fixing the team requirement, then granting
+  SSH access by editing a Teleport role.
 publishedAt: 2022-05-04T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -38,6 +40,7 @@ guests: []
 resources:
   - title: Teleport GitHub SSO Documentation
     type: url
+    url: 'https://goteleport.com/docs/admin-guides/access-controls/sso/github-sso/'
     category: documentation
   - title: Teleport RBAC Deep Dive
     type: url

--- a/content/videos/standalone/2022/global-dns-with-bgp.md
+++ b/content/videos/standalone/2022/global-dns-with-bgp.md
@@ -3,14 +3,16 @@ id: v0i31x8ecolt41m670pt9cto
 slug: global-dns-with-bgp
 title: Global DNS with BGP
 description: >-
-  Checkout https://rawkode.academy/metal and use the code "rawkode" for 200USD
-  in FREE Equinix Metal credits.
+  Run CoreDNS in three metros on Equinix Metal and advertise a single anycast
+  IP over BGP with BIRD, then reproduce the whole setup with Pulumi and CUE so
+  the closest region answers every query.
 publishedAt: 2022-08-11T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - coredns
   - pulumi
+  - cue
 chapters:
   - startTime: 0
     title: Introduction
@@ -127,9 +129,11 @@ resources:
     category: code
   - title: CoreDNS Plugins Documentation
     type: url
+    url: 'https://coredns.io/plugins/'
     category: documentation
   - title: BIRD Internet Routing Daemon
     type: url
+    url: 'https://bird.network.cz/'
     category: other
 ---
 

--- a/content/videos/standalone/2022/global-dns-with-bgp.md
+++ b/content/videos/standalone/2022/global-dns-with-bgp.md
@@ -3,9 +3,9 @@ id: v0i31x8ecolt41m670pt9cto
 slug: global-dns-with-bgp
 title: Global DNS with BGP
 description: >-
-  Run CoreDNS in three metros on Equinix Metal and advertise a single anycast
-  IP over BGP with BIRD, then reproduce the whole setup with Pulumi and CUE so
-  the closest region answers every query.
+  Run CoreDNS in three metros on Equinix Metal and advertise a single anycast IP
+  over BGP with BIRD, then reproduce the whole setup with Pulumi and CUE so the
+  closest region answers every query.
 publishedAt: 2022-08-11T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/introduction-to-bgp.md
+++ b/content/videos/standalone/2022/introduction-to-bgp.md
@@ -3,21 +3,10 @@ id: cle88zfeqmv5z0rl6g7mi083
 slug: introduction-to-bgp
 title: Introduction to BGP
 description: >-
-  Want to follow along with some FREE Equinix Metal credits?
-
-
-  Checkout https://rawkode.academy/metal and use the code "rawkode"
-
-
-  ---
-
-
-  In this session, we'll introduce you to the vocabulary and software you need
-  to be able to understand the essentials of working with BGP.
-
-
-  We'll be guiding you through broadcasting your first BGP address with the help
-  of Equinix Metal, the bare metal cloud.
+  Rawkode and Jeremy Tanner introduce BGP, covering autonomous systems,
+  prefixes, anycast routing and CDN failover. They then deploy NGINX across two
+  Equinix Metal metros, configure the BIRD daemon, and verify anycast routing
+  with curl, traceroute and Locoping.
 publishedAt: 2022-07-14T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -105,7 +94,6 @@ resources:
     category: other
   - title: Locoping
     type: url
-    url: 'https://locoping.com'
     category: other
   - title: Simple Wikipedia (BGP)
     type: url

--- a/content/videos/standalone/2022/kubescape-cli-and-github-action.md
+++ b/content/videos/standalone/2022/kubescape-cli-and-github-action.md
@@ -3,14 +3,16 @@ id: d52og3gdtmtu7w8nhkyg1uyt
 slug: kubescape-cli-and-github-action
 title: Kubescape CLI & GitHub Action
 description: >-
-  Welcome to The Complete Gudie to Kubescape. In this course, you'll learn
-  everything you need to leverage the great powers of Kubescape into your
-  platform to improve your Kubernetes security posture.
+  Use the Kubescape CLI to scan plain manifests, Kustomize overlays, and Helm
+  charts against frameworks like NSA/CISA, then wire the GitHub Action into CI
+  to publish pretty-printer, JUnit, and SARIF reports to Code Scanning.
 publishedAt: 2022-12-20T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubescape
+  - kubernetes
+  - helm
 chapters:
   - startTime: 0
     title: Introduction
@@ -67,9 +69,12 @@ resources:
     category: demos
   - title: NSA/CISA Kubernetes Hardening Guidance
     type: url
+    url: >-
+      https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
     category: documentation
   - title: Klustered Automation Repository
     type: url
+    url: 'https://github.com/rawkode-academy/klustered'
     category: code
 ---
 

--- a/content/videos/standalone/2022/kubescape-operator-and-saas.md
+++ b/content/videos/standalone/2022/kubescape-operator-and-saas.md
@@ -4,8 +4,8 @@ slug: kubescape-operator-and-saas
 title: Kubescape Operator & SaaS
 description: >-
   Deploy the Kubescape operator across AKS, EKS, and GKE with Pulumi, then use
-  Kubescape Cloud to triage configuration risks, CVEs, and RBAC across
-  workloads from Flux, Grafana, and Helm charts.
+  Kubescape Cloud to triage configuration risks, CVEs, and RBAC across workloads
+  from Flux, Grafana, and Helm charts.
 publishedAt: 2022-12-20T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/kubescape-operator-and-saas.md
+++ b/content/videos/standalone/2022/kubescape-operator-and-saas.md
@@ -3,14 +3,19 @@ id: q29r22us2pmcizlk0v0zifyb
 slug: kubescape-operator-and-saas
 title: Kubescape Operator & SaaS
 description: >-
-  Welcome to The Complete Gudie to Kubescape. In this course, you’ll learn
-  everything you need to leverage the great powers of Kubescape into your
-  platform to improve your Kubernetes security posture.
+  Deploy the Kubescape operator across AKS, EKS, and GKE with Pulumi, then use
+  Kubescape Cloud to triage configuration risks, CVEs, and RBAC across
+  workloads from Flux, Grafana, and Helm charts.
 publishedAt: 2022-12-20T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubescape
+  - kubernetes
+  - pulumi
+  - helm
+  - fluxcd
+  - grafana
 chapters:
   - startTime: 0
     title: Introduction

--- a/content/videos/standalone/2022/lets-take-a-look-at-teleport-10.md
+++ b/content/videos/standalone/2022/lets-take-a-look-at-teleport-10.md
@@ -3,8 +3,10 @@ id: m33ycy3p5m13rbpi3h4bkbv0
 slug: lets-take-a-look-at-teleport-10
 title: Let's Take a Look at Teleport 10
 description: >-
-  In this session, Ben, from Teleport, and I take a look at the new features
-  releases in Teleport 10.
+  Ben Abbott (DevRel at Teleport) walks through what's new in Teleport 10:
+  passwordless access via WebAuthn, FIDO and YubiKeys, resource-level access
+  requests, Machine ID for Kubernetes, new database integrations, and upgrade
+  guidance.
 publishedAt: 2022-07-30T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -93,6 +95,7 @@ guests:
 resources:
   - title: Teleport Upgrade Documentation
     type: url
+    url: 'https://goteleport.com/docs/management/operations/upgrading/'
     category: documentation
   - title: Rawkode Academy Discord
     type: url
@@ -103,9 +106,11 @@ resources:
     category: documentation
   - title: Teleport RFDs (Request For Discussion)
     type: url
+    url: 'https://github.com/gravitational/teleport/tree/master/rfd'
     category: documentation
   - title: Teleport Community Slack
     type: url
+    url: 'https://goteleport.com/slack'
     category: other
 ---
 

--- a/content/videos/standalone/2022/managing-tls.md
+++ b/content/videos/standalone/2022/managing-tls.md
@@ -3,14 +3,15 @@ id: ivg9hwb376cu64psybqhd5k0
 slug: managing-tls
 title: Managing TLS
 description: >-
-  Welcome to the Portainer in Production course. In this video, I guide you
-  through configuring Portainer with TLS certificates provisioned with certbot
-  for LetsEncrypt.
+  Three ways to give Portainer real TLS certificates: keep the built-in self
+  signed certs, run Certbot on the host with a systemd timer for renewals, or
+  put Caddy in front as a reverse proxy that handles the ACME dance for you.
 publishedAt: 2022-12-09T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - portainer
+  - docker
 chapters:
   - startTime: 0
     title: Introduction and Course Overview
@@ -51,7 +52,23 @@ guests: []
 resources:
   - title: Portainer in Production GitHub Repository
     type: url
-    url: 'https://github.com/rawcodeacademy/portainer-in-production'
+    url: 'https://github.com/RawkodeAcademy/portainer-in-production'
     category: code
+  - title: Certbot
+    type: url
+    url: 'https://certbot.eff.org/'
+    category: documentation
+  - title: Let's Encrypt
+    type: url
+    url: 'https://letsencrypt.org/'
+    category: documentation
+  - title: Caddy Documentation
+    type: url
+    url: 'https://caddyserver.com/docs/'
+    category: documentation
+  - title: Portainer SSL Certificate Settings
+    type: url
+    url: 'https://docs.portainer.io/admin/settings#ssl-certificate'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2022/part-2-tutorial-1-installation.md
+++ b/content/videos/standalone/2022/part-2-tutorial-1-installation.md
@@ -3,13 +3,17 @@ id: ywd7rvmdaz445o5wf0snvwx9
 slug: part-2-tutorial-1-installation
 title: 'Part 2 - Tutorial 1: Installation'
 description: >-
-  Tutorial: Learn how to install and run #InfluxDB on macOS, Linux (Debian and
-  RedHat), Docker, and Kubernetes.
+  Walk through five ways to install InfluxDB 2: brew on macOS, the apt
+  repository on Debian/Ubuntu, the yum repo on Red Hat, the official Docker
+  image with a persistent volume, and the influxdata Helm chart on Kubernetes.
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - influxdb
+  - docker
+  - helm
+  - kubernetes
 chapters:
   - startTime: 0
     title: Introduction
@@ -45,6 +49,7 @@ resources:
   - title: InfluxData InfluxDB 2 Helm Chart
     type: url
     category: code
+    url: 'https://github.com/influxdata/helm-charts'
   - title: Course Materials Installation Guide
     type: url
     category: documentation

--- a/content/videos/standalone/2022/part-3-tutorial-2-getting-started-with-influxdb.md
+++ b/content/videos/standalone/2022/part-3-tutorial-2-getting-started-with-influxdb.md
@@ -2,7 +2,7 @@
 id: f8kozfxzp1vtykj2na0sye5w
 slug: part-3-tutorial-2-getting-started-with-influxdb
 title: 'Part 3 - Tutorial 2: Getting Started with InfluxDB'
-description: Walk through the InfluxDB 2 first-run setup (admin user, org, bucket), then tour the UI: Data (Telegraf plugins, scrapers, tokens), Explore, Boards, Tasks for Flux automation, Alerts, and Settings for variables, templates, and labels.
+description: 'Walk through the InfluxDB 2 first-run setup (admin user, org, bucket), then tour the UI: Data (Telegraf plugins, scrapers, tokens), Explore, Boards, Tasks for Flux automation, Alerts, and Settings for variables, templates, and labels.'
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/part-3-tutorial-2-getting-started-with-influxdb.md
+++ b/content/videos/standalone/2022/part-3-tutorial-2-getting-started-with-influxdb.md
@@ -2,16 +2,13 @@
 id: f8kozfxzp1vtykj2na0sye5w
 slug: part-3-tutorial-2-getting-started-with-influxdb
 title: 'Part 3 - Tutorial 2: Getting Started with InfluxDB'
-description: |-
-  Learn how to navigate the InfluxDB 2 UI
-
-
-  #InfluxDB #Tutorial
+description: Walk through the InfluxDB 2 first-run setup (admin user, org, bucket), then tour the UI: Data (Telegraf plugins, scrapers, tokens), Explore, Boards, Tasks for Flux automation, Alerts, and Settings for variables, templates, and labels.
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - influxdb
+  - telegraf
 chapters:
   - startTime: 0
     title: Intro
@@ -61,9 +58,11 @@ resources:
     type: url
     category: other
   - title: InfluxDB 2 Templates
+    url: https://docs.influxdata.com/influxdb/v2/tools/influxdb-templates/
     type: url
-    category: other
+    category: documentation
   - title: Telegraf Data Collector
+    url: https://github.com/influxdata/telegraf
     type: url
     category: code
 ---

--- a/content/videos/standalone/2022/part-4-tutorial-3-collecting-metrics-with-telegraf.md
+++ b/content/videos/standalone/2022/part-4-tutorial-3-collecting-metrics-with-telegraf.md
@@ -2,11 +2,7 @@
 id: fg5n3s12kpi526uupu0w7tav
 slug: part-4-tutorial-3-collecting-metrics-with-telegraf
 title: 'Part 4 - Tutorial 3: Collecting Metrics with Telegraf'
-description: |-
-  Learn how to configure Telegraf to collect metrics and store them in InfluxDB
-
-
-  #InfluxDB #Telegraf #Tutorial
+description: 'Walk through Telegraf running against InfluxDB 2: remote TOML config, agent options like batch size, buffer limit, jitter and precision, fanning out to a second file output, and adding the Prometheus input plugin to scrape a local endpoint.'
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -47,6 +43,7 @@ resources:
     category: code
   - title: Telegraf Plugins Reference
     type: url
+    url: 'https://github.com/influxdata/telegraf/tree/master/plugins'
     category: documentation
 ---
 

--- a/content/videos/standalone/2022/part-4-tutorial-3-collecting-metrics-with-telegraf.md
+++ b/content/videos/standalone/2022/part-4-tutorial-3-collecting-metrics-with-telegraf.md
@@ -2,7 +2,11 @@
 id: fg5n3s12kpi526uupu0w7tav
 slug: part-4-tutorial-3-collecting-metrics-with-telegraf
 title: 'Part 4 - Tutorial 3: Collecting Metrics with Telegraf'
-description: 'Walk through Telegraf running against InfluxDB 2: remote TOML config, agent options like batch size, buffer limit, jitter and precision, fanning out to a second file output, and adding the Prometheus input plugin to scrape a local endpoint.'
+description: >-
+  Walk through Telegraf running against InfluxDB 2: remote TOML config, agent
+  options like batch size, buffer limit, jitter and precision, fanning out to a
+  second file output, and adding the Prometheus input plugin to scrape a local
+  endpoint.
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/part-5-workshop-1-introduction-to-flux.md
+++ b/content/videos/standalone/2022/part-5-workshop-1-introduction-to-flux.md
@@ -2,12 +2,13 @@
 id: o1184zljah5ebqa0sj8h0i43
 slug: part-5-workshop-1-introduction-to-flux
 title: 'Part 5 - Workshop 1: Introduction to Flux'
-description: Video content coming soon.
+description: 'Workshop on the Flux query language for InfluxDB 2: set up InfluxDB and Telegraf, write queries with from, range, filter, yield, group, window, and aggregateWindow, and run Flux from the InfluxDB UI, the CLI, and the VS Code extension.'
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - influxdb
+  - telegraf
 chapters:
   - startTime: 0
     title: Introduction
@@ -103,6 +104,7 @@ resources:
     category: other
   - title: Rawkode Academy Discord
     type: url
+    url: 'https://rawkode.chat'
     category: other
 ---
 

--- a/content/videos/standalone/2022/part-5-workshop-1-introduction-to-flux.md
+++ b/content/videos/standalone/2022/part-5-workshop-1-introduction-to-flux.md
@@ -2,7 +2,11 @@
 id: o1184zljah5ebqa0sj8h0i43
 slug: part-5-workshop-1-introduction-to-flux
 title: 'Part 5 - Workshop 1: Introduction to Flux'
-description: 'Workshop on the Flux query language for InfluxDB 2: set up InfluxDB and Telegraf, write queries with from, range, filter, yield, group, window, and aggregateWindow, and run Flux from the InfluxDB UI, the CLI, and the VS Code extension.'
+description: >-
+  Workshop on the Flux query language for InfluxDB 2: set up InfluxDB and
+  Telegraf, write queries with from, range, filter, yield, group, window, and
+  aggregateWindow, and run Flux from the InfluxDB UI, the CLI, and the VS Code
+  extension.
 publishedAt: 2022-01-26T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/q-and-a-lets-meet-teleport-9.md
+++ b/content/videos/standalone/2022/q-and-a-lets-meet-teleport-9.md
@@ -2,7 +2,7 @@
 id: te9uhekxxgat60sku1r85kuv
 slug: q-and-a-lets-meet-teleport-9
 title: Q&A - Let's Meet Teleport 9
-description: 'Find out more at https://rawkode.live/teleport'
+description: Ben Abbott joins David to walk through Teleport 9, covering Machine ID for automated workloads with Ansible, new database access for Redis, MariaDB and SQL Server, moderated sessions, per-session MFA, and desktop access.
 publishedAt: 2022-04-07T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -87,6 +87,7 @@ resources:
     type: url
     category: documentation
   - title: Teleport Requests for Discussion (RFD)
+    url: https://github.com/gravitational/teleport/tree/master/rfd
     type: url
     category: documentation
   - title: Why the Four Eyes Principle is Critical for Access

--- a/content/videos/standalone/2022/q-and-a-lets-meet-teleport-9.md
+++ b/content/videos/standalone/2022/q-and-a-lets-meet-teleport-9.md
@@ -2,7 +2,10 @@
 id: te9uhekxxgat60sku1r85kuv
 slug: q-and-a-lets-meet-teleport-9
 title: Q&A - Let's Meet Teleport 9
-description: Ben Abbott joins David to walk through Teleport 9, covering Machine ID for automated workloads with Ansible, new database access for Redis, MariaDB and SQL Server, moderated sessions, per-session MFA, and desktop access.
+description: >-
+  Ben Abbott joins David to walk through Teleport 9, covering Machine ID for
+  automated workloads with Ansible, new database access for Redis, MariaDB and
+  SQL Server, moderated sessions, per-session MFA, and desktop access.
 publishedAt: 2022-04-07T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -87,7 +90,7 @@ resources:
     type: url
     category: documentation
   - title: Teleport Requests for Discussion (RFD)
-    url: https://github.com/gravitational/teleport/tree/master/rfd
+    url: 'https://github.com/gravitational/teleport/tree/master/rfd'
     type: url
     category: documentation
   - title: Why the Four Eyes Principle is Critical for Access

--- a/content/videos/standalone/2022/workshop-access-control-and-roles-deep-dive.md
+++ b/content/videos/standalone/2022/workshop-access-control-and-roles-deep-dive.md
@@ -2,7 +2,7 @@
 id: ecc8n8zd3p5xk96h52qdp2p7
 slug: workshop-access-control-and-roles-deep-dive
 title: Workshop - Access Control & Roles Deep Dive
-description: 'Find out more at https://rawkode.live/teleport'
+description: 'Deep dive into Teleport RBAC: explore the editor, auditor, and access base roles, modify user traits and logins, restrict access with node labels, build elevated access approval workflows, and enforce session MFA.'
 publishedAt: 2022-02-19T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/workshop-access-control-and-roles-deep-dive.md
+++ b/content/videos/standalone/2022/workshop-access-control-and-roles-deep-dive.md
@@ -2,7 +2,10 @@
 id: ecc8n8zd3p5xk96h52qdp2p7
 slug: workshop-access-control-and-roles-deep-dive
 title: Workshop - Access Control & Roles Deep Dive
-description: 'Deep dive into Teleport RBAC: explore the editor, auditor, and access base roles, modify user traits and logins, restrict access with node labels, build elevated access approval workflows, and enforce session MFA.'
+description: >-
+  Deep dive into Teleport RBAC: explore the editor, auditor, and access base
+  roles, modify user traits and logins, restrict access with node labels, build
+  elevated access approval workflows, and enforce session MFA.
 publishedAt: 2022-02-19T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2022/workshop-database-access-mongodb-with-teleport.md
+++ b/content/videos/standalone/2022/workshop-database-access-mongodb-with-teleport.md
@@ -2,7 +2,11 @@
 id: ycuvz85u2a7678qr5o4a488z
 slug: workshop-database-access-mongodb-with-teleport
 title: Workshop - Database Access (mongoDB) with Teleport
-description: 'Find out more at https://rawkode.live/teleport'
+description: >-
+  Use Teleport's database proxy to provide identity-aware, certificate-based
+  access to MongoDB. Covers configuring a self-hosted mongod with X.509 auth,
+  issuing certs via tctl, audit logging, and extending the same flow to MongoDB
+  Atlas and Compass.
 publishedAt: 2022-01-22T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -106,9 +110,11 @@ resources:
     category: code
   - title: MongoDB Atlas Documentation
     type: url
+    url: 'https://www.mongodb.com/docs/atlas/'
     category: documentation
   - title: MongoDB Compass
     type: url
+    url: 'https://www.mongodb.com/products/tools/compass'
     category: other
 ---
 

--- a/content/videos/standalone/2022/workshop-deploying-teleport-on-kubernetes.md
+++ b/content/videos/standalone/2022/workshop-deploying-teleport-on-kubernetes.md
@@ -2,12 +2,19 @@
 id: dtax4c66pvgyj704bvojhsou
 slug: workshop-deploying-teleport-on-kubernetes
 title: Workshop - Deploying Teleport on Kubernetes
-description: 'Find out more at https://rawkode.live/teleport'
+description: >-
+  Hands-on workshop deploying Teleport on Kubernetes using the official Helm
+  charts. Covers the teleport-cluster chart with LoadBalancer and Ingress, the
+  kube-agent for connecting additional clusters, and exposing host SSH access
+  via a DaemonSet.
 publishedAt: 2022-01-19T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - teleport
+  - kubernetes
+  - helm
+  - artifacthub
 chapters:
   - startTime: 0
     title: <Untitled Chapter 1>
@@ -46,11 +53,11 @@ resources:
     category: code
   - title: Artifact Hub
     type: url
-    url: 'https://artifacthub.io'
+    url: 'https://artifacthub.io/'
     category: other
   - title: Emissary Ingress
     type: url
-    url: 'https://www.getambassador.io/products/emissary-ingress'
+    url: 'https://emissary-ingress.dev/'
     category: other
   - title: Kubernetes Office Hours
     type: url

--- a/content/videos/standalone/2023/a-hands-on-overview-of-guidepad.md
+++ b/content/videos/standalone/2023/a-hands-on-overview-of-guidepad.md
@@ -2,7 +2,7 @@
 id: lxx8tfrfnnhiv1ur4h6t60t0
 slug: a-hands-on-overview-of-guidepad
 title: A Hands-on Overview of guidepad
-description: The Development Framework for managing complexity and expanding capabilities.
+description: David builds a Pocket-style bookmark app on Guidepad. Create and list entities from the CLI, auto-enrich URLs with Microlink metadata and ChatGPT summaries, then expose a filtered todo API by adding a read field to the type and deploying with a git push.
 publishedAt: 2023-06-26T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -46,7 +46,7 @@ resources:
     type: url
     url: 'https://microlink.io/'
     category: other
-  - title: Guidepad Rawkode
+  - title: Guidepad Rawkode plugin
     type: url
     category: code
 ---

--- a/content/videos/standalone/2023/a-hands-on-overview-of-guidepad.md
+++ b/content/videos/standalone/2023/a-hands-on-overview-of-guidepad.md
@@ -2,7 +2,11 @@
 id: lxx8tfrfnnhiv1ur4h6t60t0
 slug: a-hands-on-overview-of-guidepad
 title: A Hands-on Overview of guidepad
-description: David builds a Pocket-style bookmark app on Guidepad. Create and list entities from the CLI, auto-enrich URLs with Microlink metadata and ChatGPT summaries, then expose a filtered todo API by adding a read field to the type and deploying with a git push.
+description: >-
+  David builds a Pocket-style bookmark app on Guidepad. Create and list entities
+  from the CLI, auto-enrich URLs with Microlink metadata and ChatGPT summaries,
+  then expose a filtered todo API by adding a read field to the type and
+  deploying with a git push.
 publishedAt: 2023-06-26T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/aquaproj-and-dagger.md
+++ b/content/videos/standalone/2023/aquaproj-and-dagger.md
@@ -3,8 +3,9 @@ id: phhk3ymh8qjb3pzwmmtofefz
 slug: aquaproj-and-dagger
 title: aquaproj & Dagger
 description: >-
-  In this episode of AlphaBits, Brian and David explain why they're excited
-  about aquaproj and Dagger.
+  Brian demos aquaproj for pinning CLI tool versions per-project and globally
+  via its YAML registry, then David walks through a Go Dagger pipeline that
+  builds a container, runs Hurl HTTP tests, and visualises cached steps.
 publishedAt: 2023-08-17T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -50,10 +51,18 @@ guests:
 resources:
   - title: AlphaBits Podcast
     type: url
-    url: 'https://alphabets.fm'
     category: other
   - title: aquaproj Registry
     type: url
+    url: 'https://github.com/aquaproj/aqua-registry'
     category: code
+  - title: aquaproj Documentation
+    type: url
+    url: 'https://aquaproj.github.io/docs/'
+    category: documentation
+  - title: Dagger Documentation
+    type: url
+    url: 'https://docs.dagger.io/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2023/automated-kubernetes-operations-with-komodor-and-vcluster.md
+++ b/content/videos/standalone/2023/automated-kubernetes-operations-with-komodor-and-vcluster.md
@@ -2,7 +2,11 @@
 id: oareyzu0nuanx1h7tz478z14
 slug: automated-kubernetes-operations-with-komodor-and-vcluster
 title: Automated Kubernetes Operations with Komodor and vcluster
-description: Integrate Komodor with vCluster to auto-deploy the Komodor agent into every ephemeral virtual cluster via Helm init charts, then use Komodor to observe and debug workloads (like a broken NGINX image pull) across each vCluster from a single UI.
+description: >-
+  Integrate Komodor with vCluster to auto-deploy the Komodor agent into every
+  ephemeral virtual cluster via Helm init charts, then use Komodor to observe
+  and debug workloads (like a broken NGINX image pull) across each vCluster from
+  a single UI.
 publishedAt: 2023-03-29T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -33,7 +37,7 @@ guests: []
 resources:
   - title: Komodor Helm charts repository (komodorio/helm-charts)
     type: url
-    url: https://github.com/komodorio/helm-charts
+    url: 'https://github.com/komodorio/helm-charts'
     category: code
 ---
 

--- a/content/videos/standalone/2023/automated-kubernetes-operations-with-komodor-and-vcluster.md
+++ b/content/videos/standalone/2023/automated-kubernetes-operations-with-komodor-and-vcluster.md
@@ -2,7 +2,7 @@
 id: oareyzu0nuanx1h7tz478z14
 slug: automated-kubernetes-operations-with-komodor-and-vcluster
 title: Automated Kubernetes Operations with Komodor and vcluster
-description: Video content coming soon.
+description: Integrate Komodor with vCluster to auto-deploy the Komodor agent into every ephemeral virtual cluster via Helm init charts, then use Komodor to observe and debug workloads (like a broken NGINX image pull) across each vCluster from a single UI.
 publishedAt: 2023-03-29T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -31,8 +31,9 @@ chapters:
 duration: 358
 guests: []
 resources:
-  - title: Kubernetes workshop chart from the Komodor LJOX repository
+  - title: Komodor Helm charts repository (komodorio/helm-charts)
     type: url
+    url: https://github.com/komodorio/helm-charts
     category: code
 ---
 

--- a/content/videos/standalone/2023/automating-deployments-to-the-edge.md
+++ b/content/videos/standalone/2023/automating-deployments-to-the-edge.md
@@ -3,24 +3,16 @@ id: f9qr4s42d566gqtkdzzknxn9
 slug: automating-deployments-to-the-edge
 title: Automating Deployments to the Edge
 description: >-
-  Welcome to the Portainer in Production course.
-
-
-  In this video, I walk you through Portainer's Edge APIs for administering
-  remote compute nodes with the Portainer agent.
-
-
-  Using cdktf to automate the provisioning of some bare metal devices on Equinix
-  Metal, we connect them to Portainer and automate the roll out of our nginx
-  application.
-
-
-  https://github.com/RawkodeAcademy/portainer-in-production
+  Using Terraform CDK, we provision four bare metal nodes on Equinix Metal with
+  Anycast BGP, then use Portainer's Edge Compute to deploy an NGINX container to
+  the US, Europe, and Asia and measure the latency improvements as each region
+  comes online.
 publishedAt: 2023-01-16T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - portainer
+  - terraform
 chapters:
   - startTime: 0
     title: Introduction
@@ -91,6 +83,7 @@ guests: []
 resources:
   - title: Portainer in Production repository
     type: url
+    url: 'https://github.com/rawkode-academy/portainer-in-production'
     category: code
   - title: KeyCDN Website Speed Test
     type: url

--- a/content/videos/standalone/2023/bluesky-embed-with-spin-webassembly.md
+++ b/content/videos/standalone/2023/bluesky-embed-with-spin-webassembly.md
@@ -3,14 +3,16 @@ id: ierbuewtemudd1i0w0wru28j
 slug: bluesky-embed-with-spin-webassembly
 title: BlueSky Embed with Spin WebAssembly
 description: >-
-  BlueSky is pretty cool, but you can't embed posts on to the web. So let's fix
-  that by writing a small backend service with Spin: the WebAssembly serverless
-  framework.
+  Build a Bluesky post embed with Spin and WebAssembly. We wire up a Lit web
+  component to a TypeScript Spin backend, handle CORS, cache auth tokens in the
+  key-value store, call createSession and getPostThread, and use the KV
+  Explorer to seed credentials on deploy.
 publishedAt: 2023-06-23T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - webassembly
 chapters:
   - startTime: 0
     title: Introduction
@@ -45,12 +47,15 @@ guests: []
 resources:
   - title: Bluesky API create session endpoint
     type: url
+    url: 'https://docs.bsky.app/docs/api/com-atproto-server-create-session'
     category: documentation
   - title: Bluesky API getPostThread XRPC endpoint
     type: url
+    url: 'https://docs.bsky.app/docs/api/app-bsky-feed-get-post-thread'
     category: documentation
   - title: Fermyon KV Explorer component
     type: url
+    url: 'https://github.com/fermyon/spin-kv-explorer'
     category: code
 ---
 

--- a/content/videos/standalone/2023/bluesky-embed-with-spin-webassembly.md
+++ b/content/videos/standalone/2023/bluesky-embed-with-spin-webassembly.md
@@ -5,8 +5,8 @@ title: BlueSky Embed with Spin WebAssembly
 description: >-
   Build a Bluesky post embed with Spin and WebAssembly. We wire up a Lit web
   component to a TypeScript Spin backend, handle CORS, cache auth tokens in the
-  key-value store, call createSession and getPostThread, and use the KV
-  Explorer to seed credentials on deploy.
+  key-value store, call createSession and getPostThread, and use the KV Explorer
+  to seed credentials on deploy.
 publishedAt: 2023-06-23T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/bringing-clarity-to-infrastructure-as-code-with-env0.md
+++ b/content/videos/standalone/2023/bringing-clarity-to-infrastructure-as-code-with-env0.md
@@ -3,13 +3,16 @@ id: t7zdnxgt54j4s3973zac3mjj
 slug: bringing-clarity-to-infrastructure-as-code-with-env0
 title: Bringing Clarity to Infrastructure as Code with Env0
 description: >-
-  Ever wanted to use Pulumi AND Terraform, but have some clear workflows to help
-  handle any dependencies?
+  Walk through env0 orchestrating a multi-IaC stack: Pulumi spins up a Civo
+  cluster, Terraform manages Cloudflare DNS, and CDKTF joins via workflows.
+  Covers template setup, dependencies, variable scanning, and GitLab merge
+  request plan previews.
 publishedAt: 2023-03-29T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - env0
+  - gitlab
   - pulumi
   - terraform
 chapters:
@@ -60,9 +63,11 @@ resources:
     category: code
   - title: Cloud Development Kit for Terraform (CDKTF)
     type: url
+    url: 'https://developer.hashicorp.com/terraform/cdktf'
     category: code
   - title: Cloud Development Kit for Kubernetes (cdk8s)
     type: url
+    url: 'https://cdk8s.io/'
     category: code
 ---
 

--- a/content/videos/standalone/2023/building-and-running-spin-applications-with-docker.md
+++ b/content/videos/standalone/2023/building-and-running-spin-applications-with-docker.md
@@ -3,14 +3,17 @@ id: fq72twya4m9ymyey6u0ut3qo
 slug: building-and-running-spin-applications-with-docker
 title: Building & Running Spin Applications with Docker
 description: >-
-  Since Spin 1.0, you can build and share your Spin applications as fully
-  compliant OCI images; even allowing Docker and Docker Compose to pull and run
-  them.
+  Spin 1.0 ships Spin apps as OCI artifacts. Push to GHCR with spin registry
+  push, run with spin up -f, then build a Dockerfile so docker run and docker
+  compose work, and sign the image with cosign keyless.
 publishedAt: 2023-04-27T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - docker
+  - docker-compose
+  - sigstore
 chapters:
   - startTime: 0
     title: Introduction
@@ -38,5 +41,14 @@ resources:
   - title: 'Docker documentation: Building and running Spin applications'
     type: url
     category: documentation
+    url: 'https://docs.docker.com/desktop/wasm/'
+  - title: Spin registry push and OCI artifacts
+    type: url
+    category: documentation
+    url: 'https://spinframework.dev/v3/registry-tutorial'
+  - title: Sigstore Cosign keyless signing
+    type: url
+    category: documentation
+    url: 'https://docs.sigstore.dev/cosign/signing/signing_with_blobs/'
 ---
 

--- a/content/videos/standalone/2023/building-custom-frameworks.md
+++ b/content/videos/standalone/2023/building-custom-frameworks.md
@@ -3,29 +3,35 @@ id: ts7glm4w4d8yxlmd2qnduu7q
 slug: building-custom-frameworks
 title: Building Custom Frameworks
 description: >-
-  In this video, I guide you through using Armo Cloud's custom framework
-  interface ... which is the easiest, fastest, and best way to define your
-  custom frameworks ...
+  Build a custom Kubescape framework two ways: the easy path through ARMO
+  Cloud's UI, then a local-only flow that authors controls in CUE, exports to
+  JSON, and runs Rego rules against Kubernetes manifests.
 publishedAt: 2023-01-30T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubescape
+  - opa
+  - cue
 duration: 966
 guests: []
 resources:
   - title: ARMO Cloud
     type: url
+    url: 'https://cloud.armosec.io/'
     category: other
   - title: Open Policy Agent
     type: url
-    category: code
+    url: 'https://www.openpolicyagent.org/'
+    category: documentation
   - title: Rego Playground
     type: url
+    url: 'https://play.openpolicyagent.org/'
     category: demos
   - title: CUE Language
     type: url
-    category: code
+    url: 'https://cuelang.org/'
+    category: documentation
   - title: Rawkode Academy Container Registry
     type: url
     url: 'https://ghcr.io/rawkodeacademy'

--- a/content/videos/standalone/2023/custom-controls-with-gpt.md
+++ b/content/videos/standalone/2023/custom-controls-with-gpt.md
@@ -3,14 +3,16 @@ id: wsxnftsmvohcoqr4izm8mur6
 slug: custom-controls-with-gpt
 title: Custom Controls with GPT
 description: >-
-  Rego is hard to write, but critical to writing your own Kubescape policies.
-  Can we make this easier? Armo Platform introcued GPT support to provide a text
-  based interface to making custom controls for Kubescape.
+  Armo Platform's ChatGPT integration turns plain-English prompts into Rego for
+  Kubescape custom controls. We build a "no latest tag" rule, then a
+  CAP_SYS_ADMIN deny, debug the generated policy in the Rego Playground, and run
+  it with `kubescape scan control --use-from`.
 publishedAt: 2023-03-30T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubescape
+  - opa
 chapters:
   - startTime: 0
     title: 'Introduction: ChatGPT, Kubescape, and the Rego Challenge'

--- a/content/videos/standalone/2023/dynamic-scrape-targets.md
+++ b/content/videos/standalone/2023/dynamic-scrape-targets.md
@@ -51,7 +51,8 @@ resources:
   - type: url
     title: Prometheus Kubernetes service discovery
     category: documentation
-    url: 'https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+    url: >-
+      https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
   - type: url
     title: InfluxDB 2 pprof endpoint
     category: documentation

--- a/content/videos/standalone/2023/dynamic-scrape-targets.md
+++ b/content/videos/standalone/2023/dynamic-scrape-targets.md
@@ -3,14 +3,17 @@ id: hmi73u4rxevdc9jb39tu1lxq
 slug: dynamic-scrape-targets
 title: Dynamic Scrape Targets
 description: >-
-  Parca provides first-class support for scraping your profile data from any
-  compatible pprof endpoint, so let's take a look at configuring our Parca
-  server to do just that.
+  Configure the Parca config map with a Prometheus-style scrape job that uses
+  Kubernetes service discovery, keeps pods by parca.dev annotations, and adds
+  the cluster role binding needed to scrape an InfluxDB 2 pprof endpoint.
 publishedAt: 2023-07-11T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - parca
+  - kubernetes
+  - prometheus
+  - influxdb
 chapters:
   - startTime: 0
     title: Introduction
@@ -40,6 +43,18 @@ chapters:
     title: Summary and Conclusion
 duration: 610
 guests: []
-resources: []
+resources:
+  - type: url
+    title: Parca scrape configuration documentation
+    category: documentation
+    url: 'https://www.parca.dev/docs/'
+  - type: url
+    title: Prometheus Kubernetes service discovery
+    category: documentation
+    url: 'https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+  - type: url
+    title: InfluxDB 2 pprof endpoint
+    category: documentation
+    url: 'https://docs.influxdata.com/influxdb/v2/'
 ---
 

--- a/content/videos/standalone/2023/empowering-eks-cluster-deployments-and-gitops-with-portainers-simplified-workflow.md
+++ b/content/videos/standalone/2023/empowering-eks-cluster-deployments-and-gitops-with-portainers-simplified-workflow.md
@@ -6,14 +6,15 @@ title: >-
   Empowering EKS Cluster Deployments and GitOps with Portainer's Simplified
   Workflow
 description: >-
-  Today, we'll be diving into the world of Kubernetes and GitOps, specifically
-  focusing on how Portainer simplifies the process of creating an EKS cluster
-  and adopting GitOps practices.
+  Provision an AWS EKS cluster from the Portainer UI, deploy the Google Cloud
+  Platform microservices demo via a Git manifest, then hit the cluster with
+  Portainer's in-browser kubectl shell, all in under ten minutes.
 publishedAt: 2023-08-24T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - portainer
+  - kubernetes
 chapters:
   - startTime: 0
     title: Portainer is TOO Easy
@@ -42,6 +43,7 @@ guests: []
 resources:
   - title: Google Cloud Platform microservice demo
     type: url
+    url: 'https://github.com/GoogleCloudPlatform/microservices-demo'
     category: demos
 ---
 

--- a/content/videos/standalone/2023/go-sdk.md
+++ b/content/videos/standalone/2023/go-sdk.md
@@ -3,8 +3,9 @@ id: xf99ugju3sc16q7f4iw3llv8
 slug: go-sdk
 title: Go SDK
 description: >-
-  In this video, we explore all the common tasks you'll need to accomplish with
-  Fermyon's Spin Go SDK.
+  Walk through the Spin Go SDK by writing an HTTP handler, reading request
+  headers, body, and query parameters, then making outbound HTTP requests and
+  allowlisting hosts in spin.toml.
 publishedAt: 2023-01-31T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/have-you-ever-seen-a-production-grade-server-side-webassembly-application.md
+++ b/content/videos/standalone/2023/have-you-ever-seen-a-production-grade-server-side-webassembly-application.md
@@ -3,14 +3,15 @@ id: k42oh0xm4308e1k5b12vzy8q
 slug: have-you-ever-seen-a-production-grade-server-side-webassembly-application
 title: 'Have You Ever Seen a Production Grade, Server Side, WebAssembly Application?'
 description: >-
-  Join us for the live stream where we explore the code base and add a new
-  feature to a production grade server side #WebAssembly application with
-  #Fermyon Spin
+  Justin, a senior solutions engineer at Fermyon, built his own social network
+  on Spin. Join us as we explore the codebase, add a new feature, and talk
+  about writing real-world production-grade server-side WebAssembly with Spin.
 publishedAt: 2023-02-24T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - webassembly
 chapters:
   - startTime: 0
     title: 'Introduction: The Rarity of Production Server-Side Wasm'

--- a/content/videos/standalone/2023/have-you-ever-seen-a-production-grade-server-side-webassembly-application.md
+++ b/content/videos/standalone/2023/have-you-ever-seen-a-production-grade-server-side-webassembly-application.md
@@ -4,8 +4,8 @@ slug: have-you-ever-seen-a-production-grade-server-side-webassembly-application
 title: 'Have You Ever Seen a Production Grade, Server Side, WebAssembly Application?'
 description: >-
   Justin, a senior solutions engineer at Fermyon, built his own social network
-  on Spin. Join us as we explore the codebase, add a new feature, and talk
-  about writing real-world production-grade server-side WebAssembly with Spin.
+  on Spin. Join us as we explore the codebase, add a new feature, and talk about
+  writing real-world production-grade server-side WebAssembly with Spin.
 publishedAt: 2023-02-24T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/helm-kustomize-and-pod-security-policies.md
+++ b/content/videos/standalone/2023/helm-kustomize-and-pod-security-policies.md
@@ -3,13 +3,17 @@ id: k5xzx8dfmvu7s3nzdqy32kzy
 slug: helm-kustomize-and-pod-security-policies
 title: 'Helm, Kustomize, and Pod Security Policies'
 description: >-
-  In this session, David guides you through installing Portainer to a Kubernetes
-  cluster with Helm and Kustomize.
+  Install Portainer on Kubernetes two ways (helm upgrade --install and kubectl
+  -k with Kustomize), then use Portainer's UI to enable pod security constraints
+  backed by an auto-installed Gatekeeper.
 publishedAt: 2023-03-14T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - portainer
+  - helm
+  - kubernetes
+  - opa
 chapters:
   - startTime: 0
     title: Introduction
@@ -60,6 +64,11 @@ resources:
     category: code
   - title: Kustomize documentation
     type: url
+    url: 'https://kubectl.docs.kubernetes.io/references/kustomize/'
     category: documentation
+  - title: Portainer Helm chart values.yaml
+    type: url
+    url: 'https://github.com/portainer/k8s/blob/master/charts/portainer/values.yaml'
+    category: code
 ---
 

--- a/content/videos/standalone/2023/improve-your-supply-chain-security-pipeline-with-scribe-security.md
+++ b/content/videos/standalone/2023/improve-your-supply-chain-security-pipeline-with-scribe-security.md
@@ -3,9 +3,9 @@ id: ad51s1b7h8fhtsexscspmy3x
 slug: improve-your-supply-chain-security-pipeline-with-scribe-security
 title: Improve Your Supply Chain Security Pipeline with Scribe Security
 description: >-
-  Walkthrough of Scribe Security's free tier, scanning a forked Directus
-  project to review SLSA compliance, vulnerabilities, the SBOM and licenses,
-  then wiring it up via GitHub Actions in under 55 lines of YAML.
+  Walkthrough of Scribe Security's free tier, scanning a forked Directus project
+  to review SLSA compliance, vulnerabilities, the SBOM and licenses, then wiring
+  it up via GitHub Actions in under 55 lines of YAML.
 publishedAt: 2023-04-19T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -40,19 +40,19 @@ guests: []
 resources:
   - title: SLSA Framework
     type: url
-    url: https://slsa.dev/
+    url: 'https://slsa.dev/'
     category: documentation
   - title: Directus Headless CMS
     type: url
-    url: https://github.com/directus/directus
+    url: 'https://github.com/directus/directus'
     category: code
   - title: NIST Secure Software Development Framework (SSDF)
     type: url
-    url: https://csrc.nist.gov/Projects/ssdf
+    url: 'https://csrc.nist.gov/Projects/ssdf'
     category: documentation
   - title: Scribe Security Action BOM
     type: url
-    url: https://github.com/scribe-security/action-bom
+    url: 'https://github.com/scribe-security/action-bom'
     category: code
 ---
 

--- a/content/videos/standalone/2023/improve-your-supply-chain-security-pipeline-with-scribe-security.md
+++ b/content/videos/standalone/2023/improve-your-supply-chain-security-pipeline-with-scribe-security.md
@@ -3,9 +3,9 @@ id: ad51s1b7h8fhtsexscspmy3x
 slug: improve-your-supply-chain-security-pipeline-with-scribe-security
 title: Improve Your Supply Chain Security Pipeline with Scribe Security
 description: >-
-  In this video, I explore the FREE plan on ScribeSecurity; a platform that
-  wants to increase awareness and visibility into your supply chain security
-  pipeline.
+  Walkthrough of Scribe Security's free tier, scanning a forked Directus
+  project to review SLSA compliance, vulnerabilities, the SBOM and licenses,
+  then wiring it up via GitHub Actions in under 55 lines of YAML.
 publishedAt: 2023-04-19T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -38,17 +38,21 @@ chapters:
 duration: 634
 guests: []
 resources:
-  - title: SLSA (Salsa) Framework
+  - title: SLSA Framework
     type: url
+    url: https://slsa.dev/
     category: documentation
   - title: Directus Headless CMS
     type: url
+    url: https://github.com/directus/directus
     category: code
   - title: NIST Secure Software Development Framework (SSDF)
     type: url
+    url: https://csrc.nist.gov/Projects/ssdf
     category: documentation
   - title: Scribe Security Action BOM
     type: url
+    url: https://github.com/scribe-security/action-bom
     category: code
 ---
 

--- a/content/videos/standalone/2023/integrating-spin-with-static-site-generators-ssgs.md
+++ b/content/videos/standalone/2023/integrating-spin-with-static-site-generators-ssgs.md
@@ -3,14 +3,16 @@ id: bwo73aoo2k6ae9lrukcj6onr
 slug: integrating-spin-with-static-site-generators-ssgs
 title: Integrating Spin with Static Site Generators (SSGs)
 description: >-
-  Fermyon's Spin allows you to integrate with your existing frontend-frameworks,
-  such as React, Svelte, Remix, NextJS, Astro, and Gatsby; by allowing you to
-  integrate their build command into the spin build pipeline.
+  Builds a multi-component Spin app, a JavaScript backend that calls OpenAI to
+  detect languages plus a static frontend, then swaps the vanilla HTML for an
+  Astro build to show how any SSG that produces a dist directory can be served
+  by Spin's static file server.
 publishedAt: 2023-06-07T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - webassembly
 chapters:
   - startTime: 0
     title: Introduction and Project Overview
@@ -49,9 +51,11 @@ guests: []
 resources:
   - title: Spin file server repository
     type: url
+    url: 'https://github.com/spinframework/spin-fileserver'
     category: code
   - title: Astro website creation CLI
     type: url
+    url: 'https://docs.astro.build/en/install-and-setup/'
     category: documentation
 ---
 

--- a/content/videos/standalone/2023/introduction-and-overview-of-parca-for-continuous-profiling.md
+++ b/content/videos/standalone/2023/introduction-and-overview-of-parca-for-continuous-profiling.md
@@ -3,14 +3,16 @@ id: pixbg0khkdubmvl7ydy78v5y
 slug: introduction-and-overview-of-parca-for-continuous-profiling
 title: Introduction & Overview of Parca for Continuous Profiling
 description: >-
-  Want to understand the performance of your application, considering both your
-  own code and third-party dependencies? Let's me introduce you to Parca, the
-  open-source Continuous Profiling tool from the company, Polar Signals.
+  Diagnose a runaway CPU spike on Kubernetes with Parca, the open-source
+  continuous profiler from Polar Signals. Deploy the server and eBPF agent,
+  explore icicle graphs and pprof profiles, and pinpoint the offending code.
 publishedAt: 2023-06-05T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - parca
+  - ebpf
+  - kubernetes
 chapters:
   - startTime: 0
     title: Introduction
@@ -79,6 +81,7 @@ guests: []
 resources:
   - title: Parca Quickstart Guide
     type: url
+    url: 'https://www.parca.dev/docs/quickstart/'
     category: documentation
 ---
 

--- a/content/videos/standalone/2023/keep-authentication-simple-with-portainers-oauth-connectors.md
+++ b/content/videos/standalone/2023/keep-authentication-simple-with-portainers-oauth-connectors.md
@@ -2,7 +2,11 @@
 id: aqzmvsr41szkg2uqg0yp2cu4
 slug: keep-authentication-simple-with-portainers-oauth-connectors
 title: Keep Authentication Simple with Portainers OAuth Connectors
-description: Swap Portainer's local user management for single sign-on. Walk through configuring OAuth with GitHub and Google, registering client IDs and secrets, pre-adding users, and keeping internal login as a fallback when settings go wrong.
+description: >-
+  Swap Portainer's local user management for single sign-on. Walk through
+  configuring OAuth with GitHub and Google, registering client IDs and secrets,
+  pre-adding users, and keeping internal login as a fallback when settings go
+  wrong.
 publishedAt: 2023-03-06T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/keep-authentication-simple-with-portainers-oauth-connectors.md
+++ b/content/videos/standalone/2023/keep-authentication-simple-with-portainers-oauth-connectors.md
@@ -2,7 +2,7 @@
 id: aqzmvsr41szkg2uqg0yp2cu4
 slug: keep-authentication-simple-with-portainers-oauth-connectors
 title: Keep Authentication Simple with Portainers OAuth Connectors
-description: Video content coming soon.
+description: Swap Portainer's local user management for single sign-on. Walk through configuring OAuth with GitHub and Google, registering client IDs and secrets, pre-adding users, and keeping internal login as a fallback when settings go wrong.
 publishedAt: 2023-03-06T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -50,9 +50,15 @@ guests: []
 resources:
   - title: GitHub OAuth Apps settings
     type: url
-    category: other
+    url: 'https://github.com/settings/developers'
+    category: documentation
   - title: Google Cloud API and Services Credentials
     type: url
-    category: other
+    url: 'https://console.cloud.google.com/apis/credentials'
+    category: documentation
+  - title: Portainer OAuth authentication documentation
+    type: url
+    url: 'https://docs.portainer.io/admin/settings/authentication/oauth'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2023/komodor-vs-klustered.md
+++ b/content/videos/standalone/2023/komodor-vs-klustered.md
@@ -3,12 +3,16 @@ id: dcjov47ebu5lv9zvbe787zpj
 slug: komodor-vs-klustered
 title: Komodor Vs. Klustered
 description: >-
-  A team from Komodor take on the Klustered challenge; can they fix a
-  maliciously broken Kubernetes cluster with only their own tool?
+  Komodor's CTO and engineers debug a maliciously broken Kubernetes cluster
+  live, using their timeline to track down Cilium CNI RBAC, Flux GitOps
+  reconciliation, and a NetworkPolicy blocking Drupal from Postgres.
 publishedAt: 2023-12-13T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
+  - cilium
+  - fluxcd
+  - helm
   - komodor
   - kubernetes
 chapters:

--- a/content/videos/standalone/2023/making-kubernetes-network-policies-effortless-with-otterize.md
+++ b/content/videos/standalone/2023/making-kubernetes-network-policies-effortless-with-otterize.md
@@ -3,13 +3,16 @@ id: wijy1wsp03lfq5mjrhjvtwm0
 slug: making-kubernetes-network-policies-effortless-with-otterize
 title: Making Kubernetes Network Policies Effortless with Otterize
 description: >-
-  Why make things complicated when they can be simple? Otterize is all about
-  making your life easier.
+  Otterize replaces hand-written Kubernetes NetworkPolicies with intent-based
+  access control: developers declare which services they call in ClientIntents
+  CRs, and the operator generates the policies. Demoed on Weaveworks Sock Shop,
+  with Otterize Cloud's access graph.
 publishedAt: 2023-11-29T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - otterize
+  - kubernetes
 chapters:
   - startTime: 0
     title: Introduction
@@ -82,12 +85,15 @@ guests: []
 resources:
   - title: Otterize iBack page
     type: url
+    url: 'https://docs.otterize.com/'
     category: documentation
   - title: Otterize HelmChart repository
     type: url
+    url: 'https://github.com/otterize/helm-charts'
     category: code
   - title: Weaveworks Sockshop demo
     type: url
+    url: 'https://github.com/microservices-demo/microservices-demo'
     category: demos
 ---
 

--- a/content/videos/standalone/2023/monitoring-your-security-posture-with-prometheus.md
+++ b/content/videos/standalone/2023/monitoring-your-security-posture-with-prometheus.md
@@ -2,12 +2,17 @@
 id: cvahj7nb3ypukon4fm4mreaa
 slug: monitoring-your-security-posture-with-prometheus
 title: Monitoring Your Security Posture with Prometheus
-description: Video content coming soon.
+description: >-
+  Run Kubescape as an in-cluster operator, scrape its Prometheus metrics via a
+  ServiceMonitor, and import the Grafana dashboard to track cluster risk score,
+  framework failures, and control violations as your security posture changes.
 publishedAt: 2023-01-31T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubescape
+  - prometheus
+  - grafana
 chapters:
   - startTime: 0
     title: Introduction and Overview
@@ -56,6 +61,7 @@ resources:
     category: other
   - title: Kubescape Grafana Dashboard
     type: url
+    url: 'https://github.com/kubescape/prometheus-exporter/tree/main/dashboards'
     category: other
 ---
 

--- a/content/videos/standalone/2023/ngroks-kubernetes-ingress-controller-is-amazing-2.md
+++ b/content/videos/standalone/2023/ngroks-kubernetes-ingress-controller-is-amazing-2.md
@@ -3,14 +3,17 @@ id: m8xeaa8bqd2gszto4g6j9xku
 slug: ngroks-kubernetes-ingress-controller-is-amazing-2
 title: ngrok's Kubernetes Ingress Controller is AMAZING
 description: >-
-  ngrok is the fastest way to host and secure your applications and services on
-  the internet. Learn how by following our getting started guide, or dive
-  straight into our products and offerings.
+  Walks through ngrok's Kubernetes Ingress Controller as an alternative to a
+  cloud load balancer on EKS. Installs the controller via Helm, exposes a
+  service through an Ingress, then layers on Google OAuth using an ngrok module
+  set CRD.
 publishedAt: 2023-09-22T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - ngrok
+  - kubernetes
+  - helm
 chapters:
   - startTime: 0
     title: Introduction
@@ -45,9 +48,9 @@ chapters:
 duration: 485
 guests: []
 resources:
-  - title: ngrok/kubernetes-ngrok-controller
+  - title: ngrok/kubernetes-ingress-controller
     type: url
-    url: 'https://github.com/ngrok/kubernetes-ngrok-controller'
+    url: 'https://github.com/ngrok/kubernetes-ingress-controller'
     category: code
   - title: ngrok Kubernetes Ingress Controller release blog
     type: url

--- a/content/videos/standalone/2023/nodejs-sdk-typescript.md
+++ b/content/videos/standalone/2023/nodejs-sdk-typescript.md
@@ -3,8 +3,9 @@ id: krr31oe2upl14q4rc7qufyls
 slug: nodejs-sdk-typescript
 title: NodeJS SDK (TypeScript)
 description: >-
-  In this video, we explore all the common tasks you'll need to accomplish with
-  Fermyon's Spin NodeJS SDK with TypeScript.
+  A walkthrough of Fermyon Spin's Node.js SDK in TypeScript: handling request
+  headers, ArrayBuffer bodies, JSON parsing with Zod for runtime safety, query
+  strings via qs, outbound fetch, and configuring allowed_outbound_hosts.
 publishedAt: 2023-02-02T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -39,6 +40,22 @@ chapters:
     title: Conclusion and Summary
 duration: 1103
 guests: []
-resources: []
+resources:
+  - type: url
+    title: Spin JavaScript/TypeScript components
+    category: documentation
+    url: 'https://spinframework.dev/v3/javascript-components'
+  - type: url
+    title: Spin outbound HTTP
+    category: documentation
+    url: 'https://spinframework.dev/v3/http-outbound'
+  - type: url
+    title: Zod
+    category: documentation
+    url: 'https://zod.dev/'
+  - type: url
+    title: qs query string parser
+    category: code
+    url: 'https://github.com/ljharb/qs'
 ---
 

--- a/content/videos/standalone/2023/parca-and-grafana.md
+++ b/content/videos/standalone/2023/parca-and-grafana.md
@@ -3,9 +3,9 @@ id: nl7ui50173lbqlmqxck2mw3q
 slug: parca-and-grafana
 title: Parca & Grafana
 description: >-
-  Add the Grafana Parca data source plugin, point it at your Parca server,
-  and debug a misbehaving app with flame graphs and function filters without
-  leaving Grafana.
+  Add the Grafana Parca data source plugin, point it at your Parca server, and
+  debug a misbehaving app with flame graphs and function filters without leaving
+  Grafana.
 publishedAt: 2023-07-10T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/parca-and-grafana.md
+++ b/content/videos/standalone/2023/parca-and-grafana.md
@@ -3,8 +3,9 @@ id: nl7ui50173lbqlmqxck2mw3q
 slug: parca-and-grafana
 title: Parca & Grafana
 description: >-
-  Learn how to bake your Parca profiling information into Grafana to provide a
-  single pane of glass for all your observability data.
+  Add the Grafana Parca data source plugin, point it at your Parca server,
+  and debug a misbehaving app with flame graphs and function filters without
+  leaving Grafana.
 publishedAt: 2023-07-10T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -51,8 +52,9 @@ chapters:
 duration: 561
 guests: []
 resources:
-  - title: Grafana Parca plugin
+  - title: Grafana Parca data source documentation
     type: url
-    category: other
+    url: 'https://grafana.com/docs/grafana/latest/datasources/parca/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2023/podmansh-and-infisical.md
+++ b/content/videos/standalone/2023/podmansh-and-infisical.md
@@ -2,7 +2,7 @@
 id: cpyas1mgays442brvl0fdi77
 slug: podmansh-and-infisical
 title: podmansh & Infisical
-description: 'In this episode of AlphaBits, Brian and David demo podmansh and Infisical.'
+description: 'Brian demos podmansh, using Podman containers as Linux login shells configured via Quadlet systemd units with three isolation levels. David demos Infisical for secrets management, with CLI injection, GitHub sync, folder scoping, and SDKs.'
 publishedAt: 2023-08-10T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -58,6 +58,11 @@ guests:
 resources:
   - title: podmansh man page
     type: url
+    url: 'https://docs.podman.io/en/latest/markdown/podmansh.1.html'
+    category: documentation
+  - title: Infisical documentation
+    type: url
+    url: 'https://infisical.com/docs'
     category: documentation
 ---
 

--- a/content/videos/standalone/2023/podmansh-and-infisical.md
+++ b/content/videos/standalone/2023/podmansh-and-infisical.md
@@ -2,7 +2,11 @@
 id: cpyas1mgays442brvl0fdi77
 slug: podmansh-and-infisical
 title: podmansh & Infisical
-description: 'Brian demos podmansh, using Podman containers as Linux login shells configured via Quadlet systemd units with three isolation levels. David demos Infisical for secrets management, with CLI injection, GitHub sync, folder scoping, and SDKs.'
+description: >-
+  Brian demos podmansh, using Podman containers as Linux login shells configured
+  via Quadlet systemd units with three isolation levels. David demos Infisical
+  for secrets management, with CLI injection, GitHub sync, folder scoping, and
+  SDKs.
 publishedAt: 2023-08-10T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/rust-sdk-walkthrough.md
+++ b/content/videos/standalone/2023/rust-sdk-walkthrough.md
@@ -3,13 +3,15 @@ id: ryc93p7fu30bh4kkv3ru71nk
 slug: rust-sdk-walkthrough
 title: Rust SDK Walkthrough
 description: >-
-  In this video, we explore all the common tasks you'll need to accomplish with
-  Fermyon's Spin Rust SDK.
+  A hands-on tour of Spin's Rust SDK: writing and routing an HTTP component,
+  reading headers, decoding the request body, parsing query strings, and making
+  outbound HTTP requests with allowed-domain configuration in spin.toml.
 publishedAt: 2023-01-27T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - rust
 chapters:
   - startTime: 0
     title: Introduction
@@ -30,8 +32,9 @@ chapters:
 duration: 806
 guests: []
 resources:
-  - title: Fermion Discord
+  - title: Fermyon Discord
     type: url
+    url: 'https://www.fermyon.com/discord'
     category: other
 ---
 

--- a/content/videos/standalone/2023/secure-container-images-the-easy-way.md
+++ b/content/videos/standalone/2023/secure-container-images-the-easy-way.md
@@ -3,18 +3,10 @@ id: diok2rek56nt6nq7z3839qei
 slug: secure-container-images-the-easy-way
 title: Secure Container Images The EASY Way
 description: >-
-  Do you want smaller and more secure container images?
-
-
-  In this video, we take a look at Slim Toolkit - an open source application
-  that can handle sophisticated probing of your original container image to
-  understand the required files, and slims it ALL THE WAY DOWN to the minimum.
-
-
-  Container image reductions of 10x, 50x, and even 500x are entirely possible.
-
-
-  Let's see how
+  Slim Toolkit probes a running container with HTTP or exec probes to learn
+  which files the workload actually uses, then rebuilds a minimal image.
+  Demos shrink NGINX from 33MB to 12MB, a Rust dog image from 97MB to under
+  10MB, and an unoptimised Astro build from 1.4GB to 100MB.
 publishedAt: 2023-04-25T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -38,12 +30,15 @@ guests: []
 resources:
   - title: dog DNS lookup project
     type: url
+    url: 'https://github.com/ogham/dog'
     category: code
   - title: Astro Dockerfile documentation
     type: url
+    url: 'https://docs.astro.build/en/recipes/docker/'
     category: documentation
   - title: Rawkode Academy website
     type: url
+    url: 'https://rawkode.academy'
     category: demos
 ---
 

--- a/content/videos/standalone/2023/secure-container-images-the-easy-way.md
+++ b/content/videos/standalone/2023/secure-container-images-the-easy-way.md
@@ -4,9 +4,9 @@ slug: secure-container-images-the-easy-way
 title: Secure Container Images The EASY Way
 description: >-
   Slim Toolkit probes a running container with HTTP or exec probes to learn
-  which files the workload actually uses, then rebuilds a minimal image.
-  Demos shrink NGINX from 33MB to 12MB, a Rust dog image from 97MB to under
-  10MB, and an unoptimised Astro build from 1.4GB to 100MB.
+  which files the workload actually uses, then rebuilds a minimal image. Demos
+  shrink NGINX from 33MB to 12MB, a Rust dog image from 97MB to under 10MB, and
+  an unoptimised Astro build from 1.4GB to 100MB.
 publishedAt: 2023-04-25T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/sentry-prometheus-and-grafana-integrations.md
+++ b/content/videos/standalone/2023/sentry-prometheus-and-grafana-integrations.md
@@ -2,7 +2,10 @@
 id: idafk86yfg7uq201z7v4p0wv
 slug: sentry-prometheus-and-grafana-integrations
 title: 'Sentry, Prometheus, & Grafana Integrations'
-description: 'Part 2 of the Komodor tutorial: wire Sentry, Prometheus Alertmanager, and Grafana alerting into Komodor so application exceptions and cluster alerts appear alongside Kubernetes events in the troubleshooting timeline.'
+description: >-
+  Part 2 of the Komodor tutorial: wire Sentry, Prometheus Alertmanager, and
+  Grafana alerting into Komodor so application exceptions and cluster alerts
+  appear alongside Kubernetes events in the troubleshooting timeline.
 publishedAt: 2023-02-14T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/sentry-prometheus-and-grafana-integrations.md
+++ b/content/videos/standalone/2023/sentry-prometheus-and-grafana-integrations.md
@@ -2,12 +2,14 @@
 id: idafk86yfg7uq201z7v4p0wv
 slug: sentry-prometheus-and-grafana-integrations
 title: 'Sentry, Prometheus, & Grafana Integrations'
-description: "Turn hours of K8s management & troubleshooting into minutes. Trusted by Ops \U0001F609 Loved by Devs ❤️"
+description: 'Part 2 of the Komodor tutorial: wire Sentry, Prometheus Alertmanager, and Grafana alerting into Komodor so application exceptions and cluster alerts appear alongside Kubernetes events in the troubleshooting timeline.'
 publishedAt: 2023-02-14T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - komodor
+  - prometheus
+  - grafana
 chapters:
   - startTime: 5
     title: Introduction
@@ -43,13 +45,21 @@ resources:
     type: url
     url: 'https://github.com/prometheus-operator/kube-prometheus'
     category: code
+  - title: Komodor Sentry integration docs
+    type: url
+    url: 'https://docs.komodor.com/'
+    category: documentation
   - title: Sentry
     type: url
-    url: 'https://sentry.io'
+    url: 'https://sentry.io/'
     category: other
   - title: Grafana
     type: url
-    url: 'https://grafana.com'
+    url: 'https://grafana.com/'
     category: other
+  - title: Prometheus Alertmanager
+    type: url
+    url: 'https://prometheus.io/docs/alerting/latest/alertmanager/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2023/server-side-webassembly-at-the-edge.md
+++ b/content/videos/standalone/2023/server-side-webassembly-at-the-edge.md
@@ -3,15 +3,15 @@ id: pg8dyt42vac1gmldqsjnkswg
 slug: server-side-webassembly-at-the-edge
 title: Server Side WebAssembly at the Edge
 description: >-
-  In this video, I'll show you how to get started with the Fermyon Platform. A
-  Collection of Open Source components that allows you to run your own
-  server-side WASM binaries on Equinix Metal with low-latency routing, using
-  BGP.
+  Deploying the Fermyon Platform to Equinix Metal with Terraform, using BGP
+  anycast across Dallas and Amsterdam to route Spin WebAssembly applications to
+  the nearest metro for low-latency edge serving.
 publishedAt: 2023-03-07T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - terraform
 chapters:
   - startTime: 61
     title: Introduction and Episode Goal
@@ -108,17 +108,17 @@ chapters:
 duration: 3073
 guests: []
 resources:
-  - title: Fermion Installer
+  - title: Fermyon Installer
     type: url
-    url: 'https://github.com/fermion/installer'
+    url: 'https://github.com/fermyon/installer'
     category: code
   - title: Deis Labs Hippo
     type: url
     url: 'https://github.com/deislabs/hippo'
     category: code
-  - title: Deis Labs Bundle
+  - title: Deis Labs Bindle
     type: url
-    url: 'https://github.com/deislabs/bundle'
+    url: 'https://github.com/deislabs/bindle'
     category: code
 ---
 

--- a/content/videos/standalone/2023/stateful-webassembly-apps-with-key-value-stores.md
+++ b/content/videos/standalone/2023/stateful-webassembly-apps-with-key-value-stores.md
@@ -10,6 +10,8 @@ type: recorded
 category: tutorial
 technologies:
   - spin
+  - rust
+  - webassembly
 chapters:
   - startTime: 0
     title: Introduction
@@ -36,6 +38,7 @@ resources:
     category: other
   - title: Fermyon URL shortener example
     type: url
+    url: 'https://spinframework.dev/v2/url-shortener-tutorial'
     category: documentation
 ---
 

--- a/content/videos/standalone/2023/supply-chain-security-with-a-cli-valint.md
+++ b/content/videos/standalone/2023/supply-chain-security-with-a-cli-valint.md
@@ -3,13 +3,15 @@ id: ncgxuu1vyx5yl7psezcz79dk
 slug: supply-chain-security-with-a-cli-valint
 title: 'Supply Chain Security with a CLI: valint'
 description: >-
-  Valint is a powerful tool that validates the integrity of your supply chain,
-  providing organizations with a way to enforce policies using the Scribe
-  Service, CI, or admission controller.
+  Tutorial on Valint, Scribe Security's supply chain CLI. Generate SLSA and
+  CycloneDX SBOMs for containers, Git repos, and Go projects, sign evidence with
+  Sigstore, push to OCI registries, and enforce cosign policies locally, in CI,
+  or as a Kubernetes admission controller.
 publishedAt: 2023-05-22T17:00:00.000Z
 type: recorded
 category: tutorial
-technologies: []
+technologies:
+  - sigstore
 chapters:
   - startTime: 0
     title: Introduction
@@ -46,20 +48,21 @@ guests: []
 resources:
   - title: Valint Installation Script
     type: url
-    url: 'https://get.scrapesecurity.com/install.sh'
     category: code
   - title: Scribe Security JFrog Container Registry
     type: url
     category: other
   - title: Indigo (Blue Sky Go SDK)
     type: url
+    url: 'https://github.com/bluesky-social/indigo'
     category: code
   - title: Mongo Express
     type: url
+    url: 'https://github.com/mongo-express/mongo-express'
     category: code
   - title: Sigstore
     type: url
-    url: 'https://sigstore.dev'
+    url: 'https://www.sigstore.dev/'
     category: other
 ---
 

--- a/content/videos/standalone/2023/testing-a-3-tier-application-with-daggers-go-sdk.md
+++ b/content/videos/standalone/2023/testing-a-3-tier-application-with-daggers-go-sdk.md
@@ -3,13 +3,15 @@ id: v32afbzo0mzowipaa30orbtz
 slug: testing-a-3-tier-application-with-daggers-go-sdk
 title: Testing a 3-Tier Application with Dagger's Go SDK
 description: >-
-  In this video, I walk through how to get started with Dagger's Go SDK to build
-  and test a 3-tier application with Dagger, the future of CICD.
+  Build and test a Go backend, JavaScript frontend, and Postgres database using
+  Dagger's Go SDK. Covers composable pipelines, secret redaction, dependent
+  service containers, and running a Hurl test harness locally and in CI.
 publishedAt: 2023-05-25T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - dagger
+  - postgresql
 chapters:
   - startTime: 0
     title: Local Dev & Test without Dagger

--- a/content/videos/standalone/2023/universal-blue-and-system-initiative.md
+++ b/content/videos/standalone/2023/universal-blue-and-system-initiative.md
@@ -3,13 +3,16 @@ id: jc8t4h91wok4bgq10t1s3fiv
 slug: universal-blue-and-system-initiative
 title: Universal Blue & System Initiative
 description: >-
-  In the first episode of AlphaBits, Brian and David explain why they're excited
-  about Universal Blue and System Intiative.
+  Brian shows his daily-driver Bluefin desktop, a Universal Blue image with
+  rpm-ostree rollbacks, Distrobox, Nix and Flatpak baked in. David then demos
+  System Initiative orchestrated via Tilt, dragging AWS resources onto a canvas
+  to model and deploy an EC2 stack live.
 publishedAt: 2023-08-03T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - system-initiative
+  - tilt
   - universal-blue
 chapters:
   - startTime: 0

--- a/content/videos/standalone/2023/wei-pull-and-tea-xyz.md
+++ b/content/videos/standalone/2023/wei-pull-and-tea-xyz.md
@@ -49,11 +49,11 @@ guests:
   - brian-ketelsen
 resources:
   - type: url
-    name: wei/pull
+    title: wei/pull
     category: code
     url: 'https://github.com/wei/pull'
   - type: url
-    name: pkgx (formerly tea.xyz)
+    title: pkgx (formerly tea.xyz)
     category: documentation
     url: 'https://pkgx.sh/'
 ---

--- a/content/videos/standalone/2023/wei-pull-and-tea-xyz.md
+++ b/content/videos/standalone/2023/wei-pull-and-tea-xyz.md
@@ -3,8 +3,9 @@ id: n9usdizv6skyhuv5603ivcuh
 slug: wei-pull-and-tea-xyz
 title: wei/pull and tea.xyz
 description: >-
-  In this episode of AlphaBits, Brian and David explain why they're excited
-  about wei/pull and tea.xyz.
+  Brian demos wei/pull, a GitHub app that auto-opens pull requests to keep forks
+  in sync with upstream. David then walks through tea.xyz (now pkgx), running
+  uninstalled commands, symlink shims, and resolving deps from README or t.yaml.
 publishedAt: 2023-08-24T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -46,6 +47,14 @@ chapters:
 duration: 781
 guests:
   - brian-ketelsen
-resources: []
+resources:
+  - type: url
+    name: wei/pull
+    category: code
+    url: 'https://github.com/wei/pull'
+  - type: url
+    name: pkgx (formerly tea.xyz)
+    category: documentation
+    url: 'https://pkgx.sh/'
 ---
 

--- a/content/videos/standalone/2023/whats-new-with-spin-v0-8.md
+++ b/content/videos/standalone/2023/whats-new-with-spin-v0-8.md
@@ -3,9 +3,9 @@ id: asn46r4vc2cye6ihgp2zamoh
 slug: whats-new-with-spin-v0-8
 title: What's New with Spin (v0.8)
 description: >-
-  Spin, from @fermyontech (The #WebAssembly) framework released v0.8 this week
-  (Feb 2023) and ships with some fantastic quality of life improvements. Learn
-  more about Spin at https://github.com/fermyon/spin
+  A tour of Spin 0.8: the Itty-style JavaScript router for multi-path
+  components, TLS support for outbound Postgres and MySQL connections, and
+  first-class OCI registry push, sign with cosign, and verify workflows.
 publishedAt: 2023-02-21T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2023/why-webassembly-code-once-run-everywhere.md
+++ b/content/videos/standalone/2023/why-webassembly-code-once-run-everywhere.md
@@ -3,13 +3,16 @@ id: tpw7gzgjwcw3wwnx4wh7ot7c
 slug: why-webassembly-code-once-run-everywhere
 title: 'Why WebAssembly? Code Once, Run Everywhere'
 description: >-
-  Spin is a framework for building, deploying, and running fast, secure, and
-  composable cloud microservices with WebAssembly.
+  Kicking off the Fermyon Spin course with the why of WebAssembly. A Rust
+  password validator becomes a shared domain crate consumed by a Spin HTTP
+  backend and a JavaScript frontend, both compiled to Wasm.
 publishedAt: 2023-01-23T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - webassembly
+  - rust
 chapters:
   - startTime: 0
     title: Introduction to Course & Topic

--- a/content/videos/standalone/2023/writing-server-side-webassembly-with-python.md
+++ b/content/videos/standalone/2023/writing-server-side-webassembly-with-python.md
@@ -3,8 +3,10 @@ id: p795mbb7u556q13aap1d4m1j
 slug: writing-server-side-webassembly-with-python
 title: Writing Server Side WebAssembly with Python
 description: >-
-  In this video, we explore all the common tasks you'll need to accomplish with
-  Fermyon's Spin Python SDK with TypeScript.
+  Walk through Fermyon's Spin Python SDK: installing the py2wasm plugin,
+  returning JSON, parsing headers, body, and query strings, and making outbound
+  HTTP requests, with tips for navigating the Rust source while LSP support is
+  pending.
 publishedAt: 2023-03-29T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -38,9 +40,9 @@ chapters:
 duration: 899
 guests: []
 resources:
-  - title: verimeon/spin-python-sdk
+  - title: fermyon/spin-python-sdk
     type: url
-    url: 'https://github.com/verimeon/spin-python-sdk'
+    url: 'https://github.com/spinframework/spin-python-sdk'
     category: code
 ---
 

--- a/content/videos/standalone/2023/your-own-webassembly-cloud.md
+++ b/content/videos/standalone/2023/your-own-webassembly-cloud.md
@@ -3,14 +3,15 @@ id: jckf793apc62vgj4uvzbq91m
 slug: your-own-webassembly-cloud
 title: Your Own WebAssembly Cloud
 description: >-
-  In this video, I'll show you how to get started with the Fermyon Platform. A
-  Collection of Open Source components that allows you to run your own
-  server-side WASM binaries on ANY CLOUD.
+  Deploy a Spin app to Fermyon Cloud, then stand up your own self-hosted
+  WebAssembly platform on Civo with the fermyon/installer Terraform automation,
+  walking through Nomad, Consul, Vault, Traefik, Hippo, HEPL, and Bundle.
 publishedAt: 2023-02-25T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - spin
+  - terraform
 chapters:
   - startTime: 56
     title: Introduction
@@ -43,12 +44,13 @@ chapters:
 duration: 1251
 guests: []
 resources:
-  - title: github.com/fermion/installer
+  - title: fermyon/installer
     type: url
-    url: 'https://github.com/fermion/installer'
+    url: 'https://github.com/fermyon/installer'
     category: code
-  - title: Spin 0.8 video
+  - title: What's New with Spin v0.8
     type: url
+    url: 'https://rawkode.academy/watch/whats-new-with-spin-v0-8'
     category: other
 ---
 

--- a/content/videos/standalone/2024/developing-and-building-open-source-with-dagger-for-kargo.md
+++ b/content/videos/standalone/2024/developing-and-building-open-source-with-dagger-for-kargo.md
@@ -3,13 +3,16 @@ id: t0syi87suw4qezpmy1gkht9k
 slug: developing-and-building-open-source-with-dagger-for-kargo
 title: Developing & Building Open Source with Dagger for Kargo
 description: >-
-  This live stream series will demonstrate how open source projects can leverage
-  Dagger to enhance their build automation and development environments.
+  Kat Cosgrove joins to Daggerize the Cargo project. We start with the Python
+  SDK, explore container composition and caching, debug async issues, and end
+  with a working Docker-in-Dagger setup running the Docker daemon as a service.
 publishedAt: 2024-08-08T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - dagger
+  - docker
+  - pulumi
 chapters:
   - startTime: 129
     title: Introduction to Daggerizing and Cargo
@@ -83,9 +86,13 @@ duration: 5700
 guests:
   - kat-cosgrove
 resources:
-  - title: Conductor
+  - title: Conductor (ContainerCraft dev container)
     type: url
     url: 'https://ghcr.io/containercraft/conductor'
     category: other
+  - title: Dagger documentation
+    type: url
+    url: 'https://docs.dagger.io/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2024/developing-and-building-open-source-with-dagger.md
+++ b/content/videos/standalone/2024/developing-and-building-open-source-with-dagger.md
@@ -3,14 +3,19 @@ id: g179fxks66spn3ni7749lzdd
 slug: developing-and-building-open-source-with-dagger
 title: Developing & Building Open Source with Dagger
 description: >-
-  This live stream series will demonstrate how open source projects can leverage
-  Dagger to enhance their build automation and development environments.
+  Mark Bernstein joins to Daggerize OpenUnison: writing a Dagger pipeline that
+  spins up an ephemeral k3s cluster and deploys the OpenUnison Helm charts,
+  swapping Podman for Docker along the way to make in-cluster testing work.
 publishedAt: 2024-08-15T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - dagger
   - openunison
+  - k3s
+  - helm
+  - docker
+  - podman
 chapters:
   - startTime: 0
     title: Intro & Apology
@@ -58,7 +63,7 @@ guests:
 resources:
   - title: OpenUnison Helm Charts
     type: url
-    url: 'https://github.com/OpenUnison/helmcharts'
+    url: 'https://github.com/OpenUnison/helm-charts'
     category: code
   - title: 'Kubernetes: An Enterprise Guide'
     type: url
@@ -67,8 +72,9 @@ resources:
     type: url
     url: 'https://hurl.dev'
     category: other
-  - title: k3s Dagger Module
+  - title: k3s Dagger Module (marcosnils)
     type: url
+    url: 'https://daggerverse.dev/mod/github.com/marcosnils/daggerverse/k3s'
     category: code
 ---
 

--- a/content/videos/standalone/2024/ebpf-for-runtime-enforcement.md
+++ b/content/videos/standalone/2024/ebpf-for-runtime-enforcement.md
@@ -3,15 +3,17 @@ id: etr47c1p01p3mefltqwanwhv
 slug: ebpf-for-runtime-enforcement
 title: eBPF for Runtime Enforcement
 description: >-
-  Tetragon is a flexible Kubernetes-aware security observability and runtime
-  enforcement tool that applies policy and filtering directly with eBPF,
-  allowing for reduced observation overhead, tracking of any process, and
-  real-time enforcement of policies.
+  Install Tetragon on a Linux host via the GitHub release and as a systemd
+  service, then deploy it to Kubernetes with Helm. Add a TracingPolicy that
+  hooks kernel probes to monitor module loading, and inspect events with the
+  tetra CLI.
 publishedAt: 2024-02-21T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - tetragon
+  - kubernetes
+  - helm
 chapters:
   - startTime: 0
     title: Introduction
@@ -48,12 +50,15 @@ guests: []
 resources:
   - title: Tetragon Installation Documentation
     type: url
+    url: 'https://tetragon.io/docs/installation/'
     category: documentation
   - title: Tetragon GitHub Releases
     type: url
+    url: 'https://github.com/cilium/tetragon/releases'
     category: code
   - title: Tetragon Helm Chart
     type: url
+    url: 'https://github.com/cilium/tetragon/tree/main/install/kubernetes/tetragon'
     category: code
 ---
 

--- a/content/videos/standalone/2024/microservice-troubleshooting-built-for-developers.md
+++ b/content/videos/standalone/2024/microservice-troubleshooting-built-for-developers.md
@@ -3,13 +3,17 @@ id: zh6x60pfsxnaglf391e673pj
 slug: microservice-troubleshooting-built-for-developers
 title: 'Microservice Troubleshooting, Built for Developers'
 description: >-
-  With one-click distributed tracing, Lumigo lets developers effortlessly find
-  and fix issues in serverless and containerized environments.
+  Deploy the Lumigo operator to Kubernetes with Helm, auto-instrument the
+  OpenTelemetry demo app, then walk the system map, transactions, timeline
+  traces, and issues view to debug a failing checkout.
 publishedAt: 2024-01-24T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - lumigo
+  - kubernetes
+  - helm
+  - opentelemetry
 chapters:
   - startTime: 0
     title: Introduction
@@ -58,6 +62,11 @@ guests: []
 resources:
   - title: OpenTelemetry Demo Application
     type: url
+    url: 'https://opentelemetry.io/docs/demo/'
     category: demos
+  - title: Lumigo Documentation
+    type: url
+    url: 'https://docs.lumigo.io/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2024/restrict-access-to-secure-files-with-tetragon.md
+++ b/content/videos/standalone/2024/restrict-access-to-secure-files-with-tetragon.md
@@ -3,15 +3,16 @@ id: tfahqa0n2pld6jvnu7a8k5w9
 slug: restrict-access-to-secure-files-with-tetragon
 title: Restrict Access to Secure Files with Tetragon
 description: >-
-  Tetragon is a flexible Kubernetes-aware security observability and runtime
-  enforcement tool that applies policy and filtering directly with eBPF,
-  allowing for reduced observation overhead, tracking of any process, and
-  real-time enforcement of policies.
+  Write Tetragon TracingPolicy CRDs with kprobes to observe file access in a
+  Kubernetes cluster, then filter on sys_write and paths under /etc using
+  matchArgs, and enforce policy in-kernel with the SIGKILL and getURL match
+  actions.
 publishedAt: 2024-02-22T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - tetragon
+  - kubernetes
 chapters:
   - startTime: 0
     title: Introduction to File Access Enforcement with Tetragon
@@ -80,17 +81,19 @@ guests: []
 resources:
   - title: Tetragon Tracing Policy Concepts
     type: url
+    url: 'https://tetragon.io/docs/concepts/tracing-policy/'
     category: documentation
-  - title: Tetragon GitHub Examples
+  - title: Tetragon Tracing Policy Examples
     type: url
-    url: 'https://github.com/cilium/tetragon'
+    url: 'https://github.com/cilium/tetragon/tree/main/examples/tracingpolicy'
     category: code
-  - title: di.net Linux Man Pages
+  - title: linux.die.net Man Pages
     type: url
-    url: 'https://di.net'
+    url: 'https://linux.die.net/'
     category: documentation
-  - title: Sourcegraph Linux Kernel Search
+  - title: Sourcegraph
     type: url
+    url: 'https://sourcegraph.com/'
     category: other
 ---
 

--- a/content/videos/standalone/2024/simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2.md
+++ b/content/videos/standalone/2024/simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2.md
@@ -3,13 +3,17 @@ id: my23g8vi21qfb16ei845jdjv
 slug: simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2
 title: Simplify Kubernetes Ingress & API Gateways using ngrok
 description: >-
-  We take on the challenge of safely exposing Kubernetes services to the
-  internet with ngrok.
+  Install the ngrok Kubernetes operator via Helm, wire up GatewayClass,
+  Gateway, and HTTPRoute against a custom ngrok.dev domain, route to three
+  sample services, then enforce a sliding-window rate limit with an ngrok
+  TrafficPolicy.
 publishedAt: 2024-10-03T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - ngrok
+  - kubernetes
+  - helm
 chapters:
   - startTime: 0
     title: Introduction
@@ -64,6 +68,7 @@ guests: []
 resources:
   - title: ngrok Kubernetes Operator
     type: url
+    url: 'https://github.com/ngrok/ngrok-operator'
     category: code
   - title: ngrok Helm Chart Repository
     type: url

--- a/content/videos/standalone/2024/simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2.md
+++ b/content/videos/standalone/2024/simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2.md
@@ -3,9 +3,9 @@ id: my23g8vi21qfb16ei845jdjv
 slug: simplify-kubernetes-ingress-and-api-gateways-using-ngrok-2
 title: Simplify Kubernetes Ingress & API Gateways using ngrok
 description: >-
-  Install the ngrok Kubernetes operator via Helm, wire up GatewayClass,
-  Gateway, and HTTPRoute against a custom ngrok.dev domain, route to three
-  sample services, then enforce a sliding-window rate limit with an ngrok
+  Install the ngrok Kubernetes operator via Helm, wire up GatewayClass, Gateway,
+  and HTTPRoute against a custom ngrok.dev domain, route to three sample
+  services, then enforce a sliding-window rate limit with an ngrok
   TrafficPolicy.
 publishedAt: 2024-10-03T17:00:00.000Z
 type: recorded

--- a/content/videos/standalone/2024/the-roast-of-the-linux-desktop.md
+++ b/content/videos/standalone/2024/the-roast-of-the-linux-desktop.md
@@ -3,13 +3,15 @@ id: fd8h2x0iq6qy06gui4vev807
 slug: the-roast-of-the-linux-desktop
 title: The Roast of the Linux Desktop
 description: >-
-  Linux Desktop, you're like that band that everyone insists is about to make it
-  big. You've been "the year of the Linux desktop" more times than Spinal Tap
-  has had drummers spontaneously combust.
+  David and Hayden trade OS war stories: David's Fedora/Universal Blue setup
+  versus Hayden's Windows 11 with WSL2. They demo workflows, debate paper cuts
+  like full-disk encryption, and ask whether the year of the Linux desktop will
+  ever actually arrive.
 publishedAt: 2024-07-17T17:00:00.000Z
 type: recorded
 category: tutorial
-technologies: []
+technologies:
+  - universal-blue
 chapters:
   - startTime: 0
     title: Introduction & Mobile OS Chat
@@ -52,18 +54,23 @@ guests: []
 resources:
   - title: Fedora Silverblue
     type: url
-    category: other
+    url: 'https://fedoraproject.org/atomic-desktops/silverblue/'
+    category: documentation
   - title: Universal Blue (uBlue)
     type: url
-    category: code
+    url: 'https://universal-blue.org/'
+    category: documentation
   - title: Microsoft PowerToys
     type: url
+    url: 'https://github.com/microsoft/PowerToys'
     category: code
   - title: UniGet Package Manager
     type: url
+    url: 'https://github.com/Devolutions/UniGetUI'
     category: code
   - title: Dev Home
     type: url
+    url: 'https://github.com/microsoft/devhome'
     category: code
 ---
 

--- a/content/videos/standalone/2024/using-guidepad-io-to-primitives-to-simplify-future-facing-problems.md
+++ b/content/videos/standalone/2024/using-guidepad-io-to-primitives-to-simplify-future-facing-problems.md
@@ -3,13 +3,16 @@ id: klzxhw3ow8qzrua89xr91717
 slug: using-guidepad-io-to-primitives-to-simplify-future-facing-problems
 title: Using Guidepad.io to Primitives to Simplify Future Facing Problems
 description: >-
-  Terraform has been amazing for Infrastructure as Code; but can what got is
-  here, get us to where we need to be in the future? I don't think so.
+  Terraform's resource model only understands CRUD and polls for drift. Using
+  Guidepad primitives (environments, control planes, state machines,
+  requirements), we build an event-driven S3 provider in ~100 lines of Python
+  that reconciles from CloudTrail events.
 publishedAt: 2024-01-29T17:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - guidepad
+  - terraform
 chapters:
   - startTime: 0
     title: Introduction

--- a/content/videos/standalone/2024/writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions.md
+++ b/content/videos/standalone/2024/writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions.md
@@ -2,7 +2,10 @@
 id: czct26lrzw3y5ylu4tjvfsq5
 slug: writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions
 title: Writing New Micro-services Using AI with GitLab Duo Code Suggestions
-description: David uses GitLab Duo's chat and code suggestions to build a Python pipeline that extracts frames from a video with OpenCV, runs OCR via PyTesseract, classifies the text with OpenAI, and stores the results in SQLite.
+description: >-
+  David uses GitLab Duo's chat and code suggestions to build a Python pipeline
+  that extracts frames from a video with OpenCV, runs OCR via PyTesseract,
+  classifies the text with OpenAI, and stores the results in SQLite.
 publishedAt: 2024-04-18T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2024/writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions.md
+++ b/content/videos/standalone/2024/writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions.md
@@ -2,7 +2,7 @@
 id: czct26lrzw3y5ylu4tjvfsq5
 slug: writing-new-micro-services-using-ai-with-gitlab-duo-code-suggestions
 title: Writing New Micro-services Using AI with GitLab Duo Code Suggestions
-description: Video content coming soon.
+description: David uses GitLab Duo's chat and code suggestions to build a Python pipeline that extracts frames from a video with OpenCV, runs OCR via PyTesseract, classifies the text with OpenAI, and stores the results in SQLite.
 publishedAt: 2024-04-18T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2025/build-a-production-ready-kubernetes-cluster-with-spectro-cloud-palette-no-code-tutorial.md
+++ b/content/videos/standalone/2025/build-a-production-ready-kubernetes-cluster-with-spectro-cloud-palette-no-code-tutorial.md
@@ -10,9 +10,9 @@ subtitle: >-
   how to build a production-ready, reusable Kubernetes stack using the Spectro
   Cloud Palette web UI—no code required. Think
 description: >-
-  Struggling with complex Kubernetes configurations? In this video, you'll learn
-  how to build a production-ready, reusable Kubernetes stack using the Spectro
-  Cloud Palette web UI—no code required.
+  Compose a reusable, production-ready Kubernetes cluster profile in the Spectro
+  Cloud Palette UI, layering the OS, CNI, CSI, and add-ons like Prometheus and
+  Grafana, then deploy it without writing YAML or Helm values by hand.
 publishedAt: 2025-07-07T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -24,5 +24,10 @@ technologies:
   - helm
 duration: 987
 guests: []
+resources:
+  - title: Spectro Cloud Palette documentation
+    type: url
+    url: 'https://docs.spectrocloud.com/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2025/exploring-ngroks-traffic-policies-for-secure-application-development.md
+++ b/content/videos/standalone/2025/exploring-ngroks-traffic-policies-for-secure-application-development.md
@@ -3,9 +3,9 @@ id: ovgas80n8hqlkknowpijiqbb
 slug: exploring-ngroks-traffic-policies-for-secure-application-development
 title: Exploring ngrok's Traffic Policies for Secure Application Development
 description: >-
-  In this video, you'll learn three exciting tricks to enhance your application
-  using ngrok. We'll cover how to protect an endpoint, restrict access based on
-  geolocation, and improve your application's security posture.
+  Using ngrok Traffic Policies and CEL expressions to lock down a Deno API:
+  restrict the /metrics endpoint to specific IPs, then geo-restrict /uk to
+  United Kingdom visitors with a custom CEL-interpolated 404 response.
 publishedAt: 2025-01-20T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -68,6 +68,34 @@ chapters:
     title: Conclusion & Call to Action
 duration: 866
 guests: []
-resources: []
+resources:
+  - title: ngrok Documentation
+    type: url
+    url: 'https://ngrok.com/docs'
+    category: documentation
+  - title: ngrok Traffic Policy
+    type: url
+    category: documentation
+  - title: Common Expression Language (CEL)
+    type: url
+    category: documentation
+  - title: Traffic Policy Connection Variables
+    type: url
+    category: documentation
+  - title: Traffic Policy HTTP Request Variables
+    type: url
+    category: documentation
+  - title: Traffic Policy Geo Variables
+    type: url
+    category: documentation
+  - title: Restrict IPs Action
+    type: url
+    category: documentation
+  - title: Deny Action
+    type: url
+    category: documentation
+  - title: Custom Response Action
+    type: url
+    category: documentation
 ---
 

--- a/content/videos/standalone/2025/fuck-you-hashicorp-an-ibm-company.md
+++ b/content/videos/standalone/2025/fuck-you-hashicorp-an-ibm-company.md
@@ -6,9 +6,10 @@ subtitle: >-
   HashiCorp archived the repo without warning. Here is why their excuse about
   "product market fit" is a lie.
 description: >-
-  On December 10th, HashiCorp—an IBM Company—officially archived the Cloud
-  Development Kit for Terraform (CDK) with absolutely zero notice or deprecation
-  window.
+  HashiCorp, an IBM company, archived the Terraform CDK on December 10 with no
+  deprecation window, blaming "product market fit" despite roughly half a
+  million monthly downloads. The synth-to-HCL migration path misses why people
+  picked CDKTF in the first place.
 publishedAt: 2025-12-11T00:00:00.000Z
 type: recorded
 category: editorial
@@ -20,6 +21,14 @@ resources:
   - title: Cloud Development Kit for Terraform (CDKTF)
     type: url
     url: 'https://github.com/hashicorp/terraform-cdk'
+    category: code
+  - title: cdktf on npm
+    type: url
+    url: 'https://www.npmjs.com/package/cdktf'
+    category: code
+  - title: cdktf on PyPI
+    type: url
+    url: 'https://pypi.org/project/cdktf/'
     category: code
 ---
 

--- a/content/videos/standalone/2025/kubernetes-disaster-recovery.md
+++ b/content/videos/standalone/2025/kubernetes-disaster-recovery.md
@@ -4,15 +4,18 @@ slug: kubernetes-disaster-recovery
 title: Kubernetes Disaster Recovery
 subtitle: ''
 description: >-
-  Kubernetes backups are simple in theory: etcd state plus persistent volumes.
-  The real challenge is managing this across 50 clusters without drifting
-  configs, scattered backup locations, and zero visibility.
+  Back up a stateful Postgres workload with Velero, simulate a namespace
+  disaster, and restore from S3 (SeaweedFS). Then scale the same pattern across
+  a fleet with scheduled, RBAC-controlled backups in Spectro Cloud Palette.
 publishedAt: 2025-11-25T14:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - kubernetes
   - velero
+  - postgresql
+  - seaweedfs
+  - etcd
 chapters:
   - startTime: 0
     title: Intro
@@ -31,6 +34,15 @@ guests: []
 resources:
   - title: Spectro Cloud Palette documentation
     type: url
+    url: 'https://docs.spectrocloud.com/'
+    category: documentation
+  - title: Velero documentation
+    type: url
+    url: 'https://velero.io/docs/'
+    category: documentation
+  - title: SeaweedFS
+    type: url
+    url: 'https://github.com/seaweedfs/seaweedfs'
     category: documentation
 ---
 

--- a/content/videos/standalone/2025/kubernetes-security-scanning.md
+++ b/content/videos/standalone/2025/kubernetes-security-scanning.md
@@ -6,8 +6,10 @@ subtitle: >-
   When it comes to Kubernetes tooling, the landscape is noisy and doesn't always
   have your back. Finding the right tools can be ... somewhat painful.
 description: >-
-  When it comes to Kubernetes tooling, the landscape is noisy and doesn't always
-  have your back. Finding the right tools can be ... somewhat painful.
+  Four tools for Kubernetes day-two security: kube-bench for CIS hygiene,
+  kube-hunter for red-team probing, Sonobuoy for CNCF conformance, and
+  Syft plus Grype for SBOMs and CVEs. Demo runs them by hand, then automates
+  via Spectro Cloud Palette.
 publishedAt: 2025-12-12T00:00:00.000Z
 type: recorded
 category: tutorial
@@ -50,12 +52,35 @@ chapters:
 resources:
   - title: Spectro Cloud Palette
     type: url
+    url: 'https://www.spectrocloud.com/product/palette'
     category: other
   - title: Google Microservices Demo
     type: url
+    url: 'https://github.com/GoogleCloudPlatform/microservices-demo'
     category: demos
   - title: CIS Kubernetes Benchmarks
     type: url
+    url: 'https://www.cisecurity.org/benchmark/kubernetes'
     category: documentation
+  - title: kube-bench
+    type: url
+    url: 'https://github.com/aquasecurity/kube-bench'
+    category: code
+  - title: kube-hunter
+    type: url
+    url: 'https://github.com/aquasecurity/kube-hunter'
+    category: code
+  - title: Sonobuoy
+    type: url
+    url: 'https://sonobuoy.io/'
+    category: documentation
+  - title: Syft
+    type: url
+    url: 'https://github.com/anchore/syft'
+    category: code
+  - title: Grype
+    type: url
+    url: 'https://github.com/anchore/grype'
+    category: code
 ---
 

--- a/content/videos/standalone/2025/kubernetes-security-scanning.md
+++ b/content/videos/standalone/2025/kubernetes-security-scanning.md
@@ -7,9 +7,9 @@ subtitle: >-
   have your back. Finding the right tools can be ... somewhat painful.
 description: >-
   Four tools for Kubernetes day-two security: kube-bench for CIS hygiene,
-  kube-hunter for red-team probing, Sonobuoy for CNCF conformance, and
-  Syft plus Grype for SBOMs and CVEs. Demo runs them by hand, then automates
-  via Spectro Cloud Palette.
+  kube-hunter for red-team probing, Sonobuoy for CNCF conformance, and Syft plus
+  Grype for SBOMs and CVEs. Demo runs them by hand, then automates via Spectro
+  Cloud Palette.
 publishedAt: 2025-12-12T00:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2025/minio-we-wont-miss-you.md
+++ b/content/videos/standalone/2025/minio-we-wont-miss-you.md
@@ -5,30 +5,37 @@ title: 'MinIO, we won''t miss you.'
 subtitle: >-
   MinIO just announced maintenance mode for their community edition — and
   honestly? Good riddance.
-description: This isn't about open source companies needing to make money. That's valid.
+description: >-
+  MinIO put their community edition into maintenance mode. We walk through how
+  they got here: silent AGPL relicensing in 2019 and 2021, the Weka
+  license-revocation stunt, gutting the May 2025 community console, and pushing
+  a $96K paywall for features that used to be free.
 publishedAt: 2025-12-04T00:00:00.000Z
 type: recorded
 category: editorial
 technologies:
   - minio
-  - seaweedfs
 duration: 369
 guests: []
 resources:
   - title: MinIO Community Edition Maintenance Mode Announcement
     type: url
+    url: 'https://github.com/minio/minio/issues/21714'
     category: other
   - title: Adam Jacobs' Analysis of MinIO License Enforcement
     type: url
     category: other
   - title: MinIO vs Nutanix License Compliance Case
     type: url
+    url: 'https://blog.min.io/nutanix-objects-violates-minios-open-source-license/'
     category: other
   - title: MinIO vs Weka License Revocation Incident
     type: url
+    url: 'https://blog.min.io/weka-violates-minios-open-source-licenses/'
     category: other
   - title: MinIO GitHub Community Concerns
     type: url
+    url: 'https://github.com/minio/minio/discussions/21326'
     category: other
 ---
 

--- a/content/videos/standalone/2025/ngrok-operator-tutorial.md
+++ b/content/videos/standalone/2025/ngrok-operator-tutorial.md
@@ -4,8 +4,9 @@ slug: ngrok-operator-tutorial
 title: Unboxing the ngrok Kubernetes Operator
 subtitle: Expose Any Kubernetes Service in 8 Lines of YAML
 description: >-
-  Learn how to expose your Kubernetes services to the internet in under 20
-  minutes using the ngrok Kubernetes Operator!
+  Install the ngrok Kubernetes Operator with Helm, then expose a workload using
+  an AgentEndpoint and TrafficPolicy. Add OIDC auth via Zitadel, rate limiting,
+  and a custom 429 page, all without load balancers or port forwarding.
 publishedAt: 2025-07-23T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -25,6 +26,7 @@ resources:
     category: code
   - title: ngrok Traffic Policy Actions Documentation
     type: url
+    url: 'https://ngrok.com/docs/traffic-policy/actions'
     category: documentation
   - title: ngrok vs Firewall Game
     type: url

--- a/content/videos/standalone/2025/relaunching-klustered-with-heroku-vibes.md
+++ b/content/videos/standalone/2025/relaunching-klustered-with-heroku-vibes.md
@@ -3,7 +3,10 @@ id: mbi5212lbf8b3yvidkeamkkm
 slug: relaunching-klustered-with-heroku-vibes
 title: Relaunching Klustered ... with Heroku Vibes
 subtitle: Building and Launching a Marketing Page on Heroku with AI in Under 20 Minutes
-description: Building a marketing page for the Klustered relaunch with Heroku Vibes. Covers AI-assisted development, deployment to Heroku, wiring up interactive features, then debugging the rough edges before recapping what's next for the show.
+description: >-
+  Building a marketing page for the Klustered relaunch with Heroku Vibes. Covers
+  AI-assisted development, deployment to Heroku, wiring up interactive features,
+  then debugging the rough edges before recapping what's next for the show.
 publishedAt: 2025-12-02T00:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2025/relaunching-klustered-with-heroku-vibes.md
+++ b/content/videos/standalone/2025/relaunching-klustered-with-heroku-vibes.md
@@ -3,9 +3,7 @@ id: mbi5212lbf8b3yvidkeamkkm
 slug: relaunching-klustered-with-heroku-vibes
 title: Relaunching Klustered ... with Heroku Vibes
 subtitle: Building and Launching a Marketing Page on Heroku with AI in Under 20 Minutes
-description: >-
-  In this episode, we'll embark on an exciting journey to build and launch a new
-  marketing page for the relaunch of Klustered using Heroku Vibes.
+description: Building a marketing page for the Klustered relaunch with Heroku Vibes. Covers AI-assisted development, deployment to Heroku, wiring up interactive features, then debugging the rough edges before recapping what's next for the show.
 publishedAt: 2025-12-02T00:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2025/replace-your-github-actions-yaml-with-cue.md
+++ b/content/videos/standalone/2025/replace-your-github-actions-yaml-with-cue.md
@@ -6,23 +6,25 @@ subtitle: >-
   Are you tired of copy-pasting YAML between repositories only to be bitten by
   typos after pushing?
 description: >-
-  Are you tired of copy-pasting YAML between repositories only to be bitten by
-  typos after pushing?
+  Author GitHub Actions workflows in CUE instead of YAML. Walk through cue vet,
+  import, and export, pull workflow definitions from the CUE Central Registry,
+  pin actions to SHAs, and wire in a Dagger install step.
 publishedAt: 2025-12-10T00:00:00.000Z
 type: recorded
 category: tutorial
 technologies:
   - cue
+  - dagger
 duration: 1198
 guests: []
 resources:
   - title: CUE Documentation
     type: url
-    url: 'https://cue.dev/docs'
+    url: 'https://cuelang.org/docs/'
     category: documentation
   - title: CUE Central Registry
     type: url
-    url: 'https://registry.cue.works'
+    url: 'https://registry.cue.works/'
     category: other
   - title: GitHub Actions package on CUE Registry
     type: url

--- a/content/videos/standalone/2025/unlocking-global-edge-services-with-ngrok.md
+++ b/content/videos/standalone/2025/unlocking-global-edge-services-with-ngrok.md
@@ -4,8 +4,8 @@ slug: unlocking-global-edge-services-with-ngrok
 title: Unlocking Global Edge Services with ngrok
 description: >-
   BGP routes the internet like Google Maps, but running your own POPs is hard.
-  ngrok's global load balancer spans 8 POPs with automatic failover, demoed
-  here with two Deno apps tunnelled from EU and US.
+  ngrok's global load balancer spans 8 POPs with automatic failover, demoed here
+  with two Deno apps tunnelled from EU and US.
 publishedAt: 2025-01-23T17:00:00.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2025/unlocking-global-edge-services-with-ngrok.md
+++ b/content/videos/standalone/2025/unlocking-global-edge-services-with-ngrok.md
@@ -3,8 +3,9 @@ id: h0e270cxlhdgnr6x20mcno3d
 slug: unlocking-global-edge-services-with-ngrok
 title: Unlocking Global Edge Services with ngrok
 description: >-
-  Let's dive into the complexities of Border Gateway Protocol (BGP) and explore
-  a simpler solution for low latency service delivery using ngrok.
+  BGP routes the internet like Google Maps, but running your own POPs is hard.
+  ngrok's global load balancer spans 8 POPs with automatic failover, demoed
+  here with two Deno apps tunnelled from EU and US.
 publishedAt: 2025-01-23T17:00:00.000Z
 type: recorded
 category: tutorial
@@ -43,6 +44,10 @@ chapters:
     title: Conclusion and Final Call to Action
 duration: 235
 guests: []
-resources: []
+resources:
+  - type: url
+    title: ngrok
+    url: 'https://ngrok.com/'
+    category: documentation
 ---
 

--- a/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
+++ b/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
@@ -3,7 +3,11 @@ id: hxjai2mhvplhc4rl3c7dq2eh
 slug: hadron-minimal-secure-linux-for-cloud-edge
 title: 'Hadron: Minimal & Secure Linux for Cloud & Edge'
 subtitle: Is your Linux distribution too bloated for the cloud and edge?
-description: A look at Hadron, the minimal Linux distribution from the Kairos project. Built from upstream components (musl libc, systemd, vanilla kernels) with no base-OS package manager, designed as a lean foundation for immutable, image-based cloud and edge systems.
+description: >-
+  A look at Hadron, the minimal Linux distribution from the Kairos project.
+  Built from upstream components (musl libc, systemd, vanilla kernels) with no
+  base-OS package manager, designed as a lean foundation for immutable,
+  image-based cloud and edge systems.
 publishedAt: 2026-02-05T19:24:45.000Z
 type: recorded
 category: tutorial

--- a/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
+++ b/content/videos/standalone/2026/hadron-minimal-secure-linux-for-cloud-edge.md
@@ -3,7 +3,7 @@ id: hxjai2mhvplhc4rl3c7dq2eh
 slug: hadron-minimal-secure-linux-for-cloud-edge
 title: 'Hadron: Minimal & Secure Linux for Cloud & Edge'
 subtitle: Is your Linux distribution too bloated for the cloud and edge?
-description: Is your Linux distribution too bloated for the cloud and edge?
+description: A look at Hadron, the minimal Linux distribution from the Kairos project. Built from upstream components (musl libc, systemd, vanilla kernels) with no base-OS package manager, designed as a lean foundation for immutable, image-based cloud and edge systems.
 publishedAt: 2026-02-05T19:24:45.000Z
 type: recorded
 category: tutorial


### PR DESCRIPTION
## Summary
Per-video subagent review for every video in `content/videos/**`. A fresh agent reviewed each file against its transcript, audited and improved:

1. **`technologies:`** — added missing canonical IDs (cross-referenced against `content/technologies/<id>/index.mdx`); removed ones not actually featured. Many videos went from `[]` or one tech to 3–9 accurate canonical IDs.
2. **`description:`** — when generic, identical to subtitle, or a placeholder ("Video content coming soon."), rewrote as a 1–3 sentence transcript-anchored summary, ≤280 chars, no em-dashes.
3. **`resources:`** — every entry stamped with `type: "url"` (schema requirement). URLs filled in only when verifiable from the transcript, the canonical tech profile, or WebFetch confirmation. Many broken/outdated URLs corrected.

## Diff stats
```
321 files changed, 3106 insertions(+), 1181 deletions(-)
```
9 checkpoint commits on the branch.

## Method
- 81 batches of ~4 videos in parallel, ~325 fresh subagents total. Each agent only touched its assigned video file; `id`, `slug`, `publishedAt`, `duration`, `chapters`, `show`, `guests`, etc. were never modified.
- Two prompt-injection attempts caught via WebFetch responses — both rejected, file edits remained clean.
- Common fixes surfaced: Deepgram transcription errors corrected (Caverno → Kyverno, Fermion → Fermyon, etc.); broken github URLs renamed to current canonical paths; stale Twitter/Tweepy/Equinix promo links replaced.

## Followups flagged
Many videos mentioned technologies that have no canonical profile in `content/technologies/` and were therefore not added to `technologies:`. Common gaps surfaced by the agents (worth back-filling as new technology entries someday):
- Java/JVM, Quarkus, Spring, GraalVM, Micronaut, Jakarta EE, OpenJDK
- AWS/EKS, GCP/Cloud Run, Azure (cloud providers)
- Various sub-tools — Postman, Hurl, Kustomize, OpenSSL, Promtail, Hubble, kubectl-neat, etc.
- Some standalone CNCF entries — Spectro Cloud Palette, Backstage IDP, Civo, Equinix Metal.

## Test plan
- [ ] `astro check` from website — confirm all `resources[].type`, `technologies[]` references resolve.
- [ ] Spot-check a sample of `/watch/<slug>` pages — descriptions read cleanly, Technology and Resources tabs show the new structured data.

## Human action required
- **Review per show or per topic** at your pace. The agents were conservative on URL filling (left blank when unverifiable) and on technology additions (only canonical IDs that exist in `content/technologies/`). If anything reads wrong, edit inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)