### PR TITLE
fix(website): query the gateway at / not /graphql

### DIFF
--- a/projects/rawkode.academy/website/src/lib/shows/client.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/client.ts
@@ -1,6 +1,7 @@
 // Thin helper for show plugins to query the federated GraphQL API server-side.
 
-const GRAPHQL_ENDPOINT = "https://api.rawkode.academy/graphql";
+// The Hive gateway serves GraphQL at the root path (graphqlEndpoint: "/").
+const GRAPHQL_ENDPOINT = "https://api.rawkode.academy/";
 
 export async function queryShowsApi<T>(
 	query: string,


### PR DESCRIPTION
The Hive gateway serves GraphQL at the root (`graphqlEndpoint: "/"`); the Show plugins' `queryShowsApi` was hitting `/graphql` and 404ing, so /shows/klustered rendered empty. Merging auto-deploys the website (src change).

This PR was created with the assistance of a LLM.