### PR TITLE
fix(klustered.dev): add devenv so cuenv tasks find bun

### DIFF
--- a/projects/klustered.dev/.gitignore
+++ b/projects/klustered.dev/.gitignore
@@ -9,6 +9,10 @@ node_modules/
 .wrangler/
 .dev.vars
 
+# devenv
+.devenv*
+devenv.local.nix
+
 # Local env
 .env
 .env.local

--- a/projects/klustered.dev/devenv.lock
+++ b/projects/klustered.dev/devenv.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1774687639,
+        "narHash": "sha256-nYuCwx89sBq7V0TveX9LnMnlh/tuJ+oeC5Hyz45WJEg=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "b4ea96c18cfb3ac57d8658802e06ff53bbbc7001",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/projects/klustered.dev/devenv.nix
+++ b/projects/klustered.dev/devenv.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+{
+  name = "klustered.dev";
+
+  dotenv.disableHint = true;
+
+  cachix.enable = false;
+
+  languages.javascript = {
+    enable = true;
+    package = pkgs.nodejs_24;
+  };
+  languages.typescript.enable = true;
+
+  packages = with pkgs; [
+    bun
+  ];
+
+  enterShell = ''
+    bun install
+  ''
+  + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+    export LD_LIBRARY_PATH=${pkgs.libgccjit}/lib:$LD_LIBRARY_PATH
+
+    __patchTarget="./node_modules/@cloudflare/workerd-linux-64/bin/workerd"
+    if [[ -f "$__patchTarget" ]]; then
+      ${pkgs.patchelf}/bin/patchelf --set-interpreter ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 "$__patchTarget"
+    fi
+  '';
+}

--- a/projects/klustered.dev/devenv.yaml
+++ b/projects/klustered.dev/devenv.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-unstable


### PR DESCRIPTION
## Summary

The klustered.dev deploy failed (twice) with `Failed to spawn task 'build': No such file or directory (os error 2)`. Root cause: `env.cue` declares `runtime: DevenvRuntime` but the project had no `devenv.nix`, so the devenv hook produced no `bun`. (`hermetic: false`, added in #1154, was necessary but not sufficient.)

Adds `devenv.nix` / `devenv.yaml` / `devenv.lock` modeled on `rawkode.academy/website` (bun + nodejs + the Linux workerd patchelf), and ignores `.devenv*` artifacts.

## Human action required

- After merge, the deploy must be triggered manually (devenv files are not in the workflow's path filter): `gh workflow run klustered-dev-default.yml --ref main`. I'll do this and watch it.

This PR was created with the assistance of a LLM.