### PR TITLE
feat(website): stitch anonymous → authenticated PostHog identity

### DIFF
--- a/projects/rawkode.academy/website/src/components/posthog/index.astro
+++ b/projects/rawkode.academy/website/src/components/posthog/index.astro
@@ -117,6 +117,17 @@ const { userId } = Astro.props;
 					maskAllInputs: true,
 					sampling: { rate: 0 },
 				},
+				loaded: (ph) => {
+					// Mirror the PostHog distinct id into a cookie so server-side
+					// event capture and the auth callback can stitch anonymous
+					// activity to the authenticated user.
+					try {
+						const id = ph.get_distinct_id?.();
+						if (id) {
+							document.cookie = `posthog_distinct_id=${encodeURIComponent(id)}; path=/; max-age=31536000; SameSite=Lax`;
+						}
+					} catch {}
+				},
 			});
 
 			const utm = getUtmParams();

--- a/projects/rawkode.academy/website/src/pages/api/auth/callback.ts
+++ b/projects/rawkode.academy/website/src/pages/api/auth/callback.ts
@@ -9,7 +9,12 @@ import {
 	SESSION_DURATION_SECONDS,
 	type StoredSession,
 } from "@/lib/auth/server";
-import { captureServerEvent, getDistinctId } from "@/server/analytics";
+import {
+	captureServerEvent,
+	getAnonDistinctIdFromCookies,
+	getDistinctId,
+	identifyServerUser,
+} from "@/server/analytics";
 
 export const GET: APIRoute = async (context) => {
 	const code = context.url.searchParams.get("code");
@@ -126,12 +131,30 @@ export const GET: APIRoute = async (context) => {
 		maxAge: SESSION_DURATION_SECONDS,
 	});
 
+	// Stitch the pre-auth anonymous session to the now-authenticated user
+	// so downstream PostHog queries see one identity across the funnel.
+	const anonId = getAnonDistinctIdFromCookies(context.request);
+	if (anonId && anonId !== userInfo.sub) {
+		await identifyServerUser(
+			{
+				distinctId: userInfo.sub,
+				anonId,
+				set: {
+					email: userInfo.email,
+					name: userInfo.name,
+				},
+			},
+			analytics,
+		);
+	}
+
 	await captureServerEvent(
 		{
 			event: "sign_in_completed",
 			properties: {
 				auth_method: "oidc",
 				return_to: returnTo,
+				...(anonId && anonId !== userInfo.sub ? { anon_id: anonId } : {}),
 			},
 			distinctId: userInfo.sub,
 		},

--- a/projects/rawkode.academy/website/src/server/analytics.ts
+++ b/projects/rawkode.academy/website/src/server/analytics.ts
@@ -19,16 +19,26 @@ export type AnalyticsAttribution = {
 
 /**
  * Attempt to extract an anonymous distinct id from cookies.
- * Looks for a session cookie or generates a fingerprint.
+ * Prefers the PostHog distinct id (set client-side by the posthog component)
+ * so server- and client-emitted events share a single identity. Falls back to
+ * a generic `session_id` cookie for environments where PostHog hasn't booted.
  */
 export function getAnonDistinctIdFromCookies(req: Request): string | undefined {
 	const cookieHeader = req.headers.get("cookie");
 	if (!cookieHeader) return undefined;
 
-	// Look for session cookie
-	const match = cookieHeader.match(/(?:^|;\s*)session_id=([^;]+)/);
-	if (match?.[1]) {
-		return match[1];
+	const phMatch = cookieHeader.match(/(?:^|;\s*)posthog_distinct_id=([^;]+)/);
+	if (phMatch?.[1]) {
+		try {
+			return decodeURIComponent(phMatch[1]);
+		} catch {
+			return phMatch[1];
+		}
+	}
+
+	const sessionMatch = cookieHeader.match(/(?:^|;\s*)session_id=([^;]+)/);
+	if (sessionMatch?.[1]) {
+		return sessionMatch[1];
 	}
 
 	return undefined;


### PR DESCRIPTION
## Summary
Wire up identity stitching across the funnel so anonymous activity isn't orphaned at sign-in. Three small fixes:

1. **PostHog component writes its distinct id into a cookie** (`posthog_distinct_id`, 1y, SameSite=Lax) inside the `loaded` callback so server-side handlers can see the same identity the browser is using.
2. **`getAnonDistinctIdFromCookies` reads that cookie first**, with `session_id` as fallback. Server-emitted events (newsletter signup, lead-magnet conversion) now share one identity with client events for the same visit.
3. **The OIDC auth callback calls `identifyServerUser`** (the existing helper that was previously dead code) to emit a `user.identified` CloudEvent linking `anon_id` → `user.sub`, and stamps `anon_id` on the `sign_in_completed` event so the stitch is reconstructable in the analytics pipeline.

`posthog.reset()` on logout was already wired in `profile.vue` — kept as-is.

## Why this matters
Before: anonymous events stayed orphaned after a user signed up. The funnel showed visitor and "activated_user" as disconnected populations. After: the same identity threads through the whole funnel so we can actually answer "which anonymous visits convert."

## Test plan
- [x] `bunx astro check` clean
- [ ] Verify in production after deploy: sign in once, confirm a `user.identified` CloudEvent fires with both ids, and `sign_in_completed` includes `anon_id`
- [ ] Verify the `posthog_distinct_id` cookie is set on a fresh browser session
- [ ] Verify newsletter signup as anonymous user fires with the PostHog cookie's distinct id (not "anonymous")

## Human action required
- After merge + deploy: confirm in PostHog Events that `\$identify` / merge events flow through and that the funnel for "Visitor → activated_user" works end-to-end with a test signup.

Refs #938 (Phase 1, PR 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)