### PR TITLE
feat(website): first/last-touch UTM attribution on funnel events

### DIFF
--- a/projects/rawkode.academy/website/src/actions/courses.ts
+++ b/projects/rawkode.academy/website/src/actions/courses.ts
@@ -10,6 +10,7 @@ import {
 	captureServerEvent,
 	getAttributionFromSource,
 	getDistinctId,
+	getEventAttribution,
 } from "../server/analytics";
 
 const SignupSchema = z.object({
@@ -113,6 +114,7 @@ export const signupForCourseUpdates = defineAction({
 			const analytics = env.ANALYTICS as Fetcher | undefined;
 			const attribution = getAttributionFromSource(source);
 			const campaign = parseCampaignAttribution(campaignAttribution);
+			const cookieAttribution = getEventAttribution(ctx.request);
 			await captureServerEvent(
 				{
 					event: GROWTH_EVENTS.COURSE_SIGNUP,
@@ -124,6 +126,7 @@ export const signupForCourseUpdates = defineAction({
 						...(source ? { source } : {}),
 						...attribution,
 						...campaign,
+						...cookieAttribution,
 					},
 				},
 				analytics,
@@ -144,6 +147,7 @@ export const signupForCourseUpdates = defineAction({
 						...(source ? { source } : {}),
 						...attribution,
 						...campaign,
+						...cookieAttribution,
 					},
 				},
 				analytics,

--- a/projects/rawkode.academy/website/src/actions/newsletter.ts
+++ b/projects/rawkode.academy/website/src/actions/newsletter.ts
@@ -7,6 +7,7 @@ import {
 	captureServerEvent,
 	getAttributionFromSource,
 	getDistinctId,
+	getEventAttribution,
 } from "@/server/analytics";
 
 /**
@@ -82,6 +83,7 @@ async function captureActivatedUserFromNewsletter({
 					: {}),
 				...attribution,
 				...campaign,
+				...getEventAttribution(context.request),
 			},
 		},
 		getAnalyticsBinding(),
@@ -116,6 +118,7 @@ async function captureNewsletterAnalytics({
 					: {}),
 				...getAttributionFromSource(source),
 				...campaign,
+				...getEventAttribution(context.request),
 			},
 		},
 		getAnalyticsBinding(),

--- a/projects/rawkode.academy/website/src/components/posthog/index.astro
+++ b/projects/rawkode.academy/website/src/components/posthog/index.astro
@@ -12,19 +12,20 @@ const { userId } = Astro.props;
 	let posthogInitialized = false;
 	let enableInFlight = false;
 
+	const UTM_KEYS = [
+		"utm_source",
+		"utm_medium",
+		"utm_campaign",
+		"utm_term",
+		"utm_content",
+	];
+
 	const getUtmParams = () => {
 		try {
 			const url = new URL(location.href);
 			const params = new URLSearchParams(url.search);
-			const keys = [
-				"utm_source",
-				"utm_medium",
-				"utm_campaign",
-				"utm_term",
-				"utm_content",
-			];
 			const out = {};
-			for (const key of keys) {
+			for (const key of UTM_KEYS) {
 				if (params.has(key)) {
 					out[key] = params.get(key);
 				}
@@ -33,6 +34,75 @@ const { userId } = Astro.props;
 		} catch {
 			return {};
 		}
+	};
+
+	const readCookie = (name) => {
+		try {
+			const match = document.cookie.match(
+				new RegExp(`(?:^|;\\s*)${name}=([^;]+)`),
+			);
+			return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+		} catch {
+			return undefined;
+		}
+	};
+
+	const writeCookie = (name, value, maxAgeSeconds) => {
+		try {
+			const encoded = encodeURIComponent(value);
+			document.cookie = `${name}=${encoded}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax`;
+		} catch {}
+	};
+
+	const buildAttribution = () => {
+		const utm = getUtmParams();
+		const data = {
+			landing_page: location.pathname,
+			initial_referrer: document.referrer || "",
+			...utm,
+			captured_at: new Date().toISOString(),
+		};
+		return { data, hasUtm: Object.keys(utm).length > 0 };
+	};
+
+	const persistAttributionCookies = () => {
+		const { data, hasUtm } = buildAttribution();
+		// First-touch: write once, persist a year. Identifies the original
+		// surface that brought the user. Required for cross-session funnel
+		// analysis.
+		if (!readCookie("rk_first_touch")) {
+			writeCookie("rk_first_touch", JSON.stringify(data), 60 * 60 * 24 * 365);
+		}
+		// Last-touch: overwrite when a new UTM hit lands. Useful for
+		// attributing the immediate campaign that drove an action.
+		if (hasUtm) {
+			writeCookie("rk_last_touch", JSON.stringify(data), 60 * 60 * 24 * 30);
+		}
+	};
+
+	const registerAttributionSuperProperties = () => {
+		try {
+			const utm = getUtmParams();
+			if (Object.keys(utm).length > 0) {
+				window.posthog.register({
+					...utm,
+					landing_page: location.pathname,
+				});
+			}
+			const firstTouch = readCookie("rk_first_touch");
+			if (firstTouch) {
+				const parsed = JSON.parse(firstTouch);
+				const onceProps = {};
+				for (const [k, v] of Object.entries(parsed)) {
+					if (typeof v === "string" && v) {
+						onceProps[`first_touch_${k}`] = v;
+					}
+				}
+				if (Object.keys(onceProps).length > 0) {
+					window.posthog.register_once(onceProps);
+				}
+			}
+		} catch {}
 	};
 
 	const bootstrapPostHog = () => {
@@ -109,6 +179,11 @@ const { userId } = Astro.props;
 		try {
 			bootstrapPostHog();
 
+			// Persist attribution cookies before init so the loaded callback,
+			// auth-callback, and server-side actions can read them on the very
+			// first visit.
+			persistAttributionCookies();
+
 			window.posthog.init(PH_KEY, {
 				api_host: PH_HOST,
 				autocapture: true,
@@ -130,10 +205,7 @@ const { userId } = Astro.props;
 				},
 			});
 
-			const utm = getUtmParams();
-			if (Object.keys(utm).length > 0) {
-				window.posthog.register(utm);
-			}
+			registerAttributionSuperProperties();
 
 			if (userId) {
 				window.posthog.identify(userId);

--- a/projects/rawkode.academy/website/src/pages/api/auth/callback.ts
+++ b/projects/rawkode.academy/website/src/pages/api/auth/callback.ts
@@ -13,6 +13,7 @@ import {
 	captureServerEvent,
 	getAnonDistinctIdFromCookies,
 	getDistinctId,
+	getEventAttribution,
 	identifyServerUser,
 } from "@/server/analytics";
 
@@ -155,6 +156,7 @@ export const GET: APIRoute = async (context) => {
 				auth_method: "oidc",
 				return_to: returnTo,
 				...(anonId && anonId !== userInfo.sub ? { anon_id: anonId } : {}),
+				...getEventAttribution(context.request),
 			},
 			distinctId: userInfo.sub,
 		},

--- a/projects/rawkode.academy/website/src/server/analytics.ts
+++ b/projects/rawkode.academy/website/src/server/analytics.ts
@@ -59,6 +59,96 @@ export function getDistinctId(ctx: {
 	);
 }
 
+type AttributionSnapshot = {
+	utm_source?: string;
+	utm_medium?: string;
+	utm_campaign?: string;
+	utm_term?: string;
+	utm_content?: string;
+	landing_page?: string;
+	initial_referrer?: string;
+};
+
+function parseAttributionCookie(raw?: string): AttributionSnapshot | undefined {
+	if (!raw) return undefined;
+	try {
+		const decoded = decodeURIComponent(raw);
+		const parsed = JSON.parse(decoded);
+		if (!parsed || typeof parsed !== "object") return undefined;
+		const out: AttributionSnapshot = {};
+		for (const key of [
+			"utm_source",
+			"utm_medium",
+			"utm_campaign",
+			"utm_term",
+			"utm_content",
+			"landing_page",
+			"initial_referrer",
+		] as const) {
+			const value = (parsed as Record<string, unknown>)[key];
+			if (typeof value === "string" && value) {
+				out[key] = value;
+			}
+		}
+		return Object.keys(out).length > 0 ? out : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Read the `rk_first_touch` and `rk_last_touch` cookies written by the
+ * client-side PostHog component. Use these to attach campaign attribution to
+ * server-emitted funnel events without requiring every CTA call site to pass
+ * it explicitly.
+ */
+export function getAttributionFromCookies(req: Request): {
+	first?: AttributionSnapshot;
+	last?: AttributionSnapshot;
+} {
+	const cookieHeader = req.headers.get("cookie");
+	if (!cookieHeader) return {};
+
+	const firstMatch = cookieHeader.match(
+		/(?:^|;\s*)rk_first_touch=([^;]+)/,
+	);
+	const lastMatch = cookieHeader.match(/(?:^|;\s*)rk_last_touch=([^;]+)/);
+
+	const first = parseAttributionCookie(firstMatch?.[1]);
+	const last = parseAttributionCookie(lastMatch?.[1]);
+
+	return {
+		...(first ? { first } : {}),
+		...(last ? { last } : {}),
+	};
+}
+
+/**
+ * Build the canonical event-attribution properties for funnel events.
+ * Flattens the two attribution snapshots into `first_touch_*` / `last_touch_*`
+ * keys so PostHog can group on them without parsing nested objects.
+ */
+export function getEventAttribution(req?: Request): Record<string, string> {
+	if (!req) return {};
+	const { first, last } = getAttributionFromCookies(req);
+	const out: Record<string, string> = {};
+	if (first) {
+		for (const [k, v] of Object.entries(first)) {
+			if (typeof v === "string" && v) {
+				out[`first_touch_${k}`] = v;
+			}
+		}
+	}
+	if (last) {
+		for (const [k, v] of Object.entries(last)) {
+			if (typeof v === "string" && v) {
+				out[`last_touch_${k}`] = v;
+			}
+		}
+	}
+	return out;
+}
+
 export function getAttributionFromSource(
 	source?: string,
 ): AnalyticsAttribution {
@@ -205,6 +295,20 @@ export async function captureServerEvent(
 		"utm_campaign",
 		"utm_term",
 		"utm_content",
+		"first_touch_utm_source",
+		"first_touch_utm_medium",
+		"first_touch_utm_campaign",
+		"first_touch_utm_term",
+		"first_touch_utm_content",
+		"first_touch_landing_page",
+		"first_touch_initial_referrer",
+		"last_touch_utm_source",
+		"last_touch_utm_medium",
+		"last_touch_utm_campaign",
+		"last_touch_utm_term",
+		"last_touch_utm_content",
+		"last_touch_landing_page",
+		"last_touch_initial_referrer",
 	];
 
 	if (analytics) {


### PR DESCRIPTION
## Summary
Persist campaign attribution in cookies so every server-emitted funnel event (newsletter signup, course signup, activated_user, sign-in completed) carries first-touch and last-touch attribution without each CTA call site having to pass it.

## Changes
- **PostHog component** captures `{utm_*, landing_page, initial_referrer, captured_at}` on every page load. Writes `rk_first_touch` cookie once (1y), overwrites `rk_last_touch` (30d) on new UTM hits. Registers first-touch values as PostHog `register_once` super properties and last-touch + landing_page as `register` super properties so client events get the same data.
- **`getEventAttribution(request)`** helper in `server/analytics.ts` flattens both cookies into `first_touch_*` / `last_touch_*` keys.
- **Newsletter actions** (subscribe + activated_user from lead-magnet), **course actions** (signup + activated_user), and **OIDC sign_in_completed** all merge the new attribution map.
- **`attributesToPromote`** extended so the analytics worker forwards the new keys to PostHog as event properties.

## Why this matters
We can now answer: "which UTM-tagged campaigns drove visitors who later signed up?" — across sessions, without needing every CTA to thread attribution through props. First-touch tells us the surface that brought a user; last-touch tells us the campaign that closed them.

## Test plan
- [x] `bunx astro check` clean
- [ ] Verify in production: hit any page with `?utm_source=test&utm_medium=audit&utm_campaign=verify`, then sign up for the newsletter and confirm the event has `first_touch_utm_source=test`, `first_touch_landing_page=/`, etc.
- [ ] Verify `rk_first_touch` cookie is set once and persists; `rk_last_touch` rolls forward on new UTMs.

## Human action required
- None for code. After deploy, start tagging YouTube descriptions / Slack / Twitter posts with `?utm_source=<channel>&utm_medium=<surface>&utm_campaign=<campaign>` to feed the attribution pipeline.

Refs #938 (Phase 1, PR 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)