### PR TITLE
fix(rawkode.link): add devenv so the cuenv deploy finds bun

### DIFF
--- a/projects/rawkode.link/.gitignore
+++ b/projects/rawkode.link/.gitignore
@@ -1,2 +1,4 @@
 /dist
 /node_modules
+.devenv*
+devenv.local.nix

--- a/projects/rawkode.link/devenv.lock
+++ b/projects/rawkode.link/devenv.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1774687639,
+        "narHash": "sha256-nYuCwx89sBq7V0TveX9LnMnlh/tuJ+oeC5Hyz45WJEg=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "b4ea96c18cfb3ac57d8658802e06ff53bbbc7001",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/projects/rawkode.link/devenv.nix
+++ b/projects/rawkode.link/devenv.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+{
+  name = "rawkode.link";
+
+  dotenv.disableHint = true;
+
+  cachix.enable = false;
+
+  languages.javascript = {
+    enable = true;
+    package = pkgs.nodejs_24;
+  };
+  languages.typescript.enable = true;
+
+  packages = with pkgs; [
+    bun
+  ];
+
+  enterShell = ''
+    bun install
+  ''
+  + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+    export LD_LIBRARY_PATH=${pkgs.libgccjit}/lib:$LD_LIBRARY_PATH
+
+    __patchTarget="./node_modules/@cloudflare/workerd-linux-64/bin/workerd"
+    if [[ -f "$__patchTarget" ]]; then
+      ${pkgs.patchelf}/bin/patchelf --set-interpreter ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 "$__patchTarget"
+    fi
+  '';
+}

--- a/projects/rawkode.link/devenv.yaml
+++ b/projects/rawkode.link/devenv.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-unstable

--- a/projects/rawkode.link/env.cue
+++ b/projects/rawkode.link/env.cue
@@ -6,6 +6,9 @@ schema.#Project
 
 name: "rawkode-link"
 
+runtime: schema.#DevenvRuntime
+hooks: onEnter: devenv: schema.#Devenv
+
 let _t = tasks
 
 ci: pipelines: {


### PR DESCRIPTION
## Summary

The `rawkode-link` push-to-main deploy failed with `Failed to spawn task 'deploy': No such file or directory (os error 2)`. `env.cue` ran the deploy task with `hermetic: false` but declared no devenv runtime and shipped no `devenv.nix`, so `bun` was never on PATH. This adds `runtime: DevenvRuntime` + `devenv.nix`/`devenv.yaml`/`devenv.lock` (bun + nodejs), mirroring the website and klustered.dev, and ignores `.devenv*`.

This unblocks the klustered.live redirect change (#1159), which is already on `main` but undeployed because of this failure.

## Human action required

- None. Merging redeploys `rawkode-link`.

This PR was created with the assistance of a LLM.