### PR TITLE
seo(website): drop <changefreq> from video sitemap entries

### DIFF
--- a/projects/rawkode.academy/website/src/pages/video-sitemap.xml.ts
+++ b/projects/rawkode.academy/website/src/pages/video-sitemap.xml.ts
@@ -87,7 +87,6 @@ ${sortedVideos
 		return `  <url>
     <loc>${videoUrl}</loc>
     <lastmod>${publishedDate}</lastmod>
-    <changefreq>daily</changefreq>
     <video:video>
       <video:thumbnail_loc>${escapeXml(thumbnailUrl)}</video:thumbnail_loc>
       <video:title>${escapeXml(video.data.title)}</video:title>


### PR DESCRIPTION
## Why

Google explicitly ignores \`<changefreq>\` on video sitemaps — it has no effect on crawl frequency, video enhancement validity, or any indexing decision. The current value (\`daily\`) was also inaccurate for the ~325-video archive, where most entries don't change after publication.

Dropping it produces a marginally smaller sitemap and clearer signal hygiene. No behavioural change.

## What changes

One line removed from \`projects/rawkode.academy/website/src/pages/video-sitemap.xml.ts\`:

\`\`\`diff
-    <changefreq>daily</changefreq>
\`\`\`

## NOT in this PR (worth noting)

The bigger problem in GSC's video-enhancement validity (6/133 valid) is almost certainly that Google can't probe HLS \`.m3u8\` URLs in \`<video:content_loc>\`. The cleanest fix is to:

1. Build a dedicated \`/embed/watch/{slug}\` bare-player route (no site chrome, iframe-friendly).
2. Switch the sitemap to use \`<video:player_loc>\` pointing at that route, dropping \`<video:content_loc>\`.

Google's spec requires \`player_loc\` to differ from \`<loc>\` (which is the watch page), so reusing the watch URL is not viable. That route is a real piece of work — it'll come in its own PR.

## Tested

- Adversarial review caught that an earlier draft (which tried to swap \`content_loc\` for \`player_loc\` using the watch URL) violated Google's spec. Reverted to just the safe \`<changefreq>\` removal here.
- Existing tests (\`src/tests/seo.test.ts\`) don't assert on \`<changefreq>\` and continue to pass.

This PR was created with the assistance of a LLM.