### PR TITLE
seo: rewrite SERP snippets for next-4 highest-impression pages

### DIFF
--- a/content/articles/cuengine-rust/index.mdx
+++ b/content/articles/cuengine-rust/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Building a Production-Ready CUE Library for Rust"
-description: "The technical journey of building cuengine: a high-performance FFI bridge between Rust and Go's CUE evaluator, complete with memory safety guarantees, structured error handling, and production-grade features."
+title: "Building a Rust Library for CUE: Architecture & Lessons"
+description: "Inside cuengine, a Rust library wrapping Go's CUE evaluator via FFI. Memory safety, structured errors, and production-grade architecture."
 type: article
 openGraph:
-  title: "Building a Production-Ready CUE Library for Rust"
+  title: "Building a Rust Library for CUE: Architecture & Lessons"
   subtitle: "FFI, memory safety, and production-grade architecture"
 slug: building-rust-cue-library
 publishedAt: 2025-11-27

--- a/content/articles/dagger-cicd-gitlab/index.mdx
+++ b/content/articles/dagger-cicd-gitlab/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Production Deployments with Dagger and GitLab CI
-description: Build a robust deployment pipeline using Dagger for containerized builds, GitLab CI for orchestration, and Cloudflare Pages
+title: "Deploy to Cloudflare from GitLab CI with Dagger (Tutorial)"
+description: "Build a portable GitLab CI pipeline with Dagger that deploys to Cloudflare Workers. Containerless caching, local-runnable, full source included."
 type: tutorial
 slug: dagger-gitlab-cloudflare-deployment
 openGraph:
-  title: "Production-Ready Deployments with Dagger, GitLab CI, and Cloudflare Pages"
+  title: "Deploy to Cloudflare from GitLab CI with Dagger (Tutorial)"
   subtitle: "Containerized builds, automatic previews, and zero-config deployments"
 cover:
   image: "./cover.png"

--- a/content/articles/introducing-cuenv/index.mdx
+++ b/content/articles/introducing-cuenv/index.mdx
@@ -37,7 +37,7 @@ resources:
     url: "https://cuelang.org"
     category: documentation
   - id: "4"
-    title: "Building a Production-Ready CUE Library for Rust"
+    title: "Building a Rust Library for CUE: Architecture & Lessons"
     description: "The technical story behind cuengine, the FFI bridge powering cuenv"
     type: url
     url: "/read/building-rust-cue-library"

--- a/content/technologies/krr/index.mdx
+++ b/content/technologies/krr/index.mdx
@@ -1,8 +1,8 @@
 ---
 name: Kubernetes Resource Recommender (KRR)
 seo:
-  title: 'KRR: Right-Size Kubernetes Resources'
-  description: 'Use Kubernetes Resource Recommender (KRR) to tune CPU and memory requests from Prometheus data and cut cluster spend without guesswork.'
+  title: 'KRR: Right-Size Kubernetes Requests & Limits (Robusta)'
+  description: 'KRR (Kubernetes Resource Recommender) right-sizes container requests and limits from Prometheus data. How it works and trade-offs vs VPA.'
 logos: null
 website: 'https://github.com/robusta-dev/krr'
 source: 'https://github.com/robusta-dev/krr'

--- a/content/technologies/kube-vip/index.mdx
+++ b/content/technologies/kube-vip/index.mdx
@@ -1,8 +1,8 @@
 ---
 name: kube-vip
 seo:
-  title: 'kube-vip: Bare-Metal HA Load Balancing'
-  description: 'Deploy kube-vip for highly available Kubernetes control planes and services using ARP or BGP with real-world guides and examples.'
+  title: 'kube-vip Tutorial: Bare-Metal Kubernetes HA & VIPs'
+  description: 'kube-vip provides VIPs and load balancing for bare-metal Kubernetes: control-plane HA, ARP/BGP, no MetalLB required. Tutorials, videos, deep-dives.'
 logos:
   icon: true
 website: 'https://kube-vip.io/'


### PR DESCRIPTION
## Why

Follow-up to #1128 (top-4 snippet rewrites). These four pages drive another ~11,800 impressions/quarter at 0.4-0.6% CTR, when expected CTR at their average positions (5–11) is ~3–6%. Same intent: lift CTR by writing titles and descriptions that match query intent.

## What changes

### \`content/technologies/kube-vip/index.mdx\`
| Before | After |
|---|---|
| \`kube-vip: Bare-Metal HA Load Balancing\` | \`kube-vip Tutorial: Bare-Metal Kubernetes HA & VIPs\` |
| Generic \"deploy kube-vip for HA...\" | \`kube-vip provides VIPs and load balancing for bare-metal Kubernetes: control-plane HA, ARP/BGP, no MetalLB required. Tutorials, videos, deep-dives.\` |

3080 impressions/quarter at position 11.3 — biggest absolute lift opportunity in this batch. The \"no MetalLB required\" line is the page's actual differentiator (per the body text).

### \`content/technologies/krr/index.mdx\`
| Before | After |
|---|---|
| \`KRR: Right-Size Kubernetes Resources\` | \`KRR: Right-Size Kubernetes Requests & Limits (Robusta)\` |
| Marketing description | \`KRR (Kubernetes Resource Recommender) right-sizes container requests and limits from Prometheus data. How it works and trade-offs vs VPA.\` |

Matches \`requests & limits\` query phrasing verbatim. Robusta brand name added for affinity queries. Description trimmed to match what the page actually covers (the profile doesn't have an install section, so the description shouldn't promise one).

### \`content/articles/dagger-cicd-gitlab/index.mdx\` (slug \`/read/dagger-gitlab-cloudflare-deployment\`)
| Before | After |
|---|---|
| \`Production Deployments with Dagger and GitLab CI\` | \`Deploy to Cloudflare from GitLab CI with Dagger (Tutorial)\` |
| Description said \"Cloudflare Pages\" (inaccurate — article body is about Workers) | \`Build a portable GitLab CI pipeline with Dagger that deploys to Cloudflare Workers. Containerless caching, local-runnable, full source included.\` |

Drops \"Production-Ready\" puffery, names Cloudflare Workers to match the article body, includes \"Tutorial\" as a CTR magnet.

### \`content/articles/cuengine-rust/index.mdx\` (slug \`/read/building-rust-cue-library\`)
| Before | After |
|---|---|
| \`Building a Production-Ready CUE Library for Rust\` | \`Building a Rust Library for CUE: Architecture & Lessons\` |
| Long \"technical journey\" description | \`Inside cuengine, a Rust library wrapping Go's CUE evaluator via FFI. Memory safety, structured errors, and production-grade architecture.\` |

Drops puffery; description is now technically accurate (cuengine is an FFI bridge to Go's CUE evaluator, not pure Rust).

### \`content/articles/introducing-cuenv/index.mdx\`

One-line update: a cross-reference to the cuengine article in the resources block was using the old title. Updated to match.

## SERP-fit math

| Title | Chars |
|---|---|
| kube-vip | 50 |
| krr | 54 |
| dagger article | 58 |
| cuengine article | 55 |

All under 60. Descriptions 136–147 chars (under Google's mobile ~155).

## Notes

- For the two articles, \`openGraph.title\` is kept in sync with \`title\` — the articles schema requires \`openGraph.title\` when the \`openGraph\` object is present (lesson learned from #1128).
- No year suffix (\`(2026)\`) on these four. The two technology pages are evergreen reference cards where a year would mislead; the two articles are dated write-ups where adding a year implies maintenance currency we may not commit to.

## Tested

- Adversarial code review found two issues, both addressed in this PR (krr description trimmed to match page content; stale cross-reference updated).
- All four MDX files validate against their content-collection schemas.
- No other pages reference the old titles.

This PR was created with the assistance of a LLM.