### PR TITLE
feat(website): related content rails on watch + technology pages

### DIFF
--- a/projects/rawkode.academy/website/src/components/technology/RelatedTechnologies.astro
+++ b/projects/rawkode.academy/website/src/components/technology/RelatedTechnologies.astro
@@ -1,0 +1,61 @@
+---
+interface RelatedTech {
+	id: string;
+	name: string;
+	logoUrl: string | undefined;
+	subcategory?: string | undefined;
+}
+
+interface Props {
+	technologies: RelatedTech[];
+}
+
+const { technologies } = Astro.props;
+---
+
+{technologies.length > 0 && (
+	<section class="mt-8">
+		<h3 class="text-lg font-semibold text-primary-content mb-4">
+			Related technologies
+		</h3>
+		<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			{technologies.map((tech) => (
+				<a
+					href={`/technology/${tech.id.replace(/\/index$/, "")}`}
+					class="glass-interactive group flex items-center gap-3 rounded-lg p-3"
+				>
+					<div class="h-10 w-10 flex-shrink-0 overflow-hidden rounded">
+						<img
+							src={tech.logoUrl || "/apple-touch-icon.png"}
+							alt={tech.name}
+							class="h-full w-full object-contain"
+							loading="lazy"
+							onerror="this.onerror=null; this.src='/apple-touch-icon.png'"
+						/>
+					</div>
+					<div class="min-w-0 flex-1">
+						<div class="truncate font-medium text-secondary-content group-hover:text-primary-content transition-colors">
+							{tech.name}
+						</div>
+						{tech.subcategory && (
+							<div class="truncate text-xs text-muted">{tech.subcategory}</div>
+						)}
+					</div>
+					<svg
+						class="h-4 w-4 flex-shrink-0 text-muted group-hover:text-secondary-content transition-colors"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M9 5l7 7-7 7"
+						/>
+					</svg>
+				</a>
+			))}
+		</div>
+	</section>
+)}

--- a/projects/rawkode.academy/website/src/components/video/ShowVideoSection.astro
+++ b/projects/rawkode.academy/website/src/components/video/ShowVideoSection.astro
@@ -1,0 +1,91 @@
+---
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+	show: CollectionEntry<"shows">;
+	videos: Array<{
+		id: string;
+		title: string;
+		thumbnailUrl: string;
+		slug: string;
+		duration: number | undefined;
+	}>;
+	totalVideos?: number;
+}
+
+const { show, videos, totalVideos } = Astro.props;
+
+const formatDuration = (seconds?: number | null) => {
+	if (typeof seconds !== "number" || seconds <= 0 || Number.isNaN(seconds)) {
+		return "--:--";
+	}
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	const secs = seconds % 60;
+
+	if (hours > 0) {
+		return `${hours}:${minutes.toString().padStart(2, "0")}:${secs
+			.toString()
+			.padStart(2, "0")}`;
+	}
+	return `${minutes}:${secs.toString().padStart(2, "0")}`;
+};
+
+const hasMoreVideos =
+	typeof totalVideos === "number" && totalVideos > videos.length;
+---
+
+{videos.length > 0 && (
+	<section class="mt-8">
+		<div class="flex items-center justify-between mb-4">
+			<h3 class="text-lg font-semibold text-primary-content">
+				More from {show.data.name}
+			</h3>
+			<a
+				href={`/shows/${show.id}`}
+				class="text-sm text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+			>
+				{hasMoreVideos ? `View all ${totalVideos} episodes` : "View show"}
+				<svg
+					class="w-4 h-4"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M9 5l7 7-7 7"
+					/>
+				</svg>
+			</a>
+		</div>
+
+		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+			{videos.map((video) => (
+				<a
+					href={`/watch/${video.slug}`}
+					class="group block glass-interactive rounded-lg overflow-hidden"
+				>
+					<div class="relative aspect-video overflow-hidden bg-gray-100 dark:bg-gray-800">
+						<img
+							src={video.thumbnailUrl}
+							alt={video.title}
+							class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+							loading="lazy"
+						/>
+						<div class="absolute bottom-2 right-2 bg-black/80 text-white text-xs px-2 py-1 rounded">
+							{formatDuration(video.duration)}
+						</div>
+					</div>
+					<div class="p-3">
+						<h4 class="font-medium text-secondary-content group-hover:text-primary-content line-clamp-2 transition-colors text-sm">
+							{video.title}
+						</h4>
+					</div>
+				</a>
+			))}
+		</div>
+	</section>
+)}

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -19,6 +19,7 @@ import {
 import { resolveContentDirSync } from "@rawkodeacademy/content/utils";
 import { resolveTechnologyIconUrl } from "@/utils/resolve-technology-icon";
 import { getVideosForTechnology } from "@/utils/get-videos-for-technology";
+import RelatedTechnologies from "@/components/technology/RelatedTechnologies.astro";
 
 export interface Technology extends Omit<TechnologyData, "logos"> {
 	id: string;
@@ -227,6 +228,44 @@ const videoCount = technology.videos?.length ?? 0;
 const featuredVideos = (technology.videos ?? []).slice(0, 4);
 const categoryLabel =
 	technology.subcategory ?? technology.category ?? "Cloud Native";
+
+// Build the "Related technologies" rail. Prefer explicit relatedTechnologies
+// from frontmatter, then fall back to siblings in the same subcategory.
+const RELATED_TECH_LIMIT = 6;
+const explicitRelated = Array.isArray(
+	(technology as unknown as { relatedTechnologies?: string[] })
+		.relatedTechnologies,
+)
+	? ((technology as unknown as { relatedTechnologies?: string[] })
+			.relatedTechnologies as string[])
+	: [];
+
+const allTechItems = items;
+const techById = new Map(allTechItems.map((t) => [t.id, t]));
+
+const explicitMatches = explicitRelated
+	.map((relId) => techById.get(relId) ?? techById.get(`${relId}/index`))
+	.filter((t): t is (typeof allTechItems)[number] => Boolean(t));
+
+let siblingMatches: typeof allTechItems = [];
+if (technology.subcategory) {
+	siblingMatches = allTechItems.filter(
+		(t) =>
+			t.id !== id &&
+			!explicitMatches.some((e) => e.id === t.id) &&
+			t.data.subcategory === technology.subcategory,
+	);
+}
+
+const relatedTechSeed = [...explicitMatches, ...siblingMatches];
+const relatedTechnologies = relatedTechSeed
+	.slice(0, RELATED_TECH_LIMIT)
+	.map((entry) => ({
+		id: entry.id,
+		name: entry.data.name,
+		logoUrl: resolveTechnologyIconUrl(entry.id, entry.data.logos) ?? undefined,
+		subcategory: entry.data.subcategory,
+	}));
 
 const seoTitle =
 	technology.seo?.title ??
@@ -763,6 +802,14 @@ const hasCommunityLinks =
 				/>
 			</div>
 		</section>
+
+		{relatedTechnologies.length > 0 && (
+			<section class="w-full">
+				<div class="max-w-7xl mx-auto">
+					<RelatedTechnologies technologies={relatedTechnologies} />
+				</div>
+			</section>
+		)}
 
 		<!-- CTA Section -->
 		<section class="w-full">

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -7,6 +7,7 @@ import VideoReactions from "@/components/video/VideoReactions.astro";
 import VideoContentTabs from "@/components/video/video-content-tabs.vue";
 import VideoCast from "@/components/video/VideoCast.astro";
 import TechnologyVideoSection from "@/components/video/TechnologyVideoSection.astro";
+import ShowVideoSection from "@/components/video/ShowVideoSection.astro";
 import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
 import Page from "@/wrappers/page.astro";
 import { Marked } from "marked";
@@ -104,6 +105,42 @@ const showId =
 			? (showRef as { id: string }).id
 			: null;
 const showEntry = showId ? await getEntry("shows", showId) : null;
+
+// Compute "More from this show" — other episodes in the same show, latest first,
+// excluding the current video. Empty list if the video isn't part of a show.
+const SHOW_RELATED_LIMIT = 6;
+const showRelatedAll = showEntry
+	? videos
+			.filter((v) => {
+				if (v.data.slug === slug) return false;
+				const otherShowRef = v.data.show;
+				const otherShowId =
+					typeof otherShowRef === "string"
+						? otherShowRef
+						: otherShowRef && typeof otherShowRef === "object" && "id" in otherShowRef
+							? (otherShowRef as { id: string }).id
+							: null;
+				return otherShowId === showEntry.id;
+			})
+			.sort((a, b) => {
+				const aTime =
+					a.data.publishedAt instanceof Date
+						? a.data.publishedAt.getTime()
+						: new Date(a.data.publishedAt).getTime();
+				const bTime =
+					b.data.publishedAt instanceof Date
+						? b.data.publishedAt.getTime()
+						: new Date(b.data.publishedAt).getTime();
+				return bTime - aTime;
+			})
+	: [];
+const showRelatedVideos = showRelatedAll.slice(0, SHOW_RELATED_LIMIT).map((v) => ({
+	id: v.data.id,
+	title: v.data.title,
+	thumbnailUrl: `https://content.rawkode.academy/videos/${v.data.id}/thumbnail.jpg`,
+	slug: v.data.slug,
+	duration: typeof v.data.duration === "number" ? v.data.duration : undefined,
+}));
 
 // Normalize technology references (handles both string IDs and Astro reference objects)
 const normalizedTechIds = normalizeTechnologyReferences(
@@ -360,6 +397,15 @@ if (isAuthenticated && user?.id) {
 					videoId={video.data.id}
 					resources={video.data.resources ?? []}
 				/>
+
+				{/* More from this show — only renders when the video belongs to one. */}
+				{showEntry && showRelatedVideos.length > 0 && (
+					<ShowVideoSection
+						show={showEntry}
+						videos={showRelatedVideos}
+						totalVideos={showRelatedAll.length}
+					/>
+				)}
 
 				{/* More Videos by Technology */}
 				{technologiesWithVideos.map(({ technology, videos, totalVideos }) => (


### PR DESCRIPTION
## Summary
Give visitors who finish a video or land on a technology profile a relevant next click, using data we already have. No new schemas, no new fields.

## Changes
- **`/watch/[...slug]`** — adds a "More from <show name>" rail when the video belongs to a show. Pulls the latest 6 other episodes from the same show, sorted by publishedAt desc, current episode excluded. Renders above the existing per-technology "More about X" rails.
- **`/technology/[id]`** — adds a "Related technologies" rail. Uses the explicit `relatedTechnologies` array from frontmatter first; falls back to siblings in the same subcategory when no explicit links are set. Capped at 6 entries.

## Verified locally
- `/watch/aquaproj-and-dagger` (AlphaBits episode) — h3 headings now include `"More from AlphaBits"` followed by the existing tech rails.
- `/technology/cilium` (no explicit relatedTechnologies in frontmatter) — falls back to subcategory siblings, h3 `"Related technologies"` rail renders with 6 entries.

## Test plan
- [x] `bunx astro check` clean
- [x] Watch page with show → renders "More from <show>" rail
- [x] Watch page without show → no rail (skipped, current behaviour preserved)
- [x] Tech page → renders "Related technologies"
- [ ] After deploy, verify the rails are clickable (no JS-only fallback) on a couple of mobile devices

## Human action required
None for code. Optional follow-up: hand-curate `relatedTechnologies` in a few high-traffic tech profiles (e.g. Cilium → eBPF, Kubernetes, Hubble) so the rail shows hand-picked neighbours rather than the auto-derived subcategory siblings. The script does the right thing either way.

Refs #938 (Phase 4, PR 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)