### PR TITLE
feat(website): noindex preview hosts + sitemap audit

### DIFF
--- a/projects/rawkode.academy/website/src/middleware/robots.ts
+++ b/projects/rawkode.academy/website/src/middleware/robots.ts
@@ -3,11 +3,21 @@ import type { MiddlewareHandler } from "astro";
 const NOINDEX_PREFIXES = ["/api/", "/_server-islands/"];
 const NOINDEX_EXACT_PATHS = new Set(["/graphql", "/settings"]);
 
+// Production hostnames Google should index. Anything else (workers.dev
+// preview URLs, design.rawkode.academy, branch deploys) gets a noindex
+// header so they don't compete with the canonical domain in search.
+const INDEXABLE_HOSTNAMES = new Set(["rawkode.academy", "www.rawkode.academy"]);
+
 export const robotsMiddleware: MiddlewareHandler = async (context, next) => {
 	const response = await next();
 	const pathname = context.url.pathname;
+	const hostname = context.url.hostname;
+
+	const isNonProductionHost =
+		hostname !== "" && !INDEXABLE_HOSTNAMES.has(hostname);
 
 	const shouldNoindex =
+		isNonProductionHost ||
 		NOINDEX_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
 		NOINDEX_EXACT_PATHS.has(pathname);
 


### PR DESCRIPTION
## Summary
- Add a hostname allowlist to the robots middleware: only `rawkode.academy` (and `www.rawkode.academy`) get crawled. Everything else (`*.rawkodeacademy.workers.dev` preview URLs, `design.rawkode.academy`, branch deploys, localhost dev) now returns `X-Robots-Tag: noindex, nofollow` so Google can't index duplicates that would compete with the canonical domain.
- Audited the existing sitemap setup — it's already healthy. All 12 content surfaces (pages, articles, technologies, videos, courses, learning-paths, people, shows, series, news, fresh-news, adrs) are indexed. No code changes needed there.

## Verified
- Local request from `localhost` → `X-Robots-Tag: noindex, nofollow` ✓
- `/sitemap-index.xml` returns 12 shards, all the expected content collections ✓
- Production `rawkode.academy` would fall through to the existing per-path logic (which only noindexes `/api/*`, `/graphql`, `/settings`, `/_server-islands/`).

## Human action required (Search Console)
This needs you to do the steps yourself — site verification + index requests live in your Google account.

1. Sign in to [Google Search Console](https://search.google.com/search-console) with the account that owns `rawkode.academy`.
2. Add the property if it isn't already there:
   - **Domain property** (preferred): `rawkode.academy` — verify via DNS TXT record at your DNS provider.
   - Or **URL prefix**: `https://rawkode.academy/` — verify via the HTML-tag method (a `<meta>` tag, easy to drop into `head.astro` if needed).
3. Submit the sitemap index: `Sitemaps` → enter `sitemap-index.xml` → Submit.
4. Wait 24-48 hours, then check `Coverage` → look for indexing errors. Common issues at this stage are usually: page returning 4xx/5xx, blocked by robots, or noindex on a page Google expected.
5. For the highest-traffic pages, manually request indexing via `URL Inspection` → enter URL → `Request Indexing`. Worth doing for: `/`, `/technology/matrix`, `/technology/matrix/advanced`, the top-converting tech profiles, and the top-traffic individual videos.
6. Bing Webmaster Tools (https://www.bing.com/webmasters) — same process. Lower priority but very low effort.

## Test plan
- [x] `bunx astro check` clean
- [x] Verified local response carries the noindex header
- [x] Verified sitemap-index renders 12 shards
- [ ] After deploy, confirm the production response from `rawkode.academy` does *not* include `X-Robots-Tag: noindex` on indexable pages
- [ ] After deploy, confirm a preview URL (workers.dev) *does* include it

Refs #938 (Phase 3, PR 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)