### PR TITLE
fix(klustered.dev): run cuenv tasks non-hermetically

### DIFF
--- a/projects/klustered.dev/env.cue
+++ b/projects/klustered.dev/env.cue
@@ -37,7 +37,8 @@ ci: pipelines: {
 
 tasks: {
 	dev: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "dev"]
 
 		inputs: [
@@ -50,7 +51,8 @@ tasks: {
 	}
 
 	build: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "build"]
 
 		inputs: [
@@ -67,7 +69,8 @@ tasks: {
 	}
 
 	check: schema.#Task & {
-		command: "bun"
+		hermetic: false
+		command:  "bun"
 		args: ["run", "check"]
 
 		inputs: [
@@ -81,12 +84,14 @@ tasks: {
 	deploy: schema.#TaskGroup & {
 		type: "group"
 		main: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "deploy"]
 			dependsOn: [_t.build]
 		}
 		preview: schema.#Task & {
-			command: "bun"
+			hermetic: false
+			command:  "bun"
 			args: ["x", "wrangler", "versions", "upload"]
 			dependsOn: [_t.build]
 			captures: previewUrl: {


### PR DESCRIPTION
## Summary

The klustered-dev deploy (push-to-main) failed with `Failed to spawn task 'build': No such file or directory (os error 2)`. The hand-written `env.cue` tasks ran hermetically, so `bun` was not on PATH. This adds `hermetic: false` to every task (dev/build/check/deploy), matching `rawkode.academy/website/env.cue`.

Fixes the failed deploy of #1152.

## Human action required

- None. Merging re-runs the push-to-main deploy of klustered.dev.

This PR was created with the assistance of a LLM.