### PR TITLE
feat(website): richer SEO on /technology/[id] pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/technology-article-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/technology-article-jsonld.astro
@@ -1,0 +1,64 @@
+---
+/**
+ * Wraps the "Complete Guide" / field-guide body on a technology page with
+ * TechArticle structured data. Helps Google qualify the long-form body
+ * separately from the SoftwareApplication entity for rich snippets and
+ * sitelink eligibility.
+ */
+interface Props {
+	headline: string;
+	description: string;
+	url: string;
+	image?: string | undefined;
+	siteName?: string | undefined;
+	siteUrl?: string | undefined;
+	about?: string | undefined;
+	keywords?: string | undefined;
+}
+
+const {
+	headline,
+	description,
+	url,
+	image,
+	about,
+	keywords,
+	siteName = "Rawkode Academy",
+	siteUrl = "https://rawkode.academy",
+} = Astro.props;
+
+const jsonLd = {
+	"@context": "https://schema.org",
+	"@type": "TechArticle",
+	headline,
+	description,
+	url,
+	mainEntityOfPage: {
+		"@type": "WebPage",
+		"@id": url,
+	},
+	...(image && { image }),
+	...(about && { about }),
+	...(keywords && { keywords }),
+	author: {
+		"@type": "Organization",
+		name: siteName,
+		url: siteUrl,
+	},
+	publisher: {
+		"@type": "Organization",
+		name: siteName,
+		url: siteUrl,
+		logo: {
+			"@type": "ImageObject",
+			url: `${siteUrl}/android-chrome-512x512.png`,
+		},
+	},
+};
+---
+
+<script
+	is:inline
+	type="application/ld+json"
+	set:html={JSON.stringify(jsonLd)}
+></script>

--- a/projects/rawkode.academy/website/src/components/html/technology-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/technology-jsonld.astro
@@ -8,13 +8,62 @@ interface Props {
 	source?: string | undefined;
 	documentation?: string | undefined;
 	category?: string | undefined;
+	subcategory?: string | undefined;
+	license?: string | undefined;
+	cncfStatus?: string | undefined;
+	matrixStatus?: string | undefined;
+	siteName?: string | undefined;
+	siteUrl?: string | undefined;
 }
 
-const { name, url, description, image, website, source, documentation, category } = Astro.props;
+const {
+	name,
+	url,
+	description,
+	image,
+	website,
+	source,
+	documentation,
+	category,
+	subcategory,
+	license,
+	cncfStatus,
+	matrixStatus,
+	siteName = "Rawkode Academy",
+	siteUrl = "https://rawkode.academy",
+} = Astro.props;
 
 const sameAs = [website, source, documentation].filter(
 	(v): v is string => Boolean(v),
 );
+
+const keywords = [category, subcategory, cncfStatus ? `cncf ${cncfStatus}` : undefined]
+	.filter((v): v is string => Boolean(v))
+	.join(", ");
+
+const additionalProperty = [
+	matrixStatus
+		? {
+				"@type": "PropertyValue",
+				name: "Rawkode Academy matrix status",
+				value: matrixStatus,
+		  }
+		: undefined,
+	cncfStatus
+		? {
+				"@type": "PropertyValue",
+				name: "CNCF status",
+				value: cncfStatus,
+		  }
+		: undefined,
+	license
+		? {
+				"@type": "PropertyValue",
+				name: "License",
+				value: license,
+		  }
+		: undefined,
+].filter(Boolean);
 
 const jsonLd = {
 	"@context": "https://schema.org",
@@ -24,7 +73,21 @@ const jsonLd = {
 	description,
 	...(image && { image }),
 	...(category && { applicationCategory: category }),
+	...(license && { license }),
+	...(keywords && { keywords }),
 	...(sameAs.length > 0 && { sameAs }),
+	...(documentation && { softwareHelp: documentation }),
+	creator: {
+		"@type": "Organization",
+		name: siteName,
+		url: siteUrl,
+	},
+	publisher: {
+		"@type": "Organization",
+		name: siteName,
+		url: siteUrl,
+	},
+	...(additionalProperty.length > 0 && { additionalProperty }),
 	// Required by Google for SoftwareApplication; permissive defaults
 	operatingSystem: "Any",
 	offers: {

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -6,6 +6,7 @@ import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb.astro";
 import Page from "@/wrappers/page.astro";
 import TechnologyJsonLd from "@/components/html/technology-jsonld.astro";
+import TechnologyArticleJsonLd from "@/components/html/technology-article-jsonld.astro";
 import type { GetStaticPaths } from "astro";
 import { getCollection, render } from "astro:content";
 import matter from "gray-matter";
@@ -234,16 +235,31 @@ const seoTitle =
 		? `${technology.name} Tutorials, Videos & Guides`
 		: `${technology.name} - ${categoryLabel}`);
 
+const cncfStatusLabel = (() => {
+	const status = (technology as any).cncf?.status as string | undefined;
+	if (!status) return undefined;
+	const labels: Record<string, string> = {
+		sandbox: "CNCF Sandbox",
+		incubating: "CNCF Incubating",
+		graduated: "CNCF Graduated",
+		archived: "CNCF Archived",
+	};
+	return labels[status] ?? `CNCF ${status}`;
+})();
+
 const seoDescription = (() => {
 	if (technology.seo?.description) return technology.seo.description;
 	const cncfUseCase = (technology as any).cncf?.useCase as string | undefined;
 	const parts: string[] = [];
+	const projectQualifier = cncfStatusLabel
+		? `a ${cncfStatusLabel} ${categoryLabel} project`
+		: `a ${categoryLabel} project`;
 	if (videoCount > 0) {
 		parts.push(
-			`${videoCount} video${videoCount === 1 ? "" : "s"} and tutorials covering ${technology.name}`,
+			`${videoCount} video${videoCount === 1 ? "" : "s"} and tutorials covering ${technology.name}, ${projectQualifier}`,
 		);
 	} else {
-		parts.push(`${technology.name}, a ${categoryLabel} project`);
+		parts.push(`${technology.name}, ${projectQualifier}`);
 	}
 	if (cncfUseCase) parts.push(cncfUseCase);
 	parts.push(
@@ -340,8 +356,25 @@ const hasCommunityLinks =
 		website={technology.website}
 		source={technology.source}
 		documentation={technology.documentation}
-		category={categoryLabel}
+		category={technology.category ?? categoryLabel}
+		subcategory={technology.subcategory}
+		license={technology.license}
+		cncfStatus={cncfStatusLabel}
+		matrixStatus={technology.matrix?.status ? statusLabels[technology.matrix.status] ?? technology.matrix.status : undefined}
 	/>
+	{hasContent && (
+		<TechnologyArticleJsonLd
+			slot="extra-head"
+			headline={`${technology.name}: Complete Field Guide`}
+			description={seoDescription}
+			url={technologyUrl}
+			image={absoluteLogo}
+			about={technology.name}
+			keywords={[technology.name, technology.category, technology.subcategory, cncfStatusLabel]
+				.filter((v): v is string => Boolean(v))
+				.join(", ")}
+		/>
+	)}
 	<Fragment slot="extra-head">
 		<link
 			rel="alternate"


### PR DESCRIPTION
## Summary
Beef up the structured data and SEO description on `/technology/[id]` so search engines and AI crawlers have more signal to qualify these pages. The Phase 2 reports show technology profiles are both top traffic (~30 pages in the top 25 by traffic) and convert visitors → activated users at 16-20% — this is the highest-leverage SEO target on the site.

## Changes
- **`TechnologyJsonLd` (SoftwareApplication)** now emits `license`, `keywords` (category + subcategory + CNCF status), `softwareHelp` (docs URL), `creator` + `publisher` (Rawkode Academy), and an `additionalProperty` array carrying the Rawkode Academy matrix status, the CNCF status, and the license as `PropertyValue` entries.
- **New `TechnologyArticleJsonLd`** component emits `TechArticle` structured data for the "Complete Field Guide" body when present. Helps Google qualify the long-form prose separately from the `SoftwareApplication` entity for rich snippets and sitelink eligibility.
- **SEO description fallback** now weaves in the CNCF status label (e.g. "a CNCF Graduated Cloud Native Network project") so SERP snippets carry an authoritative qualifier without per-technology editing.

`BreadcrumbList` JSON-LD was already emitted via the shared `Breadcrumb` component, so no duplication needed.

## Verification
Spot-checked on `/technology/cilium` — five JSON-LD blocks parse cleanly:

- `WebPage`, `WebSite` (from default head)
- `SoftwareApplication` (enhanced: license=Apache-2.0, keywords="Runtime, Cloud Native Network, cncf CNCF Graduated", 3 additionalProperty entries, creator + publisher, softwareHelp)
- `TechArticle` (new, only when content body exists)
- `BreadcrumbList`

## Test plan
- [x] `bunx astro check` clean
- [x] Manual: technology page renders all five JSON-LD blocks
- [ ] After deploy, validate one page via [Google Rich Results Test](https://search.google.com/test/rich-results)

## Human action required
- After merge + deploy, pick a couple of high-traffic tech pages (`cilium`, `kubernetes`, `teleport`) and paste them into Google's Rich Results Test to confirm. No code change should be needed.
- Optional: request indexing for refreshed pages in Search Console once PR 7 ships and GSC is set up.

Refs #938 (Phase 3, PR 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)