### PR TITLE
Rawkode Academy News — May 20, 2026

### DIFF
--- a/content/news/backstage-1-51-catalog-perf-ms-graph-incremental/index.mdx
+++ b/content/news/backstage-1-51-catalog-perf-ms-graph-incremental/index.mdx
@@ -1,0 +1,31 @@
+---
+title: "Backstage 1.51 takes catalog list queries from seconds to milliseconds"
+description: "Backstage v1.51.0 rewrites the entity listing and facets paths against PostgreSQL indexes, adds incremental Microsoft Graph ingestion, and ships breaking changes to navigation, OIDC defaults, and PortableSchema."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - backstage
+---
+
+Backstage v1.51.0 dropped on May 19. The catalog gets the largest gains, but the release also carries several breaking changes that platform teams will need to handle on upgrade.
+
+## Catalog query rewrites
+
+The entity listing endpoint now lets PostgreSQL walk the `(key, value, entity_id)` index in sorted order and short-circuit on `LIMIT`, which the release notes describe as "reducing typical paginated list times from seconds to milliseconds." The facets endpoint switches from `WHERE entity_id IN (subquery)` to an inner join, "with measured improvements from ~1.2x to 7x." A missing index on `relations.target_entity_ref` is now added, removing full sequential scans on orphan deletion, ancestry, and eager-pruning queries. Large installations are pointed at pre-deployment SQL so the migration does not block startup.
+
+One behavioural change to know about: entity pagination now excludes entities that lack the requested sort field, which changes total counts and navigation.
+
+## Incremental Microsoft Graph ingestion
+
+A new cursor-based Microsoft Graph user/group provider replaces the in-memory bulk load. Each burst processes a single page of up to 999 users or 100 groups, and the cursor is persisted so pod restarts resume from the last completed page. Disabled users are now filtered by default; ingesting them requires explicit configuration.
+
+## Breaking changes
+
+- `NavItemBlueprint` is removed from `@backstage/frontend-plugin-api`; navigation items are discovered from `PageBlueprint` extensions based on their `title` and `icon` params.
+- `PortableSchema.schema` is now a method — direct property access like `schema.type` is no longer supported.
+- OIDC default allow-list patterns are tightened; custom MCP clients need explicit entries.
+
+A new alpha TracingService unifies span emission across plugins and bridges OpenTelemetry context across async boundaries.
+
+**Source:** [Backstage v1.51.0](https://github.com/backstage/backstage/releases/tag/v1.51.0) — May 19, 2026.

--- a/content/news/etcd-3-7-beta-v2-api-removed/index.mdx
+++ b/content/news/etcd-3-7-beta-v2-api-removed/index.mdx
@@ -1,0 +1,27 @@
+---
+title: "etcd cuts first 3.7 beta and removes the v2 API"
+description: "etcd v3.7.0-beta.0 deletes client/v2, v2discovery, and the v2 request path, adds Unix socket endpoints and FastLeaseKeepAlive, and reports up to 2x faster lease, user, and role operations."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - etcd
+---
+
+etcd published v3.7.0-beta.0 on May 19, the first beta on the 3.7 line. The cleanup is the headline: the v2 API and discovery code are gone.
+
+## The v2 era is finally over
+
+`client/v2`, `v2discovery`, `apply_v2.go`, and the v2 request path have all been removed, along with deprecated experimental flags. The v2 store has been off by default for years and unsupported for newer features, but anything still talking to it has to be on v3 before 3.7 ships GA.
+
+## Server changes
+
+The 3.7 line adds Unix socket endpoint support, FastLeaseKeepAlive that skips the applied-index wait on lease renewal, and a scheduler change that prioritizes `LeaseRevoke` requests during overload so leases expire on time. Lease and user/role operations are reported up to 2x faster. AuthStatus can now be retrieved without an authenticated session, and clientv3 supports JWT configuration directly.
+
+## Operator-facing changes
+
+`etcdctl` global flags are hidden from the default help to reduce noise, and every `etcdutl` command picks up a timeout flag for file lock acquisition. New metrics include `etcd_server_request_duration_seconds` and watch send-loop counters. Binaries are now built with Go 1.26.
+
+This is a beta — not for production — but the v2 removal is the part to plan for now.
+
+**Source:** [etcd v3.7.0-beta.0](https://github.com/etcd-io/etcd/releases/tag/v3.7.0-beta.0) — May 19, 2026.

--- a/content/news/prometheus-3-12-rc-promql-window-functions-stackit-fix/index.mdx
+++ b/content/news/prometheus-3-12-rc-promql-window-functions-stackit-fix/index.mdx
@@ -1,0 +1,36 @@
+---
+title: "Prometheus 3.12 RC adds time-window PromQL functions and patches a STACKIT SD secret leak"
+description: "Prometheus v3.12.0-rc.0 introduces experimental start(), end(), range(), and step() PromQL functions, makes head-chunk lookup constant time in range queries, and closes a plaintext-secret exposure in the STACKIT service discovery via /-/config."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - prometheus
+---
+
+Prometheus v3.12.0-rc.0 was tagged on May 19 as the first release candidate for the 3.12 line. It mixes a security fix, four new PromQL helpers, and a head-chunk lookup rewrite that should reduce CPU on long range queries.
+
+## PromQL learns about its own window
+
+The release notes call out four new experimental functions: "Add `start()`, `end()`, `range()`, and `step()` experimental functions." These expose the evaluation window directly to expressions — useful when you need a query's behaviour to scale with the dashboard range it is rendered into, instead of being hard-coded.
+
+The `resets()` function and `rate()` / `irate()` / `increase()` now consider start-timestamp resets behind a feature flag, and the WAL learns to carry per-sample start timestamps under `st-storage`.
+
+## Performance
+
+The release notes describe the headline change as: "Make head chunk lookup in range queries constant time instead of quadratic time." Several mmap operations also skip stripes and series when no work is needed, and there is a FloatHistogram Kahan-add regression fix tied to Go 1.26.
+
+## Security
+
+GHSA-39j6-789q-qxvh closes a path where the STACKIT service discovery configuration "fixes secrets being exposed in plaintext via `/-/config` endpoint." Operators running STACKIT SD should plan to pick up the fix.
+
+## Operator-facing additions
+
+- Auto-reload-config is promoted to stable.
+- A new web interface, accessible from the Status menu, lets operators delete time series and clean tombstones.
+- `/api/v1/status/self_metrics` returns the server's own metrics as JSON.
+- DigitalOcean Managed Databases and Outscale VMs get new SD modules; AWS SD adds IPv6 EC2 discovery and external-ID support.
+
+This is an RC, not GA — useful to test against, but not to point production at.
+
+**Source:** [Prometheus 3.12.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v3.12.0-rc.0) — May 19, 2026.

--- a/content/news/spire-1-15-sigstore-stable-vault-key-manager/index.mdx
+++ b/content/news/spire-1-15-sigstore-stable-vault-key-manager/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "SPIRE 1.15 promotes Sigstore attestation out of experimental and adds a Vault Key Manager"
+description: "SPIRE v1.15.0 graduates Sigstore support in the Kubernetes and Docker workload attestors, ships a HashiCorp Vault Key Manager plugin, and changes CLI JSON output in a way that will break parsers."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - spire
+---
+
+SPIRE v1.15.0 shipped on May 19. Two items stand out for anyone running it: Sigstore-backed attestation is no longer experimental, and there is a breaking change in CLI JSON output.
+
+## Sigstore graduates in the workload attestors
+
+The release notes are explicit: "The `sigstore` support in k8s and docker attestors was promoted out of experimental." That means matching workloads on cosign-style signature verification is now a supported configuration path for the Kubernetes and Docker workload attestors, not a feature-flag preview.
+
+## Vault Key Manager
+
+A new HashiCorp Vault Key Manager plugin lets SPIRE back its signing keys with Vault instead of the on-disk or cloud-KMS options. Combined with the existing Vault upstream authority plugin, this lets a Vault-centric organisation keep more of SPIRE's key material under Vault control.
+
+## Smaller additions
+
+- The Docker workload attestor now supports rootless Podman.
+- The `aws_iid` node attestor gains an `account_id` selector.
+- The Prometheus metrics sink supports TLS.
+- PROXY protocol is supported for rate limiting behind load balancers.
+- An experimental `spiffe_id` node selector allows aliasing individual nodes.
+- WIT-SVIDs support an `iss` claim.
+
+## Breaking change to watch
+
+CLI commands no longer wrap a single object in a JSON array on output. The release notes flag this as a potentially breaking change for anyone parsing the JSON output. Automation that consumes `spire-server` or `spire-agent` JSON expecting the outer array will need to be updated. The release also bumps cosign to v3 and Go to 1.26.3.
+
+**Source:** [SPIRE v1.15.0](https://github.com/spiffe/spire/releases/tag/v1.15.0) — May 19, 2026.


### PR DESCRIPTION
## Summary

Four release-driven news items from primary sources published on 2026-05-19. All four are operationally significant releases on Tier 1 OSS projects: an etcd minor-version beta that finishes the v2 removal, a SPIRE minor with Sigstore graduation and a breaking CLI JSON change, a Backstage minor with substantial catalog query rewrites, and a Prometheus 3.12 RC adding time-window PromQL functions and a STACKIT SD secret-leak fix.

## Run metadata

- Run time: `2026-05-20 06:00 Europe/London`
- Coverage window: `2026-05-19 05:00 UTC` to `2026-05-20 05:00 UTC`
- Source URLs inspected: ~30
- Candidates longlisted: 6
- Candidates shortlisted: 5
- Segments shipped: 4
- Time horizon: last 24 hours only

## Segments

- **etcd cuts first 3.7 beta and removes the v2 API** — first beta on the 3.7 line; v2 client/discovery/request paths are gone.
- **SPIRE 1.15 promotes Sigstore attestation out of experimental** — k8s and docker attestors graduate Sigstore; new Vault Key Manager; CLI JSON output breaking change.
- **Backstage 1.51 takes catalog list queries from seconds to milliseconds** — PostgreSQL index walks, facet inner join rewrites, MS Graph incremental ingestion, several breaking changes.
- **Prometheus 3.12 RC adds time-window PromQL functions and patches a STACKIT SD secret leak** — `start()`/`end()`/`range()`/`step()`, constant-time head-chunk lookup, GHSA-39j6-789q-qxvh fix.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| etcd v3.7.0-beta.0 published 2026-05-19T20:02:08Z | GitHub API `/repos/etcd-io/etcd/releases` | ✅ |
| v2 client/v2, v2discovery, apply_v2.go removed in 3.7 | CHANGELOG-3.7.md on `main` | ✅ |
| FastLeaseKeepAlive, Unix socket endpoints, up to 2x lease/user/role perf | CHANGELOG-3.7.md | ✅ |
| SPIRE v1.15.0 published 2026-05-19T17:24:58Z | GitHub API `/repos/spiffe/spire/releases` | ✅ |
| Sigstore promoted out of experimental in k8s and docker attestors (verbatim) | SPIRE v1.15.0 release notes "Changed" section | ✅ |
| New HashiCorp Vault Key Manager plugin | SPIRE v1.15.0 release notes "Added" section | ✅ |
| Docker workload attestor supports rootless Podman | SPIRE v1.15.0 release notes "Added" section | ✅ |
| CLI JSON output no longer wraps objects in slices (breaking) | SPIRE v1.15.0 release notes "Changed" section | ✅ |
| Backstage v1.51.0 published 2026-05-19T21:12:32Z | GitHub API `/repos/backstage/backstage/releases` | ✅ |
| Catalog list "seconds to milliseconds" claim (verbatim) | Backstage v1.51.0 release notes, catalog backend section | ✅ |
| Facet endpoint "~1.2x to 7x" improvement (verbatim) | Backstage v1.51.0 release notes, catalog backend section | ✅ |
| New index on `relations.target_entity_ref` | Backstage v1.51.0 release notes, catalog backend section | ✅ |
| Microsoft Graph cursor pages of 999 users / 100 groups, resumable on restart | Backstage v1.51.0 release notes, MS Graph section | ✅ |
| NavItemBlueprint removed, replaced by PageBlueprint title/icon discovery | Backstage v1.51.0 release notes, breaking changes | ✅ |
| PortableSchema.schema must be called as a method | Backstage v1.51.0 release notes, breaking changes | ✅ |
| Prometheus v3.12.0-rc.0 published 2026-05-19T10:46:20Z | GitHub API `/repos/prometheus/prometheus/releases` | ✅ |
| `start()`, `end()`, `range()`, `step()` experimental PromQL functions added (verbatim) | Prometheus v3.12.0-rc.0 release notes, PromQL section | ✅ |
| Head chunk lookup made constant time in range queries (verbatim) | Prometheus v3.12.0-rc.0 release notes, performance section | ✅ |
| GHSA-39j6-789q-qxvh: STACKIT SD secret exposure via `/-/config` | Prometheus v3.12.0-rc.0 release notes, security section | ✅ |
| Web UI for deleting time series and tombstones, `/api/v1/status/self_metrics`, auto-reload-config stable | Prometheus v3.12.0-rc.0 release notes | ✅ |

## Items considered and dropped

- **OpenTelemetry Collector v0.152.1** (2026-05-19T19:53:43Z) — substance unclear; the visible bug fixes (snappy body-close, `max_request_body_size` enforcement on snappy, panic-to-400) and the in-flight requests metric already appear in v0.152.0 release notes (2026-05-11). Could not articulate fresh substance beyond the patch existing. Dropped on substance.
- **CNCF blog: "Automating Confidential Containers (CoCo) infrastructure with Kyverno"** (2026-05-19) — Tutorial / how-to from a project maintainer, not a release or governance change. Out of scope for this pipeline; this ships news.
- **Istio 1.30.0 and 1.29.3** (2026-05-18T19:05Z) — Substantive releases but published ~34h before the run time. Outside the 24-hour window.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial Review → Fact-check → Edit Pass → Final Review.
- Total candidates considered: 6.
- Segments shipped: 4.
- Two release candidates / betas are shipped (Prometheus 3.12.0-rc.0, etcd 3.7.0-beta.0). Both segments label them explicitly as RC/beta so readers don't misread them as GA.
- No vendor-attributed benchmark claims; all performance figures are direct quotes from upstream release notes.
- No unresolved framing concerns.

> Note: This branch (`claude/dazzling-davinci-GzeSX`) was used because it is the session-designated development branch. Suggested project convention going forward is `news/{YYYY-MM-DD}-digest`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PB37E6gBo13Rc3ofWB8rrH)_