### PR TITLE
seo(website): capture Core Web Vitals in PostHog

### DIFF
--- a/projects/rawkode.academy/website/src/components/posthog/index.astro
+++ b/projects/rawkode.academy/website/src/components/posthog/index.astro
@@ -188,6 +188,18 @@ const { userId } = Astro.props;
 				api_host: PH_HOST,
 				autocapture: true,
 				respect_dnt: true,
+				// Capture Core Web Vitals (LCP, INP, CLS, FCP, TTFB) as
+				// $web_vitals events. GSC has no CWV data for the property
+				// because field-traffic volume is below the CrUX threshold;
+				// these events are our own measurement until that changes.
+				// network_timing is off: it piggybacks on session replay,
+				// which is sampled at 0 below, so enabling it would be a
+				// silent no-op and an event-volume risk if we ever raise
+				// the replay rate without revisiting this.
+				capture_performance: {
+					web_vitals: true,
+					network_timing: false,
+				},
 				session_recording: {
 					maskAllInputs: true,
 					sampling: { rate: 0 },


### PR DESCRIPTION
## Why

Google Search Console reports \"No data\" for Core Web Vitals (mobile and desktop), because the property's field traffic is below the CrUX threshold. We won't see GSC CWV data until organic clicks grow significantly — months from now.

Until then we have no objective signal on LCP, INP, or CLS regressions, which makes Tier 4 of the SEO plan blind. Enabling PostHog's web-vitals capture gives us our own measurement loop today.

## What

One change in \`projects/rawkode.academy/website/src/components/posthog/index.astro\`: add a \`capture_performance\` block to \`posthog.init()\` with \`web_vitals: true\` and \`network_timing: false\`.

## Why \`network_timing: false\`

PostHog's network timing capture piggybacks on session replay infrastructure. Session recording is sampled at 0 in this config (\`session_recording.sampling.rate: 0\`), so enabling \`network_timing\` would be a silent no-op today and an event-volume risk if we ever raise the replay sample rate without revisiting this. Off is the correct posture.

## Cost

- **Runtime:** essentially free. Attaches a \`PerformanceObserver\`. posthog-js fails silently on browsers without the API.
- **Privacy:** \`respect_dnt: true\` is already set; web vitals are pure metric data with no PII. Event payload contains the metric name, value, rating, and URL only.
- **PostHog ingestion:** ~5 events per pageview (LCP, INP, CLS, FCP, TTFB). At current ~150 pageviews/day that's ~25k events/month — negligible.

## Next steps (separate PRs)

- Build a PostHog dashboard \"Web Vitals\" with p75 LCP/INP/CLS over time, worst-pages-by-LCP table, and Good/Needs Improvement/Poor split by device.
- After 30 days of data, identify the top 5 worst pages by p75 LCP and audit them.

## Tested

- Adversarial code review identified \`network_timing: true\` as dead code given the session-recording sampling rate of 0; fixed in this PR.
- Snippet is loaded lazily via \`requestIdleCallback\` (existing code at line ~225), so first paint is unaffected.

This PR was created with the assistance of a LLM.