### PR TITLE
fix(cuenv): run tasks non-hermetically so bun resolves on PATH (v0.42.0)

### DIFF
--- a/projects/klustered.dev/env.cue
+++ b/projects/klustered.dev/env.cue
@@ -10,12 +10,14 @@ let _t = tasks
 
 tasks: {
 	codegen: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["panda", "codegen"]
 	}
 
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["astro", "dev"]
 		dependsOn: [_t.codegen]
 
@@ -29,7 +31,8 @@ tasks: {
 	}
 
 	build: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["astro", "build"]
 		dependsOn: [_t.codegen]
 
@@ -43,7 +46,8 @@ tasks: {
 	}
 
 	preview: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["astro", "preview"]
 	}
 }

--- a/projects/rawkode.academy/api/env.cue
+++ b/projects/rawkode.academy/api/env.cue
@@ -8,11 +8,15 @@ name: "rawkode-academy-api"
 
 let _t = tasks
 
+// Run tasks non-hermetically so bun resolves on PATH (cuenv v0.42.0 hermetic
+// task spawn cannot find bare commands like `bun`).
+tasks: [string]: hermetic: false
+
 ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}

--- a/projects/rawkode.academy/codegen/platform-service.cue
+++ b/projects/rawkode.academy/codegen/platform-service.cue
@@ -30,7 +30,7 @@ import (
 	additionalDevDependencies: {[string]: string} | *{}
 
 	// Computed values
-	_nameParts:  strings.Split(serviceName, "-")
+	_nameParts: strings.Split(serviceName, "-")
 	_pascalName: strings.Join([for p in _nameParts {strings.ToTitle(p)}], "")
 
 	// Auto-inject ANALYTICS service binding
@@ -172,7 +172,7 @@ import (
 		default: {
 			environment: "production"
 			when: {
-				branch:        ["main"]
+				branch: ["main"]
 				defaultBranch: true
 				manual:        true
 			}
@@ -190,10 +190,13 @@ import (
 
 	// Auto-generated deploy tasks based on enabled features. Services that own a
 	// D1 schema also get a `migrate` task, ordered before deploy in the pipeline.
+	// `hermetic: false` so tasks inherit the activated devenv-runtime PATH that
+	// provides `bun` (cuenv v0.42.0 hermetic spawns drop it -> ENOENT on `bun`).
 	tasks: {
 		if _hasMigrations {
 			migrate: schema.#Task & {
-				command: "bun"
+				hermetic: false
+				command:  "bun"
 				args: [
 					"x", "wrangler", "d1", "migrations", "apply", "DB",
 					"--remote", "--config", "./read-model/wrangler.jsonc",
@@ -206,18 +209,24 @@ import (
 
 			if includeReadModel {
 				read: schema.#Task & {
-					command: "bun"
-					args: ["x", "wrangler", "deploy", "--config", "./read-model/wrangler.jsonc"]				}
+					hermetic: false
+					command:  "bun"
+					args: ["x", "wrangler", "deploy", "--config", "./read-model/wrangler.jsonc"]
+				}
 			}
 			if includeWriteModel {
 				write: schema.#Task & {
-					command: "bun"
-					args: ["x", "wrangler", "deploy", "--config", "./write-model/wrangler.jsonc"]				}
+					hermetic: false
+					command:  "bun"
+					args: ["x", "wrangler", "deploy", "--config", "./write-model/wrangler.jsonc"]
+				}
 			}
 			if includeHttp {
 				http: schema.#Task & {
-					command: "bun"
-					args: ["x", "wrangler", "deploy", "--config", "./http/wrangler.jsonc"]				}
+					hermetic: false
+					command:  "bun"
+					args: ["x", "wrangler", "deploy", "--config", "./http/wrangler.jsonc"]
+				}
 			}
 		}
 	}

--- a/projects/rawkode.academy/identity/env.cue
+++ b/projects/rawkode.academy/identity/env.cue
@@ -12,7 +12,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -24,7 +24,8 @@ tasks: {
 	auth: schema.#TaskGroup & {
 		type: "group"
 		generate: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "@better-auth/cli", "generate", "--config", "./src/lib/auth.config.ts", "--output", "./src/db/schema.ts", "-y"]
 		}
 	}
@@ -32,7 +33,8 @@ tasks: {
 	bun: schema.#TaskGroup & {
 		type: "group"
 		dev: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "dev"]
 			inputs: [
 				"astro.config.mjs",
@@ -46,13 +48,15 @@ tasks: {
 	migrations: schema.#TaskGroup & {
 		type: "group"
 		remote: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "d1", "migrations", "apply", "identity", "--remote"]
 		}
 	}
 
 	build: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "build"]
 		inputs: [
 			"astro.config.mjs",
@@ -63,7 +67,8 @@ tasks: {
 	}
 
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 		dependsOn: [_t.migrations.remote, _t.build]
 		inputs: [

--- a/projects/rawkode.academy/platform/search/env.cue
+++ b/projects/rawkode.academy/platform/search/env.cue
@@ -12,7 +12,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -22,7 +22,8 @@ ci: pipelines: {
 
 tasks: {
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 	}
 }

--- a/projects/rawkode.academy/platform/transcriptions/env.cue
+++ b/projects/rawkode.academy/platform/transcriptions/env.cue
@@ -28,7 +28,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -38,15 +38,18 @@ ci: pipelines: {
 
 tasks: {
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy", "--config", "./wrangler.jsonc"]
 	}
 	"check-missing": schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["scripts/schedule_missing.ts"]
 	}
 	"schedule-missing": schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["scripts/schedule_missing.ts", "--execute"]
 	}
 }

--- a/projects/rawkode.academy/platform/zitadel-zulip-connector/env.cue
+++ b/projects/rawkode.academy/platform/zitadel-zulip-connector/env.cue
@@ -20,7 +20,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -30,7 +30,8 @@ ci: pipelines: {
 
 tasks: {
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 	}
 }

--- a/projects/rawkode.academy/tasks/remove-content-prefix/env.cue
+++ b/projects/rawkode.academy/tasks/remove-content-prefix/env.cue
@@ -26,7 +26,8 @@ ci: pipelines: {}
 
 tasks: {
 	run: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "start"]
 	}
 }

--- a/projects/rawkode.academy/tasks/video-importer/env.cue
+++ b/projects/rawkode.academy/tasks/video-importer/env.cue
@@ -25,7 +25,8 @@ env: {
 
 tasks: {
 	run: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "start"]
 	}
 }

--- a/projects/rawkode.academy/website/env.cue
+++ b/projects/rawkode.academy/website/env.cue
@@ -42,7 +42,8 @@ ci: pipelines: {
 
 tasks: {
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "dev"]
 
 		inputs: [
@@ -54,7 +55,8 @@ tasks: {
 	}
 
 	build: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "build"]
 
 		inputs: [
@@ -72,12 +74,14 @@ tasks: {
 	deploy: schema.#TaskGroup & {
 		type: "group"
 		main: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "deploy"]
 			dependsOn: [_t.build]
 		}
 		preview: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "versions", "upload"]
 			dependsOn: [_t.build]
 			captures: previewUrl: {

--- a/projects/rawkode.link/env.cue
+++ b/projects/rawkode.link/env.cue
@@ -12,7 +12,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -22,7 +22,8 @@ ci: pipelines: {
 
 tasks: {
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 	}
 }

--- a/projects/rawkode.news/env.cue
+++ b/projects/rawkode.news/env.cue
@@ -11,7 +11,6 @@ hooks: onEnter: devenv: schema.#Devenv
 
 let _t = tasks
 
-
 ci: pipelines: {
 	default: {
 		environment: "production"
@@ -34,7 +33,8 @@ ci: pipelines: {
 
 tasks: {
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "dev"]
 
 		inputs: [
@@ -47,7 +47,8 @@ tasks: {
 	}
 
 	build: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "build"]
 
 		inputs: [
@@ -65,12 +66,14 @@ tasks: {
 	deploy: schema.#TaskGroup & {
 		type: "group"
 		main: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "deploy"]
 			dependsOn: [_t.build]
 		}
 		preview: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "versions", "upload"]
 			dependsOn: [_t.build]
 		}

--- a/projects/rawkode.tools/observability-collector/env.cue
+++ b/projects/rawkode.tools/observability-collector/env.cue
@@ -22,7 +22,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -32,17 +32,20 @@ ci: pipelines: {
 
 tasks: {
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "dev"]
 	}
 
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 	}
 
 	typegen: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "types", "--env-interface", "CloudflareBindings"]
 	}
 }

--- a/projects/rawkode.tools/star-catcher/env.cue
+++ b/projects/rawkode.tools/star-catcher/env.cue
@@ -22,7 +22,7 @@ ci: pipelines: {
 	default: {
 		environment: "production"
 		when: {
-			branch:        ["main"]
+			branch: ["main"]
 			defaultBranch: true
 			manual:        true
 		}
@@ -34,7 +34,8 @@ tasks: {
 	cloudflare: schema.#TaskGroup & {
 		type: "group"
 		types: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "types"]
 			inputs: ["wrangler.jsonc"]
 			outputs: ["worker-configuration.d.ts"]
@@ -42,13 +43,15 @@ tasks: {
 	}
 
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "dev"]
 		dependsOn: [_t.cloudflare.types]
 	}
 
 	deploy: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["x", "wrangler", "deploy"]
 		dependsOn: [_t.cloudflare.types]
 	}


### PR DESCRIPTION
## Summary

Workaround for a cuenv **v0.42.0 regression**: hermetic task spawns run with `env_clear()` and no longer inject the activated **devenv-runtime** PATH that provides `bun`, so any `command: "bun"` task fails to spawn (`os error 2` / ENOENT). This broke deploys for every service whose tasks actually ran (api, transcriptions, rawkode.link, observability-collector, star-catcher, zitadel-zulip; others only "passed" because change-detection skipped them).

The built-in bun contributor tasks are already `hermetic: false` for exactly this reason. This PR marks the codegen `#PlatformService` tasks and the hand-written services' bun tasks `hermetic: false` so they inherit the runtime env.

## Root cause

`crates/ci/src/executor/runner.rs` spawns with `cmd.env_clear()` then restores PATH from the parent only when the task didn't set one; under v0.42.0 the devenv-runtime PATH (where `bun` lives, via the root `env.cue` `runtime: #DevenvRuntime`) is not part of a hermetic task's env. Non-hermetic tasks inherit the activated environment, so `bun` resolves.

## Test plan

- [x] `cue fmt` clean; codegen brackets sync generates and `tasks.deploy.read.hermetic == false`
- [ ] CI: website preview deploy (runs `bun` tasks) passes — confirms the spawn fix
- [ ] After merge: re-dispatch the deploys that failed/skipped (incl. `platform-brackets` + `api` gateway, which still need their first real deploy)

## Human action required

- After merge, manually dispatch deploys for services whose tasks were skipped by change-detection and never actually deployed — notably **`platform-brackets`** (read+write workers) and the **`api` gateway** (so the brackets subgraph federates). Order brackets before the gateway.
- The proper fix belongs in cuenv (inject the runtime PATH for hermetic spawns); this is a repo-side workaround.

This PR was created with the assistance of a LLM.