### PR TITLE
feat(rawkode.link): redirect klustered.live to the show page

### DIFF
--- a/projects/rawkode.link/src/klustered.live/index.ts
+++ b/projects/rawkode.link/src/klustered.live/index.ts
@@ -1,8 +1,19 @@
 import type { Domain } from "../types";
 
+// klustered.live is decommissioned; the public show now lives on the website.
+const SHOW = "https://rawkode.academy/shows/klustered";
+
 const redirects: Domain = {
-	defaultRedirect: "https://klustered.dev",
-	redirects: {},
+	defaultRedirect: SHOW,
+	redirects: {
+		brackets: { to: `${SHOW}/brackets` },
+		schedule: { to: `${SHOW}/schedule` },
+		leaderboard: { to: `${SHOW}/leaderboard` },
+		apply: { to: `${SHOW}/apply` },
+		"schedule.ics": {
+			to: "https://rawkode.academy/api/shows/klustered/schedule.ics",
+		},
+	},
 };
 
 export default redirects;


### PR DESCRIPTION
## Summary

klustered.live (already removed from the monorepo on `main`) is served as a redirect by the `rawkode.link` worker, which owns the `klustered.live` custom domain. Its handler still pointed at the old `klustered.dev` admin; this repoints it to the public show at `rawkode.academy/shows/klustered`, with path redirects for `brackets`, `schedule`, `leaderboard`, `apply`, and `schedule.ics`.

## Human action required

- None. Merging deploys the `rawkode-link` worker.

This PR was created with the assistance of a LLM.