### PR TITLE
feat(rawkode.academy/website): tighten /technology/[id] hero

### DIFF
--- a/content/shows/klustered.md
+++ b/content/shows/klustered.md
@@ -4,5 +4,6 @@ name: Klustered
 description: "Klustered is a live gameshow where contestants race against the clock to diagnose and fix deliberately broken Kubernetes clusters. Community members sabotage the clusters, and our brave guests must use their debugging skills to bring them back to life — all while the audience watches."
 hosts:
   - rawkode
+publish: true
 ---
 

--- a/content/shows/rawkode-live.md
+++ b/content/shows/rawkode-live.md
@@ -4,5 +4,6 @@ name: Rawkode Live
 description: "Live coding, tutorials, and deep dives into cloud native technologies, DevOps tooling, and modern infrastructure — streamed live and unscripted."
 hosts:
   - rawkode
+publish: true
 ---
 

--- a/projects/rawkode.academy/website/src/components/breadcrumb/Breadcrumb.astro
+++ b/projects/rawkode.academy/website/src/components/breadcrumb/Breadcrumb.astro
@@ -12,19 +12,18 @@ type Props = {
 
 const { elements } = Astro.props;
 
-// Remove the last element (current page) - we only show the path
-const pathElements = elements.slice(0, -1);
+const lastIndex = elements.length - 1;
 ---
 
 <BreadcrumbJsonLd elements={elements} />
 
-{pathElements.length > 0 && (
+{elements.length > 0 && (
 	<nav class="breadcrumb" aria-label="Breadcrumb">
 		<ol>
-			{pathElements.map((el, i) => (
+			{elements.map((el, i) => (
 				<li>
 					{i === 0 ? (
-						<a href={el.link} class="home-link">
+						<a href={el.link} class="home-link" aria-label={el.title}>
 							<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd" />
 							</svg>
@@ -34,7 +33,11 @@ const pathElements = elements.slice(0, -1);
 							<svg class="chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
 							</svg>
-							<a href={el.link}>{el.title}</a>
+							{i === lastIndex ? (
+								<span class="current" aria-current="page">{el.title}</span>
+							) : (
+								<a href={el.link}>{el.title}</a>
+							)}
 						</>
 					)}
 				</li>
@@ -121,5 +124,21 @@ const pathElements = elements.slice(0, -1);
 	a:not(.home-link):hover {
 		color: rgb(var(--brand-primary));
 		background: rgb(var(--brand-primary) / 0.1);
+	}
+
+	.current {
+		color: var(--text-primary-content);
+		font-weight: 600;
+		padding: 0.25rem 0.5rem;
+		max-width: 16rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	@media (max-width: 640px) {
+		.current {
+			max-width: 10rem;
+		}
 	}
 </style>

--- a/projects/rawkode.academy/website/src/components/common/FeaturedContent.astro
+++ b/projects/rawkode.academy/website/src/components/common/FeaturedContent.astro
@@ -91,7 +91,7 @@ const truncatedDescription = truncateDescription(
 <section class={`section-py-tight ${sectionClass}`.trim()}>
 	<!-- Mobile/Tablet layout - matches desktop aesthetic -->
 	<a href={href} class="lg:hidden block group">
-		<div class="glass-card-shimmer overflow-hidden rounded-2xl">
+		<div class="glass-card-shimmer overflow-hidden rounded-2xl bleed-x-mobile">
 			<!-- Image section -->
 			<div class="relative aspect-[16/9] overflow-hidden">
 				{typeof thumbnailUrl === "string" ? (

--- a/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
+++ b/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="glass-card-shimmer">
+  <div class="glass-card-shimmer bleed-x-mobile">
     <!-- Tab Navigation -->
     <div class="border-b border-subtle relative z-10">
       <!-- Dropdown for Mobile -->

--- a/projects/rawkode.academy/website/src/pages/about/index.astro
+++ b/projects/rawkode.academy/website/src/pages/about/index.astro
@@ -159,7 +159,7 @@ const signatureFormats = [
 
         <section class="section-shell">
                 <div class="relative z-10 mx-auto grid max-w-6xl gap-10 px-4 lg:grid-cols-[1.1fr_0.9fr]">
-                        <div class="glass-panel rounded-[32px] p-8 shadow-[0_25px_60px_rgba(14,30,37,0.15)] dark:shadow-[0_25px_60px_rgba(0,0,0,0.65)]">
+                        <div class="glass-panel rounded-[32px] p-8 shadow-[0_25px_60px_rgba(14,30,37,0.15)] dark:shadow-[0_25px_60px_rgba(0,0,0,0.65)] bleed-x-mobile">
                                 <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Mission</p>
                                 <h2 class="mt-4 text-3xl font-semibold text-primary-content">Empower developers to navigate constant change</h2>
                                 <p class="mt-4 text-lg text-muted">
@@ -173,7 +173,7 @@ const signatureFormats = [
                         </div>
                         <div class="space-y-6">
                                 {missionPillars.map((pillar) => (
-                                        <div class="glass-panel rounded-[28px] p-6">
+                                        <div class="glass-panel rounded-[28px] p-6 bleed-x-mobile">
                                                 <h3 class="text-xl font-semibold text-primary-content">{pillar.title}</h3>
                                                 <p class="mt-2 text-muted">{pillar.description}</p>
                                         </div>
@@ -193,7 +193,7 @@ const signatureFormats = [
                         </div>
                         <div class="mt-12 grid gap-6 md:grid-cols-3">
                                 {stats.map((stat) => (
-                                        <div class="glass-panel rounded-[28px] p-8 text-center">
+                                        <div class="glass-panel rounded-[28px] p-8 text-center bleed-x-mobile">
                                                 <p class="text-4xl font-semibold text-primary-content">{stat.value}</p>
                                                 <p class="mt-2 text-lg font-medium text-secondary-content">{stat.label}</p>
                                                 <p class="mt-3 text-sm text-muted">{stat.description}</p>
@@ -248,7 +248,7 @@ const signatureFormats = [
                         </div>
                         <div class="mt-12 grid gap-6 md:grid-cols-3">
                                 {signatureFormats.map((format) => (
-                                        <div class="glass-panel flex h-full flex-col rounded-[28px] p-6">
+                                        <div class="glass-panel flex h-full flex-col rounded-[28px] p-6 bleed-x-mobile">
                                                 <div class="flex-1">
                                                         <h3 class="text-xl font-semibold text-primary-content">{format.title}</h3>
                                                         <p class="mt-3 text-muted">{format.description}</p>
@@ -274,7 +274,7 @@ const signatureFormats = [
                                 </p>
                         </div>
                         <div class="mt-12 grid gap-8 md:grid-cols-2">
-                                <div class="glass-panel overflow-hidden rounded-[32px] p-0">
+                                <div class="glass-panel overflow-hidden rounded-[32px] p-0 bleed-x-mobile">
                                         <div class="aspect-video">
                                                 <iframe
                                                         class="h-full w-full"
@@ -290,7 +290,7 @@ const signatureFormats = [
                                                 <p class="mt-2 text-muted">The pilot episode that proved live, unfiltered exploration resonated with our audience.</p>
                                         </div>
                                 </div>
-                                <div class="glass-panel overflow-hidden rounded-[32px] p-0">
+                                <div class="glass-panel overflow-hidden rounded-[32px] p-0 bleed-x-mobile">
                                         <div class="aspect-video">
                                                 <iframe
                                                         class="h-full w-full"

--- a/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
@@ -148,7 +148,7 @@ function getResourceHref(
 			<div class:list={["grid gap-8 xl:items-start", hasCourseResources && "xl:grid-cols-[minmax(0,1fr)_20rem]"]}>
 				<div class="space-y-8">
 					{Content && (
-						<section class="section-shell card-padding-lg">
+						<section class="section-shell card-padding-lg bleed-x-mobile">
 							<div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
 								<div class="space-y-2">
 									<div class="eyebrow-label">Course Overview</div>
@@ -164,7 +164,7 @@ function getResourceHref(
 						</section>
 					)}
 
-					<section id="course-content" class="section-shell card-padding-lg scroll-mt-28">
+					<section id="course-content" class="section-shell card-padding-lg scroll-mt-28 bleed-x-mobile">
 						<div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
 							<div class="space-y-2">
 								<div class="eyebrow-label">Curriculum</div>

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -266,7 +266,7 @@ const academyValues = [
 						{latestNews.map((item) => (
 							<a
 								href={`/news/${item.id}`}
-								class="soft-panel group block h-full p-4 sm:p-5"
+								class="soft-panel bleed-x-mobile group block h-full p-4 sm:p-5"
 							>
 								<div class="space-y-3">
 									<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -312,7 +312,7 @@ const academyValues = [
 						{latestLearningPaths.map((path) => (
 							<a
 								href={`/learning-paths/${path.id}`}
-								class="soft-panel group block h-full p-4 sm:p-5"
+								class="soft-panel bleed-x-mobile group block h-full p-4 sm:p-5"
 							>
 								<div class="space-y-3">
 									<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -358,7 +358,7 @@ const academyValues = [
 				{featuredVideo && (
 					<a
 						href={`/watch/${featuredVideo.data.slug}`}
-						class="soft-panel group grid gap-6 overflow-hidden p-4 sm:p-5 md:grid-cols-[20rem_minmax(0,1fr)] md:items-center lg:p-6"
+						class="soft-panel bleed-x-mobile group grid gap-6 overflow-hidden p-4 sm:p-5 md:grid-cols-[20rem_minmax(0,1fr)] md:items-center lg:p-6"
 					>
 						<div class="relative aspect-video overflow-hidden rounded-[1.15rem] bg-black/10 dark:bg-white/5">
 							<img
@@ -395,7 +395,7 @@ const academyValues = [
 					{secondaryVideos.map((video) => (
 						<a
 							href={`/watch/${video.data.slug}`}
-							class="soft-panel group block h-full p-4 sm:p-5"
+							class="soft-panel bleed-x-mobile group block h-full p-4 sm:p-5"
 						>
 							<div class="space-y-3">
 								<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -440,7 +440,7 @@ const academyValues = [
 				{featuredArticle && (
 					<a
 						href={`/read/${featuredArticle.id}`}
-						class="soft-panel group grid gap-6 overflow-hidden p-4 sm:p-5 md:grid-cols-[minmax(0,1fr)_18rem] md:items-center lg:p-6"
+						class="soft-panel bleed-x-mobile group grid gap-6 overflow-hidden p-4 sm:p-5 md:grid-cols-[minmax(0,1fr)_18rem] md:items-center lg:p-6"
 					>
 						<div class="space-y-4 md:order-1">
 							<div class="flex flex-wrap items-center gap-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -485,7 +485,7 @@ const academyValues = [
 					{secondaryArticles.map((article) => (
 						<a
 							href={`/read/${article.id}`}
-							class="soft-panel group block h-full p-4 sm:p-5"
+							class="soft-panel bleed-x-mobile group block h-full p-4 sm:p-5"
 						>
 							<div class="space-y-3">
 								<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -518,7 +518,7 @@ const academyValues = [
 
 				<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
 					{academyValues.map((value, index) => (
-						<article class="soft-panel h-full p-5 sm:p-6">
+						<article class="soft-panel bleed-x-mobile h-full p-5 sm:p-6">
 							<div class="space-y-3">
 								<p class="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted">
 									{String(index + 1).padStart(2, "0")}

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -395,9 +395,17 @@ const academyValues = [
 					{secondaryVideos.map((video) => (
 						<a
 							href={`/watch/${video.data.slug}`}
-							class="soft-panel bleed-x-mobile group block h-full p-4 sm:p-5"
+							class="soft-panel bleed-x-mobile group block h-full overflow-hidden"
 						>
-							<div class="space-y-3">
+							<div class="relative aspect-video overflow-hidden bg-black/10 dark:bg-white/5">
+								<img
+									src={`https://content.rawkode.academy/videos/${video.data.id}/thumbnail.jpg`}
+									alt={video.data.title}
+									class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-500 group-hover:scale-[1.02]"
+									loading="lazy"
+								/>
+							</div>
+							<div class="space-y-3 p-4 sm:p-5">
 								<div class="flex flex-wrap items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">
 									<span>{videoLabel(video)}</span>
 									<span class="h-1 w-1 rounded-full" style="background-color: var(--surface-border-strong)"></span>

--- a/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
@@ -121,7 +121,7 @@ const pageDescription = learningPath.data.description;
 			<Content />
 		</article>
 		<aside class="space-y-6">
-			<div class="rounded-2xl border border-surface bg-white dark:bg-gray-900 p-6 shadow-lg">
+			<div class="rounded-2xl border border-surface bg-white dark:bg-gray-900 p-6 shadow-lg bleed-x-mobile">
 				<h2 class="text-sm font-semibold uppercase tracking-wide text-muted mb-3">
 					At a Glance
 				</h2>
@@ -179,7 +179,7 @@ const pageDescription = learningPath.data.description;
 			</div>
 
 			{outline.length > 0 && (
-				<div class="rounded-2xl border border-surface bg-white dark:bg-gray-900 p-6 shadow-lg">
+				<div class="rounded-2xl border border-surface bg-white dark:bg-gray-900 p-6 shadow-lg bleed-x-mobile">
 					<h2 class="text-sm font-semibold uppercase tracking-wide text-muted mb-3">
 						Curriculum Overview
 					</h2>
@@ -209,7 +209,7 @@ const pageDescription = learningPath.data.description;
 	/>
 
 	<footer class="mt-16">
-		<div class="rounded-3xl border border-dashed border-surface p-8 text-center">
+		<div class="rounded-3xl border border-dashed border-surface p-8 text-center bleed-x-mobile">
 			<h2 class="text-2xl font-semibold text-primary-content mb-4">
 				Ready for another challenge?
 			</h2>

--- a/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/index.astro
@@ -45,7 +45,7 @@ const pageDescription =
 		listUrl={new URL("/learning-paths", Astro.site ?? Astro.url).href}
 		listName="Rawkode Academy Learning Paths"
 	/>
-	<section class="relative overflow-hidden rounded-3xl border border-surface bg-white dark:bg-gray-900">
+	<section class="relative overflow-hidden rounded-3xl border border-surface bg-white dark:bg-gray-900 bleed-x-mobile">
 		<div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/20 dark:from-primary/20 dark:to-secondary/30"></div>
 		<div class="relative z-10 px-6 py-16 md:px-10 lg:px-16">
 			<div class="max-w-3xl">

--- a/projects/rawkode.academy/website/src/pages/people/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/people/[id].astro
@@ -271,7 +271,7 @@ const relMeUrls = [
     <div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
         <!-- Profile Header -->
         <section class="w-full">
-            <div class="glass-panel rounded-3xl p-8 md:p-12 max-w-5xl mx-auto">
+            <div class="person-hero-card glass-panel rounded-3xl p-8 md:p-12 max-w-5xl mx-auto">
                 <div class="flex flex-col md:flex-row items-center md:items-start gap-8 md:gap-12">
                     <!-- Avatar -->
                     <div class="flex-shrink-0">
@@ -454,3 +454,15 @@ const relMeUrls = [
         )}
     </div>
 </Page>
+
+<style>
+    /* Mobile: hero card goes edge-to-edge so the small gutter is reclaimed. */
+    @media (max-width: 639px) {
+        .person-hero-card {
+            margin-inline: calc(50% - 50vw);
+            border-radius: 0;
+            border-inline: 0;
+            box-shadow: none;
+        }
+    }
+</style>

--- a/projects/rawkode.academy/website/src/pages/people/index.astro
+++ b/projects/rawkode.academy/website/src/pages/people/index.astro
@@ -38,7 +38,7 @@ const peopleJsonLd = sortedPeople.map((person) => ({
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->
 		<section class="w-full">
-			<div class="glass-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto">
+			<div class="glass-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto bleed-x-mobile">
 				<div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
 					<!-- Hero Copy -->
 					<div class="flex-1 space-y-4">
@@ -92,7 +92,7 @@ const peopleJsonLd = sortedPeople.map((person) => ({
 							return (
 								<a
 									href={`/people/${person.data.id}`}
-									class="people-card-link glass-card-shimmer card-hover flex flex-col overflow-hidden items-center text-center p-6"
+									class="people-card-link glass-card-shimmer card-hover bleed-x-mobile flex flex-col overflow-hidden items-center text-center p-6"
 									data-keywords={searchKeywords}
 								>
 									{/* Avatar */}

--- a/projects/rawkode.academy/website/src/pages/shows/[showId].astro
+++ b/projects/rawkode.academy/website/src/pages/shows/[showId].astro
@@ -282,7 +282,7 @@ function formatDuration(seconds: number) {
                                         videos={feedVideos}
                                 />
                         ) : (
-                                <div class="mx-auto max-w-2xl rounded-2xl glass-card p-12 text-center">
+                                <div class="mx-auto max-w-2xl rounded-2xl glass-card p-12 text-center bleed-x-mobile">
                                         <svg
                                                 class="mx-auto h-16 w-16 text-primary/30 dark:text-primary/20"
                                                 fill="none"

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -281,12 +281,6 @@ const statusLabels: Record<string, string> = {
 	assess: "Watch",
 	trial: "Explore",
 };
-const groupingLabels: Record<string, string> = {
-	plumbing: "Plumbing",
-	platform: "Platform",
-	observability: "Observability",
-	security: "Security",
-};
 const trajectoryEmoji: Record<string, string> = {
 	rising: "↗️",
 	stable: "→",
@@ -295,9 +289,6 @@ const trajectoryEmoji: Record<string, string> = {
 
 const statusLabel = technology.matrix?.status
 	? statusLabels[technology.matrix.status] || technology.matrix.status
-	: "";
-const groupingLabel = technology.matrix?.grouping
-	? groupingLabels[technology.matrix.grouping] || technology.matrix.grouping
 	: "";
 const trajectoryIcon = technology.matrix?.trajectory
 	? trajectoryEmoji[technology.matrix.trajectory]
@@ -360,122 +351,107 @@ const hasCommunityLinks =
 		/>
 	</Fragment>
 	<div class="technology-stage page-px section-py section-pt-0">
-		<section class="w-full">
-			<div class="glass-panel technology-header-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto">
-				<div class="mb-6">
-					<Breadcrumb elements={[
-						{ title: 'Home', link: '/' },
-						{ title: 'Technologies', link: '/technology' },
-						{ title: technology.name, link: `/technology/${technology.id}` },
-					]} />
+		<section class="technology-hero w-full max-w-7xl mx-auto">
+			<div class="mb-5">
+				<Breadcrumb elements={[
+					{ title: 'Home', link: '/' },
+					{ title: 'Technologies', link: '/technology' },
+					{ title: technology.name, link: `/technology/${technology.id}` },
+				]} />
+			</div>
+
+			<div class="flex items-center gap-4 mb-4">
+				<div class="technology-hero-logo">
+					<img
+						src={technology.logo ? technology.logo : placeholderLogo}
+						alt={`${technology.name} Logo`}
+						class="w-full h-full object-contain"
+						onerror={`this.onerror=null; this.src='${placeholderLogo}';`}
+					/>
 				</div>
+				<h1 class="technology-title m-0">{technology.name}</h1>
+			</div>
 
-				<div class="technology-header-grid">
-					<div class="technology-header-copy">
-						<div class="flex flex-wrap items-center gap-2 mb-3">
-							{technology.matrix && (
-								<a href="/technology/matrix" class="inline-flex flex-wrap items-center gap-2 group">
-									<span class={`matrix-badge matrix-badge-${technology.matrix.status}`}>
-										{statusLabel}
-									</span>
-									<span class="text-sm text-muted group-hover:text-primary transition-colors">
-										{groupingLabel}
-									</span>
-									{trajectoryIcon && (
-										<span class="text-sm" title={`Trajectory: ${technology.matrix.trajectory}`}>
-											{trajectoryIcon}
-										</span>
-									)}
-									<svg class="w-4 h-4 text-gray-400 group-hover:text-primary transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
-									</svg>
-								</a>
-							)}
-							{technology.cncf?.status && (
-								<span class={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border ${cncfStatusColors[technology.cncf.status]}`}>
-									<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-									</svg>
-									CNCF {cncfStatusLabels[technology.cncf.status]}
-								</span>
-							)}
-							{technology.category && (
-								<span class="technology-taxonomy-pill">
-									{technology.category}{technology.subcategory && ` / ${technology.subcategory}`}
-								</span>
-							)}
-						</div>
+			<div class="flex flex-wrap items-center gap-2 mb-5">
+				{technology.matrix && (
+					<a
+						href="/technology/matrix"
+						class={`matrix-badge matrix-badge-${technology.matrix.status} matrix-badge-link`}
+						title={`Matrix: ${statusLabel}${trajectoryIcon ? ` · ${technology.matrix.trajectory}` : ""}`}
+					>
+						{statusLabel}
+						{trajectoryIcon && <span class="ml-1">{trajectoryIcon}</span>}
+					</a>
+				)}
+				{technology.cncf?.status && (
+					<span class={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border ${cncfStatusColors[technology.cncf.status]}`}>
+						CNCF {cncfStatusLabels[technology.cncf.status]}
+					</span>
+				)}
+				{(technology.subcategory || technology.category) && (
+					<span class="technology-taxonomy-pill" title={technology.category && technology.subcategory ? `${technology.category} / ${technology.subcategory}` : undefined}>
+						{technology.subcategory ?? technology.category}
+					</span>
+				)}
+				{technology.license && (
+					<span class="technology-taxonomy-pill">
+						{technology.license}
+					</span>
+				)}
+			</div>
 
-						<p class="technology-kicker">
-							{hasContent ? "Technology Guide" : "Technology Overview"}
-						</p>
-						<h1 class="technology-title">{technology.name}</h1>
-
-						<div class="flex flex-wrap gap-3 items-center">
-							{technology.website && (
-								<a
-									href={technology.website}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl"
-								>
-									<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
-									</svg>
-									Official Website
-								</a>
-							)}
-							{technology.documentation && (
-								<a
-									href={technology.documentation}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="btn-glass inline-flex items-center gap-2 px-5 py-2.5 rounded-xl"
-								>
-									<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-									</svg>
-									Documentation
-								</a>
-							)}
-							{technology.source && (
-								<a
-									href={technology.source}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="btn-glass inline-flex items-center gap-2 px-5 py-2.5 rounded-xl"
-								>
-									<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" />
-									</svg>
-									Source Code
-								</a>
-							)}
-							{hasContent && (
-								<a href="#complete-guide" class="technology-guide-link">
-									Read the guide
-								</a>
-							)}
-						</div>
-
-						{technology.license && (
-							<p class="mt-4 text-sm text-muted">
-								License: <span class="font-medium text-secondary-content">{technology.license}</span>
-							</p>
+			<div class="flex flex-wrap gap-2 items-center">
+				{hasContent && (
+					<a href="#complete-guide" class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold">
+						<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+						</svg>
+						Read the guide
+					</a>
+				)}
+				{technology.website && (
+					<a
+						href={technology.website}
+						target="_blank"
+						rel="noopener noreferrer"
+						class={`${hasContent ? 'btn-outline' : 'btn-solid'} inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold`}
+					>
+						<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+						</svg>
+						Official Website
+					</a>
+				)}
+				{(technology.documentation || technology.source) && (
+					<div class="flex flex-wrap gap-x-4 gap-y-1 items-center text-sm">
+						{technology.documentation && (
+							<a
+								href={technology.documentation}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-link inline-flex items-center gap-1.5"
+							>
+								<svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+								</svg>
+								Documentation
+							</a>
+						)}
+						{technology.source && (
+							<a
+								href={technology.source}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-link inline-flex items-center gap-1.5"
+							>
+								<svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" />
+								</svg>
+								Source code
+							</a>
 						)}
 					</div>
-
-					<div class="technology-logo-shell">
-						<div class="glass-media-brand technology-logo-card">
-							<img
-								src={technology.logo ? technology.logo : placeholderLogo}
-								alt={`${technology.name} Logo`}
-								class="w-full h-full object-contain drop-shadow-lg"
-								onerror={`this.onerror=null; this.src='${placeholderLogo}';`}
-							/>
-						</div>
-					</div>
-				</div>
+				)}
 			</div>
 		</section>
 
@@ -922,35 +898,72 @@ const hasCommunityLinks =
 		gap: clamp(1.5rem, 3vw, 2.5rem);
 	}
 
-	.technology-header-panel {
+	.technology-hero {
 		position: relative;
-		overflow: hidden;
 	}
 
-	.technology-header-panel::before {
-		content: "";
-		position: absolute;
-		inset: auto -5rem -7rem auto;
-		width: 16rem;
-		height: 16rem;
-		border-radius: 9999px;
-		background: radial-gradient(circle, rgba(20, 184, 166, 0.18), rgba(20, 184, 166, 0));
-		pointer-events: none;
-	}
-
-	.technology-header-grid {
-		position: relative;
+	.technology-hero-logo {
+		flex-shrink: 0;
+		width: 3rem;
+		height: 3rem;
 		display: grid;
-		gap: clamp(1.5rem, 3vw, 3rem);
-		align-items: center;
+		place-items: center;
 	}
 
-	.technology-header-copy {
-		position: relative;
-		z-index: 1;
+	@media (min-width: 768px) {
+		.technology-hero-logo {
+			width: 4rem;
+			height: 4rem;
+		}
+	}
+
+	.technology-hero-logo img {
+		max-width: 100%;
+		max-height: 100%;
+	}
+
+	.matrix-badge-link {
+		text-decoration: none;
+		transition: transform 180ms ease, filter 180ms ease;
+	}
+
+	.matrix-badge-link:hover {
+		transform: translateY(-1px);
+		filter: brightness(1.05);
+	}
+
+	.btn-outline {
+		color: var(--text-primary-content);
+		background: transparent;
+		border: 1px solid rgba(148, 163, 184, 0.45);
+		transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+	}
+
+	.btn-outline:hover {
+		transform: translateY(-1px);
+		border-color: var(--brand-primary);
+		background: rgba(95, 94, 215, 0.04);
+	}
+
+	:global(.dark) .btn-outline {
+		border-color: rgba(148, 163, 184, 0.32);
+	}
+
+	.text-link {
+		color: var(--text-secondary-content);
+		font-weight: 500;
+		text-decoration: none;
+		transition: color 180ms ease;
+	}
+
+	.text-link:hover {
+		color: var(--brand-primary);
+		text-decoration: underline;
+		text-underline-offset: 3px;
 	}
 
 	.technology-kicker {
+		/* retained for the Field Guide kicker further down the page */
 		margin: 0 0 0.85rem;
 		font-size: 0.72rem;
 		font-weight: 700;
@@ -962,58 +975,23 @@ const hasCommunityLinks =
 	.technology-taxonomy-pill {
 		display: inline-flex;
 		align-items: center;
-		padding: 0.4rem 0.75rem;
+		padding: 0.25rem 0.65rem;
 		border-radius: 9999px;
-		font-size: 0.76rem;
+		font-size: 0.72rem;
 		font-weight: 600;
-		color: rgb(31, 41, 55);
-		background: rgba(255, 255, 255, 0.72);
+		color: var(--text-secondary-content);
+		background: rgba(148, 163, 184, 0.12);
 		border: 1px solid rgba(148, 163, 184, 0.22);
 	}
 
 	.technology-title {
-		margin: 0 0 1rem;
-		font-size: clamp(2.2rem, 4.2vw, 3.8rem);
-		line-height: 0.98;
-		font-weight: 850;
-		letter-spacing: -0.05em;
-		color: rgb(15, 23, 42);
+		margin: 0;
+		font-size: clamp(2rem, 6vw, 3.2rem);
+		line-height: 1.04;
+		font-weight: 800;
+		letter-spacing: -0.04em;
+		color: var(--text-primary-content);
 		text-wrap: balance;
-	}
-
-	.technology-guide-link {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0.72rem 1rem;
-		border-radius: 0.9rem;
-		font-size: 0.95rem;
-		font-weight: 700;
-		color: rgb(15, 23, 42);
-		background: rgba(255, 255, 255, 0.7);
-		border: 1px solid rgba(148, 163, 184, 0.2);
-		transition:
-			transform 180ms ease,
-			border-color 180ms ease,
-			background 180ms ease;
-	}
-
-	.technology-guide-link:hover {
-		transform: translateY(-1px);
-		background: rgba(255, 255, 255, 0.94);
-		border-color: rgba(13, 148, 136, 0.24);
-	}
-
-	.technology-logo-shell {
-		display: grid;
-		place-items: center;
-	}
-
-	.technology-logo-card {
-		width: clamp(8.2rem, 18vw, 11rem);
-		height: clamp(8.2rem, 18vw, 11rem);
-		padding: 1.2rem;
-		border-radius: 2rem;
 	}
 
 	.main-content-grid {

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -402,20 +402,12 @@ const hasCommunityLinks =
 
 			<div class="technology-cta-row">
 				<div class="flex flex-wrap gap-2 items-center">
-					{hasContent && (
-						<a href="#complete-guide" class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold">
-							<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-								<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-							</svg>
-							Read the guide
-						</a>
-					)}
 					{technology.website && (
 						<a
 							href={technology.website}
 							target="_blank"
 							rel="noopener noreferrer"
-							class={`${hasContent ? 'btn-outline' : 'btn-solid'} inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold`}
+							class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold"
 						>
 							<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
@@ -1040,13 +1032,19 @@ const hasCommunityLinks =
 			inset 0 1px 0 rgba(255, 255, 255, 0.82);
 	}
 
-	/* Mobile: kill card chrome on the long-form panels so content meets the
-	 * viewport edge instead of leaving a narrow gutter on either side. */
+	/* Mobile: pull the grid all the way out to the viewport edges (escapes
+	 * both the main layout's page-px and .technology-stage's page-px) and
+	 * strip card chrome on each panel so content reaches the device edges.
+	 * The panels' internal padding stays put, keeping prose aligned with
+	 * the breadcrumb/hero. */
 	@media (max-width: 639px) {
+		.main-content-grid {
+			margin-inline: calc(50% - 50vw);
+		}
+
 		.guide-panel,
 		.video-panel,
 		.matrix-rail-panel {
-			margin-inline: calc(-1 * var(--space-page));
 			border-radius: 0;
 			border-inline: 0;
 			box-shadow: none;

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -1040,6 +1040,25 @@ const hasCommunityLinks =
 			inset 0 1px 0 rgba(255, 255, 255, 0.82);
 	}
 
+	/* Mobile: kill card chrome on the long-form panels so content meets the
+	 * viewport edge instead of leaving a narrow gutter on either side. */
+	@media (max-width: 639px) {
+		.guide-panel,
+		.video-panel,
+		.matrix-rail-panel {
+			margin-inline: calc(-1 * var(--space-page));
+			border-radius: 0;
+			border-inline: 0;
+			box-shadow: none;
+		}
+
+		.technology-signal-panel {
+			border-radius: 0;
+			border-inline: 0;
+			box-shadow: none;
+		}
+	}
+
 	.guide-prose :global(pre) {
 		max-width: 100%;
 		overflow-x: auto;

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -400,28 +400,30 @@ const hasCommunityLinks =
 				)}
 			</div>
 
-			<div class="flex flex-wrap gap-2 items-center">
-				{hasContent && (
-					<a href="#complete-guide" class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold">
-						<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-						</svg>
-						Read the guide
-					</a>
-				)}
-				{technology.website && (
-					<a
-						href={technology.website}
-						target="_blank"
-						rel="noopener noreferrer"
-						class={`${hasContent ? 'btn-outline' : 'btn-solid'} inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold`}
-					>
-						<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
-						</svg>
-						Official Website
-					</a>
-				)}
+			<div class="technology-cta-row">
+				<div class="flex flex-wrap gap-2 items-center">
+					{hasContent && (
+						<a href="#complete-guide" class="btn-solid inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold">
+							<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+							</svg>
+							Read the guide
+						</a>
+					)}
+					{technology.website && (
+						<a
+							href={technology.website}
+							target="_blank"
+							rel="noopener noreferrer"
+							class={`${hasContent ? 'btn-outline' : 'btn-solid'} inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold`}
+						>
+							<svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+							</svg>
+							Official Website
+						</a>
+					)}
+				</div>
 				{(technology.documentation || technology.source) && (
 					<div class="flex flex-wrap gap-x-4 gap-y-1 items-center text-sm">
 						{technology.documentation && (
@@ -932,6 +934,22 @@ const hasCommunityLinks =
 		filter: brightness(1.05);
 	}
 
+	.technology-cta-row {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.875rem;
+	}
+
+	@media (min-width: 640px) {
+		.technology-cta-row {
+			flex-direction: row;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 0.5rem 1.25rem;
+		}
+	}
+
 	.btn-outline {
 		color: var(--text-primary-content);
 		background: transparent;
@@ -996,8 +1014,13 @@ const hasCommunityLinks =
 
 	.main-content-grid {
 		display: grid;
+		grid-template-columns: minmax(0, 1fr);
 		gap: 1.25rem;
 		align-items: start;
+	}
+
+	.main-content-grid > * {
+		min-width: 0;
 	}
 
 	.media-rail {
@@ -1006,6 +1029,8 @@ const hasCommunityLinks =
 	}
 
 	.guide-panel {
+		min-width: 0;
+		overflow-wrap: anywhere;
 		border: 1px solid rgba(148, 163, 184, 0.16);
 		background:
 			linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9)),
@@ -1013,6 +1038,22 @@ const hasCommunityLinks =
 		box-shadow:
 			0 18px 44px rgba(15, 23, 42, 0.06),
 			inset 0 1px 0 rgba(255, 255, 255, 0.82);
+	}
+
+	.guide-prose :global(pre) {
+		max-width: 100%;
+		overflow-x: auto;
+	}
+
+	.guide-prose :global(table) {
+		display: block;
+		max-width: 100%;
+		overflow-x: auto;
+	}
+
+	.guide-prose :global(img) {
+		max-width: 100%;
+		height: auto;
 	}
 
 	.guide-title {

--- a/projects/rawkode.academy/website/src/pages/technology/index.astro
+++ b/projects/rawkode.academy/website/src/pages/technology/index.astro
@@ -45,7 +45,7 @@ try {
 	<div class="flex flex-col stack-gap-lg section-py section-pt-0 page-px">
 		<!-- Hero Section -->
 		<section class="w-full">
-			<div class="glass-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto">
+			<div class="glass-panel rounded-3xl p-6 md:p-8 max-w-7xl mx-auto bleed-x-mobile">
 				<div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
 					<!-- Hero Copy -->
 					<div class="flex-1 space-y-4">
@@ -99,7 +99,7 @@ try {
 							return (
 								<a
 									href={`/technology/${tech.id}`}
-									class="tech-card-link glass-card-shimmer card-hover flex flex-col overflow-hidden"
+									class="tech-card-link glass-card-shimmer card-hover bleed-x-mobile flex flex-col overflow-hidden"
 									data-keywords={searchKeywords}
 								>
 									{/* Logo Container */}

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -305,7 +305,7 @@ if (isAuthenticated && user?.id) {
 				/>
 
 				{/* Server-rendered episode description for UX and crawlability */}
-				<section class="glass-card-shimmer p-4 sm:p-6">
+				<section class="glass-card-shimmer bleed-x-mobile p-4 sm:p-6">
 					<div class="space-y-1">
 						<p class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
 							Overview

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -173,12 +173,10 @@ const breadcrumbElements = showEntry
 			{ title: "Home", link: "/" },
 			{ title: "Videos", link: "/watch" },
 			{ title: showEntry.data.name, link: `/shows/${showEntry.id}` },
-			{ title: video.data.title, link: `/watch/${video.data.slug}` },
 		]
 	: [
 			{ title: "Home", link: "/" },
 			{ title: "Videos", link: "/watch" },
-			{ title: video.data.title, link: `/watch/${video.data.slug}` },
 		];
 
 const thumbnailUrl = `https://content.rawkode.academy/videos/${video.data.id}/thumbnail.jpg`;

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -390,6 +390,7 @@ html.dark {
 			);
 	}
 
+
 	.surface-divider {
 		border-color: var(--surface-border);
 	}
@@ -981,11 +982,17 @@ html.dark {
 	}
 
 	/* Mobile full-bleed escape hatch for card-style sections.
-	 * Cancels the parent `.content-px` mobile padding (px-3) so the card
-	 * stretches to the device edge; restores normal card chrome from `sm` up.
-	 * Pair with a class that provides border/radius (e.g. `glass-card-shimmer`). */
+	 * Pulls the element to the true viewport edges (escaping however many
+	 * layers of page-px sit between it and the viewport) and strips
+	 * horizontal chrome below sm. Restores normal card chrome from sm up. */
 	.bleed-x-mobile {
-		@apply -mx-3 rounded-none border-x-0 sm:mx-0 sm:rounded-2xl sm:border-x;
+		@apply rounded-none border-x-0 sm:rounded-2xl sm:border-x;
+	}
+
+	@media (max-width: 639px) {
+		.bleed-x-mobile {
+			margin-inline: calc(50% - 50vw);
+		}
 	}
 
 	/* Responsive Section Gap - for vertical spacing between sections */

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -980,6 +980,14 @@ html.dark {
 		@apply px-3 sm:px-6 lg:px-8;
 	}
 
+	/* Mobile full-bleed escape hatch for card-style sections.
+	 * Cancels the parent `.content-px` mobile padding (px-3) so the card
+	 * stretches to the device edge; restores normal card chrome from `sm` up.
+	 * Pair with a class that provides border/radius (e.g. `glass-card-shimmer`). */
+	.bleed-x-mobile {
+		@apply -mx-3 rounded-none border-x-0 sm:mx-0 sm:rounded-2xl sm:border-x;
+	}
+
 	/* Responsive Section Gap - for vertical spacing between sections */
 	.section-gap {
 		@apply space-y-3 sm:space-y-4 lg:space-y-6;


### PR DESCRIPTION
## Summary

Mobile-focused rework of the technology detail page hero. Same data, smaller chrome, clearer hierarchy.

Inspired by [this audit](https://github.com/rawkode-academy/rawkode-academy/pulls) — paraphrased: \"three different CTA styles, one full-width category pill that says Observability twice, an arrow between two unrelated status pills, and a card-inside-padded-viewport that double-margins the content on mobile.\"

## Before → After (concrete)

| Before | After |
|---|---|
| Inner glass-panel card with its own padding inside the page padding | Flat hero, content sits in page-px directly |
| Logo as a standalone ~10rem card stacked under the buttons | 48px logo inline with the heading (64px at md+) |
| Status row: matrix link → CNCF pill with arrow → giant taxonomy pill saying "Observability and Analysis / Observability" | One chips row: matrix, CNCF, subcategory, license — all consistent small pills |
| 3 CTAs at equal visual weight: gradient pill + glass pill + glass pill + outlined link | Primary "Read the guide" (gradient) → outline "Official Website" → text links for Documentation + Source code |
| "TECHNOLOGY GUIDE" kicker above the heading | Removed — added zero information |

## Out of scope (will follow up)

- The breadcrumb still drops the leaf (\"Home > Technologies\" only). That's the `Breadcrumb.astro` component's default behaviour, not page-specific. Worth a separate audit.
- Edge-to-edge mobile across other detail pages (/watch, /read, /news) — same pattern, separate PR.

## Test plan

- [ ] astro check is clean (verified locally).
- [ ] Visit \`/technology/perses\` on mobile + desktop; logo + heading inline; chips row wraps; CTAs in clear hierarchy.
- [ ] Visit \`/technology/<slug>\` for a tech without an MDX body (e.g. one of the 16 just-added entries): "Read the guide" disappears; "Official Website" becomes the gradient primary.
- [ ] Visit a tech with no logo file (\`logos:\` block empty); placeholder renders at 48px instead of as a giant card.

## Human action required

None — pure UI change, no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)