### PR TITLE
[codex] Sync Cuenv agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ content/scripts/output/youtube-descriptions/
 
 # Local Claude Code agent state
 **/.claude/scheduled_tasks.lock
+
+# BEGIN cuenv vcs
+.agents/skills/
+.cuenv/vcs/cache/
+.cuenv/vcs/tmp/
+# END cuenv vcs

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,0 +1,11 @@
+version = 4
+
+[vcs.cuenv-skills]
+url = "https://github.com/cuenv/cuenv.git"
+reference = "main"
+commit = "4f21b63258a0068cdf8c080f180106c807a6216d"
+tree = "c8e936625512de7644437551b64b0ff85cd1a006"
+vendor = false
+path = ".agents/skills"
+subdir = ".agents/skills"
+subtree = "5259ceafa1f8965f304b9270241c7e6134908968"

--- a/env.cue
+++ b/env.cue
@@ -80,6 +80,14 @@ ci: provider: github: {
 	}
 }
 
+vcs: "cuenv-skills": {
+	url:       "https://github.com/cuenv/cuenv.git"
+	reference: "main"
+	vendor:    false
+	subdir:    ".agents/skills"
+	path:      ".agents/skills"
+}
+
 env: {
 	environment: production: {
 		CLOUDFLARE_ACCOUNT_ID: "0aeb879de8e3cdde5fb3d413025222ce"


### PR DESCRIPTION
## Summary

- Add a root `vcs` dependency that syncs Cuenv's `.agents/skills` subtree into this repository.
- Lock the synced subtree in `cuenv.lock`.
- Ignore the generated `.agents/skills` and `.cuenv/vcs` cache/tmp paths because the dependency is declared with `vendor: false`.

## Validation

- `cuenv info .`
- `cuenv sync vcs`
- `cuenv sync vcs --check`
- `git diff --check`

## Notes

The materialized `.agents/skills` directory is generated locally by `cuenv sync vcs` and intentionally not committed.