### PR TITLE
fix(rawkode.academy): repair share images and changelog

### DIFF
--- a/content/changelog/2026-05-24-site-redesign-and-sharing.md
+++ b/content/changelog/2026-05-24-site-redesign-and-sharing.md
@@ -1,0 +1,11 @@
+---
+title: "Site redesign and share previews"
+description: "A broad cleanup across the academy site: simpler collection pages, clearer navigation, stronger Technology Matrix placement, refreshed organization pages, and reliable OpenGraph share images."
+type: improvement
+date: 2026-05-24T12:00:00.000Z
+author: rawkode
+---
+
+The site now puts the main learning surfaces first: news, videos, articles, courses, learning paths, shows, technologies, people, and the Technology Matrix.
+
+This update also cleans up mobile spacing, removes repeated editorial labels, improves watch and article layouts, refreshes the organization pages, and restores large OpenGraph images for social previews.

--- a/projects/rawkode.academy/platform/image-service/src/lib/payload.ts
+++ b/projects/rawkode.academy/platform/image-service/src/lib/payload.ts
@@ -2,16 +2,19 @@ import * as utf64 from "utf64";
 
 export interface Payload {
   format: "svg" | "png";
-	title: string;
-	subtitle: string | undefined;
+  title: string;
+  subtitle: string | undefined;
+  text: string | undefined;
   template: string;
   image: URL | undefined;
 }
 
 export const DEFAULT_PAYLOAD: Payload = {
   format: "svg",
-	title: "Hello, World!",
-	subtitle: "The best way to learn and keep up to date with Cloud Native, Kubernetes, & WebAssembly",
+  title: "Hello, World!",
+  subtitle:
+    "The best way to learn and keep up to date with Cloud Native, Kubernetes, & WebAssembly",
+  text: undefined,
   template: "gradient",
   image: undefined,
 };
@@ -27,7 +30,7 @@ export const getPayloadFromSearchParams = (
 
     try {
       const payload: Partial<Payload> = JSON.parse(decodedPayload);
-			return { ...DEFAULT_PAYLOAD, ...payload };
+      return { ...DEFAULT_PAYLOAD, ...payload };
     } catch (error) {
       return DEFAULT_PAYLOAD;
     }

--- a/projects/rawkode.academy/platform/image-service/src/pages/robots.txt.ts
+++ b/projects/rawkode.academy/platform/image-service/src/pages/robots.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 
 const BODY = `User-agent: *
+Allow: /image
 Disallow: /
 `;
 

--- a/projects/rawkode.academy/platform/image-service/src/templates/gradient.ts
+++ b/projects/rawkode.academy/platform/image-service/src/templates/gradient.ts
@@ -2,68 +2,73 @@ import { DEFAULT_PAYLOAD } from "@/lib/payload";
 import { createHash, type Template } from "@/lib/template";
 import { html } from "satori-html";
 
+const truncate = (value: string | undefined, maxLength: number) => {
+	if (!value) {
+		return "";
+	}
+
+	const normalized = value.replace(/\s+/g, " ").trim();
+
+	if (normalized.length <= maxLength) {
+		return normalized;
+	}
+
+	return `${normalized.slice(0, maxLength - 1).trim()}...`;
+};
+
 export const template: Template = {
-  font: {
-    name: "Quicksand",
-    weight: 500,
-    style: "normal",
-  },
+	font: {
+		name: "Inter",
+		weight: 700,
+		style: "normal",
+	},
 
-  hash() {
-    // we call the render method with a stable input to calculate the hash
-    return createHash(this.render(DEFAULT_PAYLOAD));
-  },
+	hash() {
+		return createHash(this.render(DEFAULT_PAYLOAD));
+	},
 
-  render(payload) {
-    // Modern logo with gradient
-    const logo = `<svg width="140" height="40" viewBox="0 0 140 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M10 20C10 14.4772 14.4772 10 20 10H120C125.523 10 130 14.4772 130 20V20C130 25.5228 125.523 30 120 30H20C14.4772 30 10 25.5228 10 20V20Z" fill="url(#paint0_linear)"/>
-      <path d="M30 20H40" stroke="white" stroke-width="2" stroke-linecap="round"/>
-      <path d="M35 15V25" stroke="white" stroke-width="2" stroke-linecap="round"/>
-      <path d="M50 15H120" stroke="white" stroke-width="2" stroke-linecap="round"/>
-      <path d="M50 25H100" stroke="white" stroke-width="2" stroke-linecap="round"/>
-      <defs>
-        <linearGradient id="paint0_linear" x1="10" y1="20" x2="130" y2="20" gradientUnits="userSpaceOnUse">
-          <stop stop-color="#6366F1"/>
-          <stop offset="1" stop-color="#8B5CF6"/>
-        </linearGradient>
-      </defs>
-    </svg>`;
+	render(payload) {
+		const eyebrow = truncate(payload.subtitle, 72) || "Rawkode Academy";
+		const summary = truncate(payload.text, 105);
 
-    return html(`
-      <div style="display: flex; flex-direction: column; width: 1200px; height: 630px; background: linear-gradient(135deg, #4F46E5 0%, #7C3AED 50%, #EC4899 100%); color: white; font-family: Inter;">
-        <!-- Top accent line -->
-        <div style="height: 8px; background: rgba(255, 255, 255, 0.2); display: flex;"></div>
+		return html(`
+			<div style="display: flex; width: 1200px; height: 630px; background: #f4f1ea; color: #17130f; font-family: Inter;">
+				<div style="display: flex; width: 100%; height: 100%; padding: 54px 60px; flex-direction: column; border: 1px solid #d8d2c7;">
+					<div style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
+						<div style="display: flex; align-items: center;">
+							<div style="display: flex; width: 36px; height: 36px; background: #17130f; border-radius: 4px; margin-right: 16px;"></div>
+							<div style="display: flex; flex-direction: column;">
+								<div style="display: flex; font-size: 24px; font-weight: 700; letter-spacing: -0.01em; color: #17130f;">Rawkode</div>
+								<div style="display: flex; font-size: 24px; font-weight: 700; letter-spacing: -0.01em; color: #17130f; margin-top: -4px;">Academy</div>
+							</div>
+						</div>
+						<div style="display: flex; font-size: 18px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: #2d7e67;">rawkode.academy</div>
+					</div>
 
-        <div style="display: flex; padding: 60px; flex-direction: column; height: 100%; position: relative;">
-          <!-- Background decorative elements -->
-          <div style="position: absolute; width: 600px; height: 600px; border-radius: 50%; background: rgba(255, 255, 255, 0.05); top: -200px; right: -200px; display: flex;"></div>
-          <div style="position: absolute; width: 400px; height: 400px; border-radius: 50%; background: rgba(255, 255, 255, 0.05); bottom: -100px; left: -100px; display: flex;"></div>
+					<div style="display: flex; width: 100%; height: 1px; background: #d8d2c7; margin-top: 38px;"></div>
 
-          <!-- Logo -->
-          <div style="display: flex; margin-bottom: 60px; z-index: 1;">
-            ${logo}
-          </div>
+					<div style="display: flex; flex: 1; flex-direction: column; justify-content: center; padding-right: 80px; padding-bottom: 24px;">
+						<div style="display: flex; align-items: center; margin-bottom: 22px;">
+							<div style="display: flex; width: 10px; height: 10px; border-radius: 999px; background: #2d7e67; margin-right: 16px;"></div>
+							<div style="display: flex; font-size: 20px; font-weight: 700; color: #2d7e67; letter-spacing: 0.12em; text-transform: uppercase;">${eyebrow}</div>
+						</div>
 
-          <!-- Main content -->
-          <div style="display: flex; flex-direction: column; flex: 1; justify-content: center; z-index: 1;">
-            <div style="width: 80px; height: 6px; background: rgba(255, 255, 255, 0.6); margin-bottom: 32px; display: flex;"></div>
-            <h1 style="font-size: 72px; font-weight: 700; color: white; margin: 0 0 32px 0; line-height: 1.1; max-width: 800px; letter-spacing: -0.02em; display: flex;">
-              ${payload.title}
-            </h1>
-            <p style="font-size: 28px; color: rgba(255, 255, 255, 0.8); margin: 0; line-height: 1.5; max-width: 600px; display: flex;">
-              ${payload.subtitle}
-            </p>
-          </div>
+						<div style="display: flex; font-size: 60px; font-weight: 700; line-height: 1.02; letter-spacing: -0.035em; color: #17130f; max-width: 1000px;">
+							${payload.title}
+						</div>
 
-          <!-- Footer -->
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 60px; z-index: 1;">
-            <div style="font-size: 18px; color: rgba(255, 255, 255, 0.7); font-weight: 500; display: flex;">
-              Rawkode Academy
-            </div>
-          </div>
-        </div>
-      </div>
-    `);
-  },
+						${
+							summary
+								? `<div style="display: flex; margin-top: 22px; max-width: 780px; font-size: 24px; font-weight: 700; line-height: 1.28; letter-spacing: -0.012em; color: #5d574f;">${summary}</div>`
+								: ""
+						}
+					</div>
+
+					<div style="display: flex; align-items: center; width: 100%; border-top: 1px solid #d8d2c7; padding-top: 18px;">
+						<div style="display: flex; font-size: 20px; font-weight: 700; color: #17130f;">Practical cloud native learning.</div>
+					</div>
+				</div>
+			</div>
+		`);
+	},
 };

--- a/projects/rawkode.academy/website/src/components/html/opengraph.astro
+++ b/projects/rawkode.academy/website/src/components/html/opengraph.astro
@@ -1,6 +1,6 @@
 ---
-import * as utf64 from "utf64";
 import type { CollectionEntry } from "astro:content";
+import { resolveOpenGraphImage } from "@/lib/open-graph";
 
 const {
 	title,
@@ -23,35 +23,14 @@ const openGraphDescription =
 	description ??
 	"The Rawkode Academy provides educational, entertaining, and cutting-edge learning paths for you, or your developers, to keep up with the fast-paced, ever-evolving, and extremely volatile Cloud Native landscape.";
 
-// Static fallback served from our own origin. Used when the caller hasn't
-// passed an image and we'd otherwise rely on the dynamic image service
-// (image.rawkode.academy) - that service has been returning 403 site-wide,
-// which broke every social-share preview on the affected pages. Falling
-// back to the brand icon means the preview is at least branded rather than
-// broken. Pages that have a real image (article covers, etc.) still go
-// through the dynamic service to get a per-page card.
-const staticFallbackImageUrl = new URL(
-	"/android-chrome-512x512.png",
-	openGraphUrl,
-).href;
-
-const openGraphImageUrl = image
-	? `https://image.rawkode.academy/image?payload=${utf64.encode(
-			JSON.stringify({
-				...image,
-				title,
-				subtitle,
-				format: "png",
-				template: "gradient",
-			}),
-		)}`
-	: staticFallbackImageUrl;
-
-// The static fallback is the brand icon at known dimensions; declaring
-// them lets social platforms render the preview without fetching the
-// asset and inspecting it first.
-const usingStaticFallback = !image;
-const ogImageAlt = usingStaticFallback ? "Rawkode Academy" : title;
+const openGraphImage = resolveOpenGraphImage({
+	title,
+	subtitle,
+	description: openGraphDescription,
+	image,
+	pageUrl: openGraphUrl,
+	useImageDirectly,
+});
 
 // Show article-specific meta tags only when the caller opts in via the
 // `isArticle` prop. The previous heuristic also matched `/blog/` (a route
@@ -92,16 +71,14 @@ const firstAuthorMastodon = shouldShowArticleMeta
 <meta property="og:title" content={title} />
 <meta property="og:description" content={openGraphDescription} />
 <meta property="og:url" content={openGraphUrl} />
-<meta
-	property="og:image"
-	content={useImageDirectly ? image?.image : openGraphImageUrl}
-/>
-<meta property="og:image:alt" content={ogImageAlt} />
-{usingStaticFallback && (
+<meta property="og:image" content={openGraphImage.url} />
+<meta property="og:image:secure_url" content={openGraphImage.url} />
+<meta property="og:image:alt" content={openGraphImage.alt} />
+{openGraphImage.type && (
 	<>
-		<meta property="og:image:type" content="image/png" />
-		<meta property="og:image:width" content="512" />
-		<meta property="og:image:height" content="512" />
+		<meta property="og:image:type" content={openGraphImage.type} />
+		<meta property="og:image:width" content={String(openGraphImage.width)} />
+		<meta property="og:image:height" content={String(openGraphImage.height)} />
 	</>
 )}
 {firstAuthorMastodon && (
@@ -152,11 +129,8 @@ const firstAuthorMastodon = shouldShowArticleMeta
 <meta property="twitter:url" content={openGraphUrl} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={openGraphDescription} />
-<meta
-	name="twitter:image"
-	content={useImageDirectly ? image?.image : openGraphImageUrl}
-/>
-<meta name="twitter:image:alt" content={ogImageAlt} />
+<meta name="twitter:image" content={openGraphImage.url} />
+<meta name="twitter:image:alt" content={openGraphImage.alt} />
 
 {!shouldShowArticleMeta && (
 	<script
@@ -167,7 +141,7 @@ const firstAuthorMastodon = shouldShowArticleMeta
 			"@type": pageType,
 			name: title,
 			description: openGraphDescription,
-			image: useImageDirectly ? image?.image : openGraphImageUrl,
+			image: openGraphImage.url,
 			url: openGraphUrl.toString(),
 			publisher: {
 				"@type": "Organization",

--- a/projects/rawkode.academy/website/src/lib/open-graph.ts
+++ b/projects/rawkode.academy/website/src/lib/open-graph.ts
@@ -1,0 +1,79 @@
+import * as utf64 from "utf64";
+import type { ImageServicePayload } from "@/types/image-service";
+
+export const OPEN_GRAPH_IMAGE_WIDTH = 1200;
+export const OPEN_GRAPH_IMAGE_HEIGHT = 630;
+export const IMAGE_SERVICE_URL = "https://image.rawkode.academy/image";
+
+const DEFAULT_DESCRIPTION =
+	"Hands-on cloud native lessons, articles, and field notes from Rawkode Academy.";
+
+type OpenGraphImageInput = {
+	title: string;
+	subtitle?: string;
+	description?: string;
+	image?: Partial<ImageServicePayload>;
+	pageUrl: URL;
+	useImageDirectly?: boolean;
+};
+
+export type ResolvedOpenGraphImage = {
+	url: string;
+	alt: string;
+	width?: number;
+	height?: number;
+	type?: "image/png";
+};
+
+const imageUrlFromValue = (
+	value: unknown,
+	pageUrl: URL,
+): string | undefined => {
+	if (value instanceof URL) {
+		return value.href;
+	}
+
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return undefined;
+	}
+
+	return new URL(value, pageUrl).href;
+};
+
+export const resolveOpenGraphImage = ({
+	title,
+	subtitle,
+	description,
+	image,
+	pageUrl,
+	useImageDirectly = false,
+}: OpenGraphImageInput): ResolvedOpenGraphImage => {
+	const directImageUrl = imageUrlFromValue(image?.image, pageUrl);
+
+	if (useImageDirectly && directImageUrl) {
+		return {
+			url: directImageUrl,
+			alt: title,
+		};
+	}
+
+	const payload = {
+		...image,
+		text: image?.text ?? description ?? subtitle ?? DEFAULT_DESCRIPTION,
+		title,
+		subtitle,
+		format: "png",
+		template: "gradient",
+	};
+
+	const url = new URL(IMAGE_SERVICE_URL);
+	url.searchParams.set("payload", utf64.encode(JSON.stringify(payload)));
+
+	return {
+		url: url.href,
+		alt: title,
+		type: "image/png",
+		width: OPEN_GRAPH_IMAGE_WIDTH,
+		height: OPEN_GRAPH_IMAGE_HEIGHT,
+	};
+};

--- a/projects/rawkode.academy/website/src/pages/changelog/index.astro
+++ b/projects/rawkode.academy/website/src/pages/changelog/index.astro
@@ -1,14 +1,7 @@
 ---
 import { getCollection, getEntry } from "astro:content";
-import { marked } from "marked";
 import EditorialShell from "@/components/ui/EditorialShell.astro";
 import Page from "@/wrappers/page.astro";
-
-marked.setOptions({
-	breaks: true,
-	gfm: true,
-	pedantic: false,
-});
 
 const changelogEntries = await getCollection("changelog");
 
@@ -16,15 +9,30 @@ const sortedChangelog = changelogEntries.sort((a, b) => {
 	return b.data.date.getTime() - a.data.date.getTime();
 });
 
+const cleanTitle = (title: string) =>
+	title
+		.replace(/\p{Extended_Pictographic}/gu, "")
+		.trim()
+		.replace(/^(New Feature|Feature|Improvement|Fix|Breaking):\s*/i, "")
+		.trim();
+
+const cleanSummary = (description: string) =>
+	(description.split("\n\n")[0] ?? "")
+		.replace(/\s*(What's New|Why This Matters):.*$/is, "")
+		.replace(/\p{Extended_Pictographic}/gu, "")
+		.replace(/\*\*/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+
 const processedChangelog = await Promise.all(
 	sortedChangelog.map(async (entry) => {
-		const renderedContent = marked(entry.body || "");
 		const authorEntry = await getEntry(entry.data.author);
 
 		return {
 			...entry.data,
 			id: entry.id,
-			renderedContent: String(renderedContent),
+			title: cleanTitle(entry.data.title),
+			summary: cleanSummary(entry.data.description),
 			author: {
 				name: authorEntry?.data.name || "Unknown",
 				avatar_url: authorEntry?.data.avatarUrl || "",
@@ -36,35 +44,17 @@ const processedChangelog = await Promise.all(
 
 <Page
 	title="Changelog"
-	description="Stay up to date with the latest changes and improvements to Rawkode Academy."
+	description="Rawkode Academy product updates, fixes, and content changes."
 >
 	<EditorialShell
-		eyebrow="Product notes"
+		eyebrow="Updates"
 		title="Changelog"
-		lede="A running record of the features, fixes, and content updates shipped across Rawkode Academy."
+		lede="Product updates, fixes, and content changes."
 		compact
 	>
 		<div class="editorial-actions" slot="actions">
-			<a class="editorial-button" href="#latest">Latest updates</a>
 			<a class="editorial-button editorial-button--secondary" href="https://github.com/rawkode-academy">GitHub</a>
 		</div>
-
-		<section class="editorial-section">
-			<div class="editorial-stat-grid">
-				<div class="editorial-stat">
-					<span class="editorial-stat__value">{changelogEntries.length}</span>
-					<span class="editorial-stat__label">Updates</span>
-				</div>
-				<div class="editorial-stat">
-					<span class="editorial-stat__value">Open</span>
-					<span class="editorial-stat__label">Source</span>
-				</div>
-				<div class="editorial-stat">
-					<span class="editorial-stat__value">Live</span>
-					<span class="editorial-stat__label">Project record</span>
-				</div>
-			</div>
-		</section>
 
 		<section id="latest" class="editorial-section changelog-list">
 			{
@@ -73,12 +63,9 @@ const processedChangelog = await Promise.all(
 						<p class="editorial-card__body">No changelog entries yet.</p>
 					</div>
 				) : (
-					processedChangelog.map((entry, index) => (
+					processedChangelog.map((entry) => (
 						<article class="changelog-entry">
 							<div class="changelog-entry__meta">
-								<span class="editorial-pill">
-									No{String(processedChangelog.length - index).padStart(3, "0")}
-								</span>
 								<span class="editorial-pill">{entry.type}</span>
 								<time datetime={entry.date.toISOString()}>
 									{entry.date.toLocaleDateString("en-US", {
@@ -89,7 +76,15 @@ const processedChangelog = await Promise.all(
 								</time>
 							</div>
 							<h2>{entry.title}</h2>
-							<div class="editorial-prose changelog-entry__body" set:html={entry.renderedContent} />
+							<p class="changelog-entry__summary">{entry.summary}</p>
+							{entry.pullRequest && (
+								<a
+									class="changelog-entry__link"
+									href={`https://github.com/rawkode-academy/rawkode-academy/pull/${entry.pullRequest}`}
+								>
+									View pull request
+								</a>
+							)}
 							<footer class="changelog-entry__byline">
 								{entry.author.avatar_url && (
 									<img
@@ -113,12 +108,16 @@ const processedChangelog = await Promise.all(
 	.changelog-list {
 		display: flex;
 		flex-direction: column;
-		gap: 0;
+		gap: 0.25rem;
 	}
 
 	.changelog-entry {
 		border-top: 1px solid var(--editorial-hairline);
-		padding: 2rem 0;
+		display: grid;
+		grid-template-columns: minmax(8rem, 13rem) minmax(0, 1fr);
+		column-gap: clamp(1.5rem, 4vw, 4rem);
+		row-gap: 0.75rem;
+		padding: clamp(1.5rem, 3vw, 2.5rem) 0;
 	}
 
 	.changelog-entry:first-child {
@@ -129,9 +128,10 @@ const processedChangelog = await Promise.all(
 	.changelog-entry__meta {
 		display: flex;
 		flex-wrap: wrap;
+		align-content: start;
 		align-items: center;
 		gap: 0.5rem;
-		margin-bottom: 0.9rem;
+		grid-row: span 4;
 	}
 
 	.changelog-entry__meta time,
@@ -151,16 +151,29 @@ const processedChangelog = await Promise.all(
 		line-height: 1.05;
 		letter-spacing: 0;
 		color: var(--editorial-ink);
-		margin: 0 0 1rem;
+		margin: 0;
 		text-wrap: balance;
 	}
 
-	.changelog-entry__body {
-		max-width: 46rem;
+	.changelog-entry__summary {
+		max-width: 48rem;
+		margin: 0;
+		color: var(--editorial-ink-soft);
+		font-size: 1rem;
+		line-height: 1.65;
 	}
 
-	.changelog-entry__body :global(p:last-child) {
-		margin-bottom: 0;
+	.changelog-entry__link {
+		width: fit-content;
+		color: var(--editorial-ink);
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		text-decoration: none;
+		text-transform: uppercase;
+		border-bottom: 1px solid var(--editorial-hairline-strong);
+		padding-bottom: 0.22rem;
 	}
 
 	.changelog-entry__byline {
@@ -180,7 +193,17 @@ const processedChangelog = await Promise.all(
 
 	@media (max-width: 700px) {
 		.changelog-entry {
+			display: block;
 			padding: 1.5rem 0;
+		}
+
+		.changelog-entry__meta {
+			margin-bottom: 0.75rem;
+		}
+
+		.changelog-entry__summary,
+		.changelog-entry__link {
+			margin-top: 0.85rem;
 		}
 	}
 </style>

--- a/projects/rawkode.academy/website/src/tests/open-graph.test.ts
+++ b/projects/rawkode.academy/website/src/tests/open-graph.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import * as utf64 from "utf64";
+import {
+	OPEN_GRAPH_IMAGE_HEIGHT,
+	OPEN_GRAPH_IMAGE_WIDTH,
+	resolveOpenGraphImage,
+} from "@/lib/open-graph";
+
+const payloadFromUrl = (url: string) => {
+	const payload = new URL(url).searchParams.get("payload");
+	if (!payload) {
+		throw new Error("Missing image payload");
+	}
+
+	return JSON.parse(utf64.decode(payload));
+};
+
+describe("resolveOpenGraphImage", () => {
+	it("generates a large share card when no image is provided", () => {
+		const image = resolveOpenGraphImage({
+			title: "Latest Articles",
+			description: "Articles and tutorials.",
+			pageUrl: new URL("https://rawkode.academy/read"),
+		});
+
+		expect(image.url).toMatch("https://image.rawkode.academy/image?payload=");
+		expect(image.type).toBe("image/png");
+		expect(image.width).toBe(OPEN_GRAPH_IMAGE_WIDTH);
+		expect(image.height).toBe(OPEN_GRAPH_IMAGE_HEIGHT);
+		expect(image.alt).toBe("Latest Articles");
+
+		expect(payloadFromUrl(image.url)).toMatchObject({
+			title: "Latest Articles",
+			text: "Articles and tutorials.",
+			format: "png",
+			template: "gradient",
+		});
+	});
+
+	it("keeps direct images absolute when requested", () => {
+		const image = resolveOpenGraphImage({
+			title: "Hands-on Introduction to sympozium",
+			image: {
+				image: new URL("/images/video.jpg", "https://rawkode.academy/watch"),
+			},
+			pageUrl: new URL("https://rawkode.academy/watch"),
+			useImageDirectly: true,
+		});
+
+		expect(image).toEqual({
+			url: "https://rawkode.academy/images/video.jpg",
+			alt: "Hands-on Introduction to sympozium",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- replace tiny fallback OpenGraph icons with generated 1200x630 share cards
- allow social crawlers to fetch image-service cards
- simplify the changelog page and add the current redesign/share-preview entry

## Verification
- bun test src/tests/open-graph.test.ts
- bun run build
- rendered HTML checks for homepage/article OG tags and changelog copy