### PR TITLE
Rawkode Academy News — May 21, 2026

### DIFF
--- a/content/news/containerd-cve-2026-46680-runasnonroot-bypass/index.mdx
+++ b/content/news/containerd-cve-2026-46680-runasnonroot-bypass/index.mdx
@@ -1,0 +1,30 @@
+---
+title: "containerd patches a runAsNonRoot bypass across every supported branch"
+description: "containerd v2.3.1, v2.2.4, v2.0.9, and v1.7.32 fix CVE-2026-46680, a moderate-severity flaw that lets a crafted image override a pod's numeric runAsUser by exploiting integer overflow in OCI USER parsing."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - containerd
+  - kubernetes
+---
+
+The containerd maintainers shipped coordinated patches on May 20 — v2.3.1, v2.2.4, v2.0.9, and v1.7.32 — fixing CVE-2026-46680, a moderate-severity advisory that lets a crafted image bypass a pod's `runAsNonRoot` restriction.
+
+## What the advisory covers
+
+GHSA-fqw6-gf59-qr4w describes numeric `User` directives in OCI specs that exceed the 32-bit integer range. When the value falls outside that range, containerd parses it as a username instead, then resolves it against the image's `/etc/passwd`. An image whose passwd file maps that string to UID 0 lands the container as root, even when the pod spec asked for a non-root numeric user. The advisory lists containerd v1.7.27+ and v2.0.4+ as affected.
+
+## Other notable fixes
+
+- AF_ALG is now blocked in the default seccomp socket policy, removing a kernel crypto API path from container processes.
+- The overlayfs `rebase` capability is disabled when running in a user namespace, which had been breaking layer extraction.
+- The sandbox task API now handles non-runc runtimes correctly; task fields in Runc options are deprecated.
+- Metadata and mount plugin boltdb files now close cleanly on server shutdown.
+- The transfer plugin no longer errors out when EROFS differ is configured without `mkfs.erofs` on the host.
+
+## Mitigations short of upgrading
+
+The advisory lists restricting image imports to trusted sources, enforcing a numeric `runAsUser` in Pod security contexts, or upgrading to Kubernetes 1.34+ — which validates `runAsUser` independently of the runtime — as workarounds for clusters that cannot patch immediately. The 2.x branches also pick up Go 1.26.3 and bump the containerd API to v1.11.1.
+
+**Source:** [containerd security advisory GHSA-fqw6-gf59-qr4w](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) — May 20, 2026.

--- a/content/news/flux-2-8-8-go-git-cves-helm-controller-memory/index.mdx
+++ b/content/news/flux-2-8-8-go-git-cves-helm-controller-memory/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "Flux 2.8.8 patches two go-git CVEs and stops helm-controller memory growth"
+description: "Flux v2.8.8 picks up go-git v5.19.1 to address CVE-2026-45571 and CVE-2026-45570, fixes an unbounded memory leak in helm-controller's Kubernetes client transport, and adds GCP sovereign cloud artifact registry support."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies:
+  - fluxcd
+---
+
+Flux v2.8.8 shipped on May 20. It is a patch release, but the helm-controller memory fix and two go-git CVEs are reasons to pick it up.
+
+## go-git CVEs
+
+The release bumps go-git to v5.19.1 to address CVE-2026-45571 and CVE-2026-45570. Anything using source-controller's Git fetch path picks up the fix.
+
+## helm-controller memory leak
+
+The notes flag "unbounded memory growth caused by a Kubernetes client transport retry wrapper accumulating on every reconcile." Long-lived helm-controller pods reconciling many Helm releases have been the most exposed to this; the wrapper is now cleaned up between reconciles.
+
+## GCP sovereign cloud artifact registries
+
+Source-controller and image-reflector-controller now support GCP sovereign cloud artifact registries — a real gap for operators running on sovereign-region GKE who had been pointing pipelines at the standard `pkg.dev` endpoints.
+
+## Other patches worth noting
+
+- HTTP timeout for artifact fetching is now configurable, so reconciles cannot block indefinitely on a hung remote.
+- Helm release names longer than 53 characters no longer break the Helm test action.
+- Charts whose `crds/` directories contain non-CRD objects are no longer force-applied alongside CRDs.
+- OCIRepository tags now encode Helm semver build metadata correctly.
+
+Helm moves back to upstream v4.2.0 and the controllers ship against Kubernetes 1.36.1. No breaking changes are flagged for the v2.8.x upgrade path.
+
+**Source:** [Flux v2.8.8](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) — May 20, 2026.

--- a/content/news/ofu-fleet-scale-gpu-efficiency-arxiv/index.mdx
+++ b/content/news/ofu-fleet-scale-gpu-efficiency-arxiv/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "Paper proposes OFU, a counter-based GPU efficiency metric validated on 608 production training jobs"
+description: "An arXiv paper submitted on May 20 introduces Overall FLOP Utilization, a precision-agnostic GPU efficiency metric derived from two on-chip counters, and reports r = 0.78 correlation with application-level MFU across 608 production training jobs on H100 and GB200."
+publishedAt: 2026-05-20
+authors:
+  - rawkode
+technologies: []
+---
+
+A paper submitted to arXiv on May 20 proposes Overall FLOP Utilization (OFU), a GPU efficiency metric derived from two on-chip counters — Tensor Pipe Activity and SM clock frequency — that needs no application-level instrumentation.
+
+## The metric
+
+OFU is positioned against application-reported MFU, which requires per-workload integration that fleet operators rarely get to control. The authors argue for a hardware-level signal that any GPU exposing the two counters can produce, including H100 and GB200 across precisions. The result is a single number per device, comparable across heterogeneous workloads.
+
+## How well it tracks MFU
+
+Across 608 production training jobs, OFU correlates with application-level MFU at r = 0.78, and predicts MFU within ≤2 percentage points after applying a tile-quantization correction. The paper reports that the metric has already surfaced efficiency regressions in production deployments rather than just being demonstrated on synthetic benchmarks.
+
+## Why this matters
+
+If a platform team has been falling back on `nvidia-smi` SM-active fraction to gauge GPU utilization across a multi-tenant fleet, OFU offers a signal grounded in tensor-pipe activity rather than coarse SM occupancy — without asking application teams to integrate anything.
+
+**Source:** [Instant GPU Efficiency Visibility at Fleet Scale (arXiv:2605.20799)](https://arxiv.org/abs/2605.20799) — May 20, 2026.


### PR DESCRIPTION
## Summary

Three segments survived the editorial pipeline for the 24-hour window ending 06:00 Europe/London on 2026-05-21:

- A coordinated containerd patch wave fixing a runAsNonRoot bypass (CVE-2026-46680)
- Flux v2.8.8, which closes two go-git CVEs and an unbounded helm-controller memory leak
- An arXiv paper proposing OFU, a counter-derived GPU efficiency metric validated on 608 production training jobs

## Run metadata

- Run time: `2026-05-21 06:00 Europe/London`
- Coverage window: `2026-05-20 06:00 BST` → `2026-05-21 06:00 BST`
- Source URLs inspected: ~55
- Candidates longlisted: 10
- Candidates shortlisted: 4
- Segments shipped: 3
- Time horizon: last 24 hours only

## Segments

- **containerd patches a runAsNonRoot bypass across every supported branch** — coordinated v1.7.32/v2.0.9/v2.2.4/v2.3.1 release with a moderate-severity advisory; affects everyone running containerd v1.7.27+ or v2.0.4+.
- **Flux 2.8.8 patches two go-git CVEs and stops helm-controller memory growth** — patch release with a real-world memory leak fix that has been biting long-lived helm-controller pods.
- **Paper proposes OFU, a counter-based GPU efficiency metric validated on 608 production training jobs** — arXiv:2605.20799; r = 0.78 vs application MFU, no application instrumentation required.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| containerd v2.3.1, v2.2.4, v2.0.9, v1.7.32 released May 20, 2026 | [containerd releases](https://github.com/containerd/containerd/releases) | ✅ |
| CVE-2026-46680 covers numeric `User` directives exceeding 32-bit range | [GHSA-fqw6-gf59-qr4w](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) | ✅ |
| Affected versions: v1.7.27+ and v2.0.4+; mitigations include Kubernetes 1.34+ | [GHSA-fqw6-gf59-qr4w](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) | ✅ |
| AF_ALG seccomp hardening, overlayfs rebase fix, sandbox task API fix | [v2.3.1 release notes](https://github.com/containerd/containerd/releases/tag/v2.3.1) | ✅ |
| Flux v2.8.8 published 2026-05-20 11:53 UTC | [v2.8.8 release](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) | ✅ |
| CVE-2026-45571 and CVE-2026-45570 addressed via go-git v5.19.1 | [v2.8.8 release notes](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) | ✅ |
| helm-controller unbounded memory growth fix wording | [v2.8.8 release notes](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) | ✅ |
| GCP sovereign cloud artifact registry support | [v2.8.8 release notes](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) | ✅ |
| Helm 53-character fix, OCIRepository semver build metadata, K8s 1.36.1, Helm v4.2.0 | [v2.8.8 release notes](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) | ✅ |
| arXiv 2605.20799 submitted 2026-05-20 06:44:25 UTC | [arXiv abstract](https://arxiv.org/abs/2605.20799) | ✅ |
| OFU derived from Tensor Pipe Activity and SM clock frequency | [arXiv abstract](https://arxiv.org/abs/2605.20799) | ✅ |
| r = 0.78 vs application-level MFU; ≤2 pp after tile-quantization correction | [arXiv abstract](https://arxiv.org/abs/2605.20799) | ✅ |
| Evaluated across 608 production training jobs; H100 and GB200 | [arXiv abstract](https://arxiv.org/abs/2605.20799) | ✅ |

## Items considered and dropped

- **OpenTelemetry Collector v0.152.1** (May 19, 19:53 UTC) — too thin: the in-flight-requests exporter metric and assorted bug fixes do not stand alone now that v0.152.0 has been covered in the May 12 digest.
- **arXiv:2605.20863 "PlexRL"** (May 20) — interesting RLVR multiplexing work with a claimed 37.58 % cost-efficiency win, but no released code or scheduler integration; failed actionability.
- **CNCF "Introducing Prempti" blog** (May 20) — cross-post of a Falco/Prempti announcement whose primary artifacts (Falco blog, GitHub v0.2.1) are from May 12. Fails the freshness gate because the primary source pre-dates the 24-hour window.
- **Kubernetes blog "Announcing etcd 3.7.0-beta.0"** (May 20) — cross-post of the etcd release that was covered in the May 20 digest (`etcd-3-7-beta-v2-api-removed`).
- **Prometheus 3.12.0-rc.0, Backstage v1.51.0, SPIRE v1.15.0, Flux/etcd auxiliary entries** — already shipped under previous slugs.
- **No fresh releases on May 19–20** from: Cilium, Istio, Envoy, Argo CD/Rollouts, vLLM, SGLang, TensorRT-LLM, Triton, NCCL, Slurm, Karpenter, KEDA, cert-manager, OPA, cosign, Tetragon, Linkerd, Karmada, KGateway, KubeVirt, Crossplane, Calico, Strimzi, Rook, Harbor, Dragonfly, OpenTofu, Gateway API.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial Review → Fact-check → Edit Pass → Final Review.
- Total candidates considered: 10. Segments shipped: 3.
- No vendor-attributed performance claims in this digest. The OFU "r = 0.78" and "≤2 pp" numbers come from a peer-process arXiv preprint and are presented as the paper's findings, not as independently corroborated facts.
- Unresolved framing concerns: none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEUsJEpAzHudnZZ5ux6o7F)_