### PR TITLE
feat(website): richer SEO on /watch/[...slug] pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/html/video-metadata.astro
+++ b/projects/rawkode.academy/website/src/components/html/video-metadata.astro
@@ -1,4 +1,14 @@
 ---
+interface PersonRef {
+	name: string;
+	url?: string;
+}
+
+interface SeriesRef {
+	name: string;
+	url: string;
+}
+
 interface Props {
 	title: string;
 	description: string;
@@ -14,6 +24,9 @@ interface Props {
 	category?: string | undefined;
 	isVideoList?: boolean;
 	clips?: Array<{ name: string; startOffset: number; endOffset?: number }>;
+	creators?: PersonRef[] | undefined;
+	guests?: PersonRef[] | undefined;
+	partOfSeries?: SeriesRef | undefined;
 }
 
 const {
@@ -31,7 +44,16 @@ const {
 	category,
 	isVideoList = false,
 	clips = [],
+	creators,
+	guests = [],
+	partOfSeries,
 } = Astro.props;
+
+// Default to the channel host if no specific creators are provided.
+const resolvedCreators: PersonRef[] =
+	creators && creators.length > 0
+		? creators
+		: [{ name: "David McKay", url: "https://rawkode.academy" }];
 
 // Format duration from seconds to ISO 8601
 function formatDuration(seconds: number): string {
@@ -111,11 +133,34 @@ const structuredData = isVideoList
 					height: 512,
 				},
 			},
-			creator: {
-				"@type": "Person",
-				name: "David McKay",
-				url: "https://rawkode.academy",
-			},
+			creator:
+				resolvedCreators.length === 1
+					? {
+							"@type": "Person",
+							name: resolvedCreators[0]!.name,
+							...(resolvedCreators[0]!.url
+								? { url: resolvedCreators[0]!.url }
+								: {}),
+						}
+					: resolvedCreators.map((person) => ({
+							"@type": "Person",
+							name: person.name,
+							...(person.url ? { url: person.url } : {}),
+						})),
+			...(guests.length > 0 && {
+				actor: guests.map((person) => ({
+					"@type": "Person",
+					name: person.name,
+					...(person.url ? { url: person.url } : {}),
+				})),
+			}),
+			...(partOfSeries && {
+				partOfSeries: {
+					"@type": "CreativeWorkSeries",
+					name: partOfSeries.name,
+					url: partOfSeries.url,
+				},
+			}),
 			hasPart: clips?.length
 				? clips.map((c) => ({
 						"@type": "Clip",

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -182,6 +182,43 @@ const breadcrumbElements = showEntry
 const thumbnailUrl = `https://content.rawkode.academy/videos/${video.data.id}/thumbnail.jpg`;
 const streamUrl = `https://content.rawkode.academy/videos/${video.data.id}/stream.m3u8`;
 const captionUrl = `https://content.rawkode.academy/videos/${video.data.id}/captions/en.vtt`;
+
+// Trim the raw video description to fit Google's ~160-char SERP cap. Cut on a
+// word boundary, prefer the first paragraph, drop markdown that won't render
+// in a meta tag.
+const META_DESCRIPTION_LIMIT = 160;
+const metaDescription = (() => {
+	const firstParagraph =
+		processedDescription.replace(/\r\n/g, "\n").split(/\n{2,}/)[0] ?? "";
+	const raw = firstParagraph
+		.replace(/[*_`]+/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (!raw) return video.data.description ?? "";
+	if (raw.length <= META_DESCRIPTION_LIMIT) return raw;
+	const truncated = raw.slice(0, META_DESCRIPTION_LIMIT);
+	const lastSpace = truncated.lastIndexOf(" ");
+	return `${truncated.slice(0, lastSpace > 80 ? lastSpace : META_DESCRIPTION_LIMIT)}…`;
+})();
+
+const creatorRefs = hostEntries.length > 0
+	? hostEntries.map((host) => ({
+			name: host.data.name,
+			url: `https://rawkode.academy/people/${host.id}`,
+		}))
+	: undefined;
+
+const guestRefs = guestEntries.map((guest) => ({
+	name: guest.data.name,
+	url: `https://rawkode.academy/people/${guest.id}`,
+}));
+
+const partOfSeriesRef = showEntry
+	? {
+			name: showEntry.data.name,
+			url: `https://rawkode.academy/shows/${showEntry.id}`,
+		}
+	: undefined;
 const watchVideoSeoText = await buildWatchVideoSeoText({
 	captionUrl,
 	description: processedDescription,
@@ -221,7 +258,8 @@ if (isAuthenticated && user?.id) {
 
 <Page
 	title={video.data.title}
-	description={video.data.description}
+	description={metaDescription}
+	noindex={metaDescription.length < 30}
 	useImageDirectly={true}
 	image={{ image: new URL(thumbnailUrl) }}
 >
@@ -239,6 +277,9 @@ if (isAuthenticated && user?.id) {
 		isLiveBroadcast={video.data.type === "live"}
 		category={video.data.category}
 		clips={clips}
+		creators={creatorRefs}
+		guests={guestRefs}
+		partOfSeries={partOfSeriesRef}
 	/>
 	<link
 		slot="extra-head"


### PR DESCRIPTION
## Summary
Tighten the SEO surface on `/watch/[...slug]` so individual video pages compete better for long-tail search. The Phase 2 traffic-sources report shows search is the largest external channel (~214 visitors / 90d) and video pages mostly sit in the tail — better per-video signal should pull more search visitors directly into the highest-converting funnel surface.

## Changes
- **VideoObject JSON-LD enrichments**:
  - `creator` is now an array of show hosts when the video belongs to a show (each linked to their `/people` page), instead of a hard-coded `David McKay` singleton.
  - `actor` array of video guests with `/people` URLs.
  - `partOfSeries` (`CreativeWorkSeries`) references the show entity when present, so Google can group episodes properly.
- **`meta description` generator** trims the video body description to ~160 chars on a word boundary, after stripping markdown markers and collapsing whitespace. Falls back to the full description if short enough.
- **`noindex` when the trimmed description is < 30 chars** — pages without a useful snippet shouldn't dilute overall site quality.

## Verified locally
- `/watch/exploring-ngroks-traffic-policies-for-secure-application-development` (standalone, no show) — falls back to David McKay creator. Meta description: 154 chars.
- `/watch/aquaproj-and-dagger` (AlphaBits episode) — emits multi-host `creator` ([David Flanagan, Brian Ketelsen]), single guest `actor` (Brian Ketelsen), and `partOfSeries: AlphaBits` with the correct show URL.

## Test plan
- [x] `bunx astro check` clean
- [x] Manual spot check on a standalone video and a show-attached video
- [ ] After deploy, validate one video via [Google Rich Results Test](https://search.google.com/test/rich-results) for `VideoObject`

## Human action required
- After merge + deploy, pick a high-traffic video and paste into Google's Rich Results Test to confirm `VideoObject` validates with the new fields.

Refs #938 (Phase 3, PR 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)