### PR TITLE
fix(rawkode.academy/identity): index verification expiry cleanup

### DIFF
--- a/projects/rawkode.academy/identity/migrations/0012_add_verification_expires_at_index.sql
+++ b/projects/rawkode.academy/identity/migrations/0012_add_verification_expires_at_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS `verification_expiresAt_idx` ON `verification` (`expires_at`);
+--> statement-breakpoint

--- a/projects/rawkode.academy/identity/migrations/meta/_journal.json
+++ b/projects/rawkode.academy/identity/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1771891200000,
       "tag": "0011_add_rawkode_cloud_oauth",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1779703500000,
+      "tag": "0012_add_verification_expires_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/rawkode.academy/identity/src/db/schema.ts
+++ b/projects/rawkode.academy/identity/src/db/schema.ts
@@ -87,7 +87,10 @@ export const verification = sqliteTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("verification_identifier_idx").on(table.identifier)],
+  (table) => [
+    index("verification_identifier_idx").on(table.identifier),
+    index("verification_expiresAt_idx").on(table.expiresAt),
+  ],
 );
 
 export const jwks = sqliteTable("jwks", {


### PR DESCRIPTION
## Summary
- add a D1 migration for an index on verification.expires_at
- keep the Drizzle identity schema aligned with the new index
- make the migration idempotent with IF NOT EXISTS

## Root Cause
Production login callbacks were failing in Better Auth while it attempted to clean expired verification rows:

```
DELETE FROM verification WHERE expires_at < ?
```

The production verification table had over 2.19M expired rows and no index on expires_at, so the callback path spent ~35s in cleanup and returned 500.

## Validation
- Confirmed production failure with `cuenv -e production exec dx wrangler tail --format json --ip self`.
- Confirmed production table had 2,194,081 verification rows, 2,194,025 expired rows, and no expires_at index before manual cleanup.
- After manual `DELETE FROM verification`, confirmed invalid callback returns fast: `302 0.108959`.
- Ran `git diff --cached --check`.
- `bun run build` in `projects/rawkode.academy/identity` currently fails on an existing Vite plugin type mismatch in `astro.config.mjs`, before this migration is exercised.