### PR TITLE
fix(codegen): plain-prefix task inputs so deploys are change-detected

### DIFF
--- a/projects/rawkode.academy/codegen/platform-service.cue
+++ b/projects/rawkode.academy/codegen/platform-service.cue
@@ -204,7 +204,7 @@ import (
 					"x", "wrangler", "d1", "migrations", "apply", "DB",
 					"--remote", "--config", "./read-model/wrangler.jsonc",
 				]
-				inputs: ["data-model/**", "read-model/wrangler.jsonc"]
+				inputs: ["data-model", "read-model/wrangler.jsonc"]
 			}
 		}
 
@@ -216,7 +216,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./read-model/wrangler.jsonc"]
-					inputs: ["read-model/**", "data-model/**", "package.json"]
+					inputs: ["read-model", "data-model", "package.json"]
 				}
 			}
 			if includeWriteModel {
@@ -224,7 +224,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./write-model/wrangler.jsonc"]
-					inputs: ["write-model/**", "data-model/**", "package.json"]
+					inputs: ["write-model", "data-model", "package.json"]
 				}
 			}
 			if includeHttp {
@@ -232,7 +232,7 @@ import (
 					hermetic: false
 					command:  "bun"
 					args: ["x", "wrangler", "deploy", "--config", "./http/wrangler.jsonc"]
-					inputs: ["http/**", "data-model/**", "package.json"]
+					inputs: ["http", "data-model", "package.json"]
 				}
 			}
 		}

--- a/projects/rawkode.academy/platform/brackets/data-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/schema.ts
@@ -1,5 +1,6 @@
 // Multi-tenant bracket schema: `showId` on `seasons` is the tenant key; every
-// other table derives its show through its season.
+// other table derives its show through its season. Brackets, entries, matches,
+// and results are all scoped beneath a season.
 import { sql } from "drizzle-orm";
 import {
 	integer,


### PR DESCRIPTION
cuenv `matches_pattern` uses `starts_with` for non-glob patterns but globset for `**`; `data-model/**` matched nested files but not direct children (`data-model/schema.ts`), so the brackets deploy stayed 'No affected tasks'. Plain prefixes match both. The schema nudge triggers brackets' first deploy + remote migration via CI.

This PR was created with the assistance of a LLM.