### PR TITLE
fix(codegen): declare deploy/migrate task inputs for change-detection

### DIFF
--- a/projects/rawkode.academy/codegen/platform-service.cue
+++ b/projects/rawkode.academy/codegen/platform-service.cue
@@ -192,6 +192,9 @@ import (
 	// D1 schema also get a `migrate` task, ordered before deploy in the pipeline.
 	// `hermetic: false` so tasks inherit the activated devenv-runtime PATH that
 	// provides `bun` (cuenv v0.42.0 hermetic spawns drop it -> ENOENT on `bun`).
+	// `inputs` drive cuenv change-detection: without them the deploy/migrate
+	// tasks are never "affected" and CI skips them. data-model/** is shared by
+	// the read and write workers (and gates migrations).
 	tasks: {
 		if _hasMigrations {
 			migrate: schema.#Task & {
@@ -201,6 +204,7 @@ import (
 					"x", "wrangler", "d1", "migrations", "apply", "DB",
 					"--remote", "--config", "./read-model/wrangler.jsonc",
 				]
+				inputs: ["data-model/**", "read-model/wrangler.jsonc"]
 			}
 		}
 
@@ -212,6 +216,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./read-model/wrangler.jsonc"]
+					inputs: ["read-model/**", "data-model/**", "package.json"]
 				}
 			}
 			if includeWriteModel {
@@ -219,6 +224,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./write-model/wrangler.jsonc"]
+					inputs: ["write-model/**", "data-model/**", "package.json"]
 				}
 			}
 			if includeHttp {
@@ -226,6 +232,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./http/wrangler.jsonc"]
+					inputs: ["http/**", "data-model/**", "package.json"]
 				}
 			}
 		}

--- a/projects/rawkode.academy/platform/brackets/data-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/schema.ts
@@ -1,3 +1,5 @@
+// Multi-tenant bracket schema: `showId` on `seasons` is the tenant key; every
+// other table derives its show through its season.
 import { sql } from "drizzle-orm";
 import {
 	integer,


### PR DESCRIPTION
Codegen deploy/migrate tasks had no `inputs`, so cuenv change-detection found `No affected tasks` and CI skipped them (which is why brackets/gateway never actually deployed). Declaring inputs makes a service deploy when its code changes. The brackets data-model nudge triggers its first deploy + remote migration via CI.

This PR was created with the assistance of a LLM.