### PR TITLE
fix(website): use cloudflare:workers env in show routes (Astro v6)

### DIFF
--- a/projects/rawkode.academy/website/src/pages/api/shows/[showId]/[...slug].ts
+++ b/projects/rawkode.academy/website/src/pages/api/shows/[showId]/[...slug].ts
@@ -1,10 +1,11 @@
+import { env } from "cloudflare:workers";
 import type { APIRoute } from "astro";
 import { getShowExtension } from "@/lib/shows/registry";
 import type { ShowEnv } from "@/lib/shows/types";
 
 export const prerender = false;
 
-export const ALL: APIRoute = async ({ params, request, locals, url }) => {
+export const ALL: APIRoute = async ({ params, request, url }) => {
 	const { showId, slug } = params;
 	if (!showId) return new Response(null, { status: 404 });
 
@@ -12,15 +13,12 @@ export const ALL: APIRoute = async ({ params, request, locals, url }) => {
 	const endpoint = ext?.endpoints?.find((e) => e.slug === (slug ?? ""));
 	if (!ext || !endpoint) return new Response(null, { status: 404 });
 
-	const env =
-		(locals as { runtime?: { env?: ShowEnv } }).runtime?.env ?? {};
-
 	return endpoint.handler({
 		showId,
 		slug: endpoint.slug,
 		params,
 		request,
 		url,
-		env,
+		env: env as unknown as ShowEnv,
 	});
 };

--- a/projects/rawkode.academy/website/src/pages/shows/[showId]/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/shows/[showId]/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = false;
 
+import { env } from "cloudflare:workers";
 import { getCollection } from "astro:content";
 import ShowLayout from "@/layouts/ShowLayout.astro";
 import { getShowExtension, getShowNav } from "@/lib/shows/registry";
@@ -18,8 +19,6 @@ const ext = getShowExtension(showId);
 const page = ext?.pages.find((p) => p.slug === (slug ?? ""));
 if (!ext || !page) return new Response(null, { status: 404 });
 
-const env = (Astro.locals as { runtime?: { env?: ShowEnv } }).runtime?.env ?? {};
-
 const data = page.load
 	? await page.load({
 			showId,
@@ -27,7 +26,7 @@ const data = page.load
 			params: Astro.params,
 			request: Astro.request,
 			url: Astro.url,
-			env,
+			env: env as unknown as ShowEnv,
 		})
 	: {};
 


### PR DESCRIPTION
Astro v6 removed `Astro.locals.runtime.env`; the show catch-all page + endpoint used it and 500'd. Switch to `import { env } from "cloudflare:workers"`. Merging auto-deploys the website.

This PR was created with the assistance of a LLM.