### PR TITLE
[codex] Add bracket-scoped instant apply teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ content/scripts/output/youtube-descriptions/
 
 # Local Claude Code agent state
 **/.claude/scheduled_tasks.lock
+
+# BEGIN cuenv vcs
+.agents/skills/
+.cuenv/vcs/cache/
+.cuenv/vcs/tmp/
+# END cuenv vcs

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,0 +1,11 @@
+version = 4
+
+[vcs.cuenv-skills]
+url = "https://github.com/cuenv/cuenv.git"
+reference = "main"
+commit = "4f21b63258a0068cdf8c080f180106c807a6216d"
+tree = "c8e936625512de7644437551b64b0ff85cd1a006"
+vendor = false
+path = ".agents/skills"
+subdir = ".agents/skills"
+subtree = "5259ceafa1f8965f304b9270241c7e6134908968"

--- a/docs/superpowers/specs/2026-05-25-klustered-instant-apply-teams-design.md
+++ b/docs/superpowers/specs/2026-05-25-klustered-instant-apply-teams-design.md
@@ -17,9 +17,14 @@ This also requires choosing **team vs individual** when a bracket is created.
 
 ## Decisions (from brainstorming)
 
-1. **Apply targets a bracket.** Only one season is ever live at a time, so the
-   Apply tab lists the live season's open bracket(s); team/individual is the
-   existing `brackets.kind` (`solo` | `team`).
+1. **Apply targets a specific bracket.** A season has **multiple brackets**
+   (e.g. S26 "Summer 2026" has a Solo bracket *and* a Team bracket). The Apply
+   tab lists every open bracket of the live season as its own card;
+   team/individual is the existing `brackets.kind` (`solo` | `team`). A
+   competitor is season-scoped, so per-bracket intent ("entered Solo", "entered
+   Team", or both) is tracked separately in a new `bracket_applications` table.
+   Assumption: at most one Team bracket per season (so team formation is
+   unambiguous) — see open questions.
 2. **Apply creates a competitor instantly** (idempotent), linked by `userId`
    (OIDC `sub`). No pending-approval gate. The bracket itself (entries + matches)
    is still built **live on stream by the admin** — that is out of scope here
@@ -37,9 +42,14 @@ This also requires choosing **team vs individual** when a bracket is created.
 
 | Stage | Where | Writes to |
 |-------|-------|-----------|
-| Apply | website Apply tab | `competitors` only |
-| Form / join teams | klustered.dev `/me`, `/join/{token}` | `teams`, `teamMembers`, `team_invites` |
+| Apply | website Apply tab | `competitors`, `bracket_applications` |
+| Form / join teams | klustered.dev `/me`, `/join/{token}` | `teams`, `teamMembers`, `team_invites`, `bracket_applications` |
 | Build bracket live | klustered.dev admin (existing, **out of scope**) | `bracketEntries`, `matches` |
+
+The admin builds each bracket live by drawing from the season's
+`bracket_applications` (Solo bracket: applicant competitors; Team bracket: the
+formed `teams`). That seeding UI is out of scope here; this change only produces
+the data it draws from.
 
 ## How auth/reads work today (verified)
 
@@ -70,6 +80,16 @@ to forward the request's `Cookie` header on the one authenticated read.
 
 #### Schema (`data-model/schema.ts` + migration)
 
+- New table `bracket_applications` (per-bracket intent; the season competitor is
+  shared across that season's brackets):
+  - `id` text pk
+  - `bracketId` → `brackets.id` (cascade)
+  - `competitorId` → `competitors.id` (cascade)
+  - `createdAt` timestamp
+  - unique `(bracketId, competitorId)`
+  - This is the explicit "entered this bracket" record. It is **not** a
+    `bracketEntry` (no seed; the bracket is still built live). The legacy
+    `registrations` table is not reused.
 - New table `team_invites`:
   - `token` text pk (cuid2, opaque)
   - `teamId` → `teams.id` (cascade)
@@ -89,23 +109,31 @@ and these methods additionally validate invariants.
 
 - `selfRegisterCompetitor({ bracketId, userId, displayName }) → { competitorId, seasonId, bracketKind }`
   - Resolve bracket → season.
-  - If a competitor with `(seasonId, userId)` exists, return it (**idempotent**).
-  - Else generate a unique `personSlug` from `displayName` (slugify + numeric
-    dedupe within the season) and insert the competitor with `userId`.
-- `formTeam({ seasonId, name, userId }) → { teamId, token }`
-  - Find caller's competitor in the season; error if none.
-  - Reject if the competitor is already on a team this season (one team per
+  - If a competitor with `(seasonId, userId)` exists, reuse it; else generate a
+    unique `personSlug` from `displayName` (slugify + numeric dedupe within the
+    season) and insert the competitor with `userId`.
+  - Upsert `bracket_applications (bracketId, competitorId)` (**idempotent** on
+    the unique key). This is what records "entered this specific bracket".
+- `formTeam({ bracketId, name, userId }) → { teamId, token }`
+  - Resolve bracket → season; verify `bracket.kind = "team"`.
+  - Find caller's competitor in the season; error if none (they must have
+    applied first).
+  - Reject if the competitor is already on a team in this season (one team per
     competitor per season — enforced in logic; no DB unique exists).
   - Create the team (slug = slugify(name), deduped), add caller as
-    `teamMembers` with `role = "captain"`, mint a `team_invites` token.
+    `teamMembers` with `role = "captain"`, ensure
+    `bracket_applications (bracketId, competitorId)`, mint a `team_invites`
+    token (storing `teamId` + `seasonId`).
 - `joinTeamViaInvite({ token, userId, displayName }) → { teamId, seasonId }`
-  - Validate token exists and `revokedAt` is null.
-  - Resolve team + season. Ensure a competitor exists for `userId` (create like
+  - Validate token exists and `revokedAt` is null. Resolve team + season, and
+    the season's Team bracket (the `kind = "team"` bracket; assumes exactly one).
+  - Ensure a competitor exists for `userId` (create like
     `selfRegisterCompetitor` if missing).
   - Reject if competitor already on a team this season, or if the team already
-    has `bracket.teamSize` members. (Team size: read the relevant team bracket's
-    `teamSize`; see open question below if a season can host multiple brackets.)
-  - Add as `teamMembers` (`role = "member"`); idempotent if already a member.
+    has `teamBracket.teamSize` members.
+  - Add as `teamMembers` (`role = "member"`), ensure
+    `bracket_applications (teamBracketId, competitorId)`. Idempotent if already
+    a member.
 - `renameTeam({ teamId, name, userId }) → { ok }` — captain only.
 - `createTeamInvite({ teamId, userId }) → { token }` — regenerate; captain/member only.
 - `revokeTeamInvite({ token, userId }) → { ok }` — set `revokedAt`.
@@ -118,12 +146,23 @@ Add a shared `slugify`/dedupe helper used by competitor and team creation.
 
 - `main.ts`: build a Yoga context from request headers, reading
   `X-Gateway-User-Id` (and name/email if useful) into `ctx.user`.
-- New JWT/header-gated field, e.g. extend the `Show` entity:
-  `myParticipation(showId via entity): MyParticipation` returning, for the live
-  season's open brackets, whether the caller is a registered competitor and
-  which team they are on (and `bracketKind`). Returns null/empty when
-  unauthenticated. Used by the website Apply tab to render "✓ Registered" and
-  the correct manage-link.
+- New header-gated field on the federated `Show` entity, e.g.
+  `myParticipation`, returning a **per-bracket** list for the live season's open
+  brackets:
+  ```graphql
+  type MyParticipation { brackets: [MyBracketParticipation!]! }
+  type MyBracketParticipation {
+    bracketId: String!
+    bracketSlug: String!
+    bracketKind: String!     # solo | team
+    applied: Boolean!        # from bracket_applications
+    team: MyTeam             # null unless team bracket and on a team
+  }
+  type MyTeam { id: String!  name: String!  slug: String!  isCaptain: Boolean!  memberCount: Int! }
+  ```
+  Returns empty/`applied: false` when unauthenticated (no `X-Gateway-User-Id`).
+  The Apply tab uses this to render each bracket card's state (Apply vs
+  "✓ Entered") and the correct manage-link.
 
 ### B. `rawkode.academy/website` (Apply tab)
 
@@ -138,10 +177,12 @@ Add a shared `slugify`/dedupe helper used by competitor and team creation.
   all input fields.
   - Signed-out → "Sign in to apply" (link to the website OIDC sign-in with
     `returnTo` back to the apply tab).
-  - Signed-in → one card per open bracket: season name, **Team**/**Individual**
-    badge, **Apply** button (POST). If `myParticipation` shows already
-    registered → "✓ Registered" plus a CTA to `https://klustered.dev/me`
-    ("Set up your team" for team kind, "Manage your profile" for solo).
+  - Signed-in → one card per open bracket (S26 shows two: Solo and Team), each
+    with the bracket name, **Team**/**Individual** badge, and an **Apply** button
+    (POST) targeting that bracket. If `myParticipation` shows `applied` for that
+    bracket → "✓ Entered" plus a CTA to `https://klustered.dev/me`: for a Team
+    bracket, "Set up your team" (and, if not yet on a team, nudge to do so); for
+    Solo, "Manage your profile". A user can enter Solo, Team, or both.
   - Editorial design system (see `website/CLAUDE.md`): hairline cards, mono
     labels, no shadows/blur. No em-dashes in copy.
 - **`apply` endpoint** (`src/lib/shows/plugins/bracket/endpoints.ts`): read the
@@ -159,13 +200,16 @@ Add a shared `slugify`/dedupe helper used by competitor and team creation.
   and, shown when Team, a `teamSize` input (default 2). Pass both to
   `bracketsWrite(env).createBracket({ ..., kind, teamSize })`.
 - **`/me/team`** (new page + nav entry in `src/lib/nav.ts`):
-  - Determine the competitor's live-season bracket kind (direct D1 read — the
-    established klustered.dev pattern).
-  - Team edition, no team yet → "Name your team" form → POST → `formTeam` →
-    redirect to the team view.
-  - Team edition, on a team → show team name (rename if captain), roster, the
-    copyable invite link, and captain controls (regenerate / revoke link).
-  - Solo edition → "You're registered for {season} (Individual)" only.
+  - Resolve the live season's **Team bracket** (the `kind = "team"` bracket;
+    direct D1 read — the established klustered.dev pattern). `teamSize` comes
+    from this bracket. The page is only relevant when such a bracket is open;
+    otherwise show "No team bracket is open."
+  - Entered the Team bracket, no team yet → "Name your team" form → POST →
+    `formTeam({ bracketId: teamBracketId })` → redirect to the team view.
+  - On a team → show team name (rename if captain), roster, the copyable invite
+    link, and captain controls (regenerate / revoke link).
+  - Show Solo-bracket status (entered / not) separately on `/me`, since a
+    competitor may be in both brackets.
 - **`/join/[token]`** (new page + API):
   - Add `/join` to the auth-required prefixes in `src/middleware.ts` so
     unauthenticated visitors are bounced to sign-in with `returnTo`.
@@ -176,39 +220,40 @@ Add a shared `slugify`/dedupe helper used by competitor and team creation.
   `content/people/{slug}.mdx`" note so it does not show for self-applied
   competitors whose `personSlug` has no content profile (the `getPerson` lookup
   is already best-effort; the copy is the only issue).
-- **Mirror schema** in `src/db/schema.ts`: add `team_invites` and
-  `brackets.teamSize` so klustered.dev's direct D1 reads compile. (klustered.dev
-  reads D1 directly; those reads stay as-is and are not migrated to GraphQL in
-  this change.)
+- **Mirror schema** in `src/db/schema.ts`: add `bracket_applications`,
+  `team_invites`, and `brackets.teamSize` so klustered.dev's direct D1 reads
+  compile. (klustered.dev reads D1 directly; those reads stay as-is and are not
+  migrated to GraphQL in this change.)
 
 ## Data flow
 
 ```
-Apply (website)
-  user → Apply button → /api/shows/klustered/apply
+Apply (website) — per bracket (S26 shows Solo + Team cards)
+  user → Apply button on a bracket → /api/shows/klustered/apply
     → BRACKETS_WRITE.selfRegisterCompetitor({ bracketId, userId, displayName })
-    → competitor (idempotent) → redirect back
+    → season competitor (idempotent) + bracket_applications(bracketId) → redirect
   Apply tab read → queryShowsApi(myParticipation, cookies) → gateway validates
     Better Auth cookie via IDENTITY → forwards X-Gateway-User-Id → brackets
-    subgraph → "✓ Registered" + link to klustered.dev/me
+    subgraph → per-bracket "✓ Entered" + link to klustered.dev/me
 
-Form team (klustered.dev)
-  captain → /me/team → formTeam → team + captain member + invite token
-    → copyable klustered.dev/join/{token}
+Form team (klustered.dev, Team bracket only)
+  captain → /me/team → formTeam({ teamBracketId }) → team + captain member
+    + bracket_applications + invite token → copyable klustered.dev/join/{token}
 
 Join (klustered.dev)
   colleague → /join/{token} → sign in → joinTeamViaInvite
-    → competitor (if missing) + teamMember → /me/team
+    → competitor (if missing) + teamMember + bracket_applications → /me/team
 
 Build bracket live (admin, out of scope)
-  admin draws formed teams/competitors into bracketEntries + matches on stream
+  admin draws applicants (Solo) / formed teams (Team) into bracketEntries
+    + matches on stream
 ```
 
 ## Deploy order (service-binding rule)
 
-1. `platform/brackets` — schema migration (`team_invites`, `brackets.teamSize`),
-   new write commands, read-model participation field. Deploy + apply D1
-   migrations first.
+1. `platform/brackets` — schema migration (`bracket_applications`,
+   `team_invites`, `brackets.teamSize`), new write commands, read-model
+   participation field. Deploy + apply D1 migrations first.
 2. `rawkode.academy/website` — add `BRACKETS_WRITE` binding, Apply rewrite,
    cookie-forwarding read.
 3. `klustered.dev` — admin `kind`/`teamSize`, `/me/team`, `/join/{token}`,
@@ -220,11 +265,14 @@ must be live before the website binding lands.
 ## Testing
 
 - **brackets write-model**: unit/integration tests for `selfRegisterCompetitor`
-  (idempotency, slug dedupe), `formTeam` (one-team-per-season, captain role),
-  `joinTeamViaInvite` (token valid/revoked, team-full cap, already-on-team),
+  (competitor idempotency + slug dedupe + `bracket_applications` upsert, incl.
+  applying to both Solo and Team in one season), `formTeam`
+  (one-team-per-season, captain role, kind=team guard), `joinTeamViaInvite`
+  (token valid/revoked, team-full cap, already-on-team, records application),
   `renameTeam`/`revokeTeamInvite` ownership. Follow the existing `tests/` setup.
-- **brackets read-model**: `myParticipation` returns correctly for
-  authenticated vs anonymous (header present/absent), reflects team membership.
+- **brackets read-model**: `myParticipation` returns the correct per-bracket
+  list for authenticated vs anonymous (header present/absent), reflects
+  per-bracket `applied` and team membership.
 - **website**: Apply tab renders signed-out / signed-in / registered states;
   endpoint calls `selfRegisterCompetitor` with session identity; anonymous read
   path unaffected.
@@ -241,11 +289,15 @@ must be live before the website binding lands.
 
 ## Open questions (resolve during planning)
 
-1. **Multiple brackets per season.** Apply targets a bracket and competitors are
-   season-scoped. If a live season ever has both a solo and a team bracket, how
-   is team-size / kind resolved for a competitor on `/me/team`? Current
-   assumption: one bracket per live season. Confirm we can rely on that, or pick
-   a rule (e.g., team features key off the season's team bracket).
+1. **One Team bracket per season (teams are season-scoped).** Seasons have
+   multiple brackets (Solo + Team for S26), and `teams`/`teamMembers` reference
+   `seasonId`, not `bracketId`. Team formation therefore assumes exactly one
+   `kind = "team"` bracket per season. If you ever want two Team brackets in one
+   season (e.g. "Team Beginner" + "Team Pro"), `teams` must become
+   bracket-scoped (add `teams.bracketId`), which also touches the admin teams UI
+   and `generateBracket`'s "this season's teams" query. Decision needed: keep
+   season-scoped teams + the one-Team-bracket assumption now, or make teams
+   bracket-scoped up front.
 2. **Captain leaving.** If a captain `leaveTeam`s, do we promote the oldest
    member, block until reassigned, or dissolve the team?
 3. **Where `myParticipation` hangs.** As a field on the federated `Show` entity

--- a/docs/superpowers/specs/2026-05-25-klustered-instant-apply-teams-design.md
+++ b/docs/superpowers/specs/2026-05-25-klustered-instant-apply-teams-design.md
@@ -1,0 +1,263 @@
+# Klustered instant-apply + self-service teams — design
+
+Date: 2026-05-25
+Status: Approved for planning
+Scope: `projects/rawkode.academy/platform/brackets`, `projects/rawkode.academy/website`, `projects/klustered.dev`
+
+## Problem
+
+The Klustered "Apply" tab on the website is a details form (bracket dropdown,
+display name, email, optional team name, message) that writes a pending
+`registration`. We want it to be a one-click action for a logged-in user, using
+their identity. After applying, a competitor should manage their own details on
+`klustered.dev`: for team editions they name their team and invite colleagues
+via a shareable link; colleagues join by opening the link and signing in.
+
+This also requires choosing **team vs individual** when a bracket is created.
+
+## Decisions (from brainstorming)
+
+1. **Apply targets a bracket.** Only one season is ever live at a time, so the
+   Apply tab lists the live season's open bracket(s); team/individual is the
+   existing `brackets.kind` (`solo` | `team`).
+2. **Apply creates a competitor instantly** (idempotent), linked by `userId`
+   (OIDC `sub`). No pending-approval gate. The bracket itself (entries + matches)
+   is still built **live on stream by the admin** — that is out of scope here
+   and must not be touched by apply/team formation.
+3. **Team join = auto-join on click + sign-in.** First applicant becomes the
+   team captain, names the team, and gets a tokenized invite link
+   (`klustered.dev/join/{token}`). Colleagues open it, sign in, and are added.
+4. **Team size is capped per bracket** via a new `brackets.teamSize` (default 2);
+   joining rejects once full.
+5. **No email column** on competitors — identity (`id.rawkode.academy`) owns email.
+6. **Reads go through GraphQL** (CQRS). The "am I already registered?" read is an
+   authenticated federated query, not a write-model RPC.
+
+## Stage model (strict separation)
+
+| Stage | Where | Writes to |
+|-------|-------|-----------|
+| Apply | website Apply tab | `competitors` only |
+| Form / join teams | klustered.dev `/me`, `/join/{token}` | `teams`, `teamMembers`, `team_invites` |
+| Build bracket live | klustered.dev admin (existing, **out of scope**) | `bracketEntries`, `matches` |
+
+## How auth/reads work today (verified)
+
+- The website's session is its own (`rawkode-session` + `SESSION` KV), but the
+  browser also carries Better Auth cookies (`better-auth.session_token` /
+  `__Secure-better-auth.session_token`) — see `website/src/middleware/auth.ts`,
+  `website/src/actions/auth.ts`.
+- The Hive gateway authenticates each request in `api/src/auth/index.ts`: it
+  validates the Better Auth cookie via the `IDENTITY` service binding
+  (`/auth/get-session`) and builds `{ user, session, isAuthenticated }`.
+- The gateway forwards identity to subgraphs as **headers**, not a JWT
+  (`api/src/transport/service-binding.ts:74-82`): `X-Gateway-User-Id`,
+  `X-Gateway-User-Email`, `X-Gateway-User-Name`.
+- `website/src/lib/shows/client.ts` `queryShowsApi` currently does an anonymous
+  `fetch` to `https://api.rawkode.academy/` with no cookies.
+
+**Implication:** authenticated reads already work at the gateway. The brackets
+read-model only needs to consume `X-Gateway-User-Id`, and the website only needs
+to forward the request's `Cookie` header on the one authenticated read.
+
+> Do **not** copy `platform/email-preferences`' `ctx.jwt.payload.sub` pattern.
+> It predates the current gateway and does not match what is actually forwarded
+> (`X-Gateway-User-*` headers). Brackets reads the header.
+
+## Component design
+
+### A. `platform/brackets` (deploy first — both apps bind it)
+
+#### Schema (`data-model/schema.ts` + migration)
+
+- New table `team_invites`:
+  - `token` text pk (cuid2, opaque)
+  - `teamId` → `teams.id` (cascade)
+  - `seasonId` → `seasons.id` (cascade)
+  - `createdByUserId` text not null
+  - `createdAt` timestamp
+  - `revokedAt` timestamp nullable
+  - Reusable until revoked; no expiry.
+- `brackets.teamSize` integer not null default 2 (meaningful only when
+  `kind = "team"`; ignored for solo).
+
+#### Write-model RPC (`write-model/main.ts`, new methods on `BracketsWriteModel`)
+
+All take the caller's `userId` (OIDC sub) for ownership/record-keeping;
+authorization is enforced at klustered.dev/website (trusted service binding),
+and these methods additionally validate invariants.
+
+- `selfRegisterCompetitor({ bracketId, userId, displayName }) → { competitorId, seasonId, bracketKind }`
+  - Resolve bracket → season.
+  - If a competitor with `(seasonId, userId)` exists, return it (**idempotent**).
+  - Else generate a unique `personSlug` from `displayName` (slugify + numeric
+    dedupe within the season) and insert the competitor with `userId`.
+- `formTeam({ seasonId, name, userId }) → { teamId, token }`
+  - Find caller's competitor in the season; error if none.
+  - Reject if the competitor is already on a team this season (one team per
+    competitor per season — enforced in logic; no DB unique exists).
+  - Create the team (slug = slugify(name), deduped), add caller as
+    `teamMembers` with `role = "captain"`, mint a `team_invites` token.
+- `joinTeamViaInvite({ token, userId, displayName }) → { teamId, seasonId }`
+  - Validate token exists and `revokedAt` is null.
+  - Resolve team + season. Ensure a competitor exists for `userId` (create like
+    `selfRegisterCompetitor` if missing).
+  - Reject if competitor already on a team this season, or if the team already
+    has `bracket.teamSize` members. (Team size: read the relevant team bracket's
+    `teamSize`; see open question below if a season can host multiple brackets.)
+  - Add as `teamMembers` (`role = "member"`); idempotent if already a member.
+- `renameTeam({ teamId, name, userId }) → { ok }` — captain only.
+- `createTeamInvite({ teamId, userId }) → { token }` — regenerate; captain/member only.
+- `revokeTeamInvite({ token, userId }) → { ok }` — set `revokedAt`.
+- `leaveTeam({ teamId, userId }) → { ok }` — remove caller's membership;
+  if captain leaves, hand off captaincy or block (see open questions).
+
+Add a shared `slugify`/dedupe helper used by competitor and team creation.
+
+#### Read-model (`read-model/schema.ts` + `read-model/main.ts`)
+
+- `main.ts`: build a Yoga context from request headers, reading
+  `X-Gateway-User-Id` (and name/email if useful) into `ctx.user`.
+- New JWT/header-gated field, e.g. extend the `Show` entity:
+  `myParticipation(showId via entity): MyParticipation` returning, for the live
+  season's open brackets, whether the caller is a registered competitor and
+  which team they are on (and `bracketKind`). Returns null/empty when
+  unauthenticated. Used by the website Apply tab to render "✓ Registered" and
+  the correct manage-link.
+
+### B. `rawkode.academy/website` (Apply tab)
+
+- **Bind `BRACKETS_WRITE`** in `wrangler.jsonc` (currently absent → the existing
+  apply form is dead). Point at `platform-brackets-write-model`. Update the
+  endpoint's binding type.
+- **`queryShowsApi`** (`src/lib/shows/client.ts`): accept optional request
+  cookies and forward them as the `Cookie` header to the gateway when present,
+  so authenticated reads (`myParticipation`) resolve the user. Anonymous reads
+  unchanged.
+- **`Apply.astro`** (`src/lib/shows/plugins/bracket/pages/Apply.astro`): remove
+  all input fields.
+  - Signed-out → "Sign in to apply" (link to the website OIDC sign-in with
+    `returnTo` back to the apply tab).
+  - Signed-in → one card per open bracket: season name, **Team**/**Individual**
+    badge, **Apply** button (POST). If `myParticipation` shows already
+    registered → "✓ Registered" plus a CTA to `https://klustered.dev/me`
+    ("Set up your team" for team kind, "Manage your profile" for solo).
+  - Editorial design system (see `website/CLAUDE.md`): hairline cards, mono
+    labels, no shadows/blur. No em-dashes in copy.
+- **`apply` endpoint** (`src/lib/shows/plugins/bracket/endpoints.ts`): read the
+  user from the session; if absent return 401/redirect to sign-in. Call
+  `BRACKETS_WRITE.selfRegisterCompetitor({ bracketId, userId, displayName })`.
+  Redirect back to the apply tab (which then shows registered state + the
+  klustered.dev link). Drop the old `teamName`/`email`/`message` fields.
+- The plugin's `load(ctx)` for Apply must pass `ctx.request` cookies into
+  `queryShowsApi` so the participation read is authenticated.
+
+### C. `klustered.dev`
+
+- **Admin bracket create form** (`src/pages/admin/brackets.astro` +
+  `src/pages/api/admin/brackets.ts`): add a `kind` selector (Individual / Team)
+  and, shown when Team, a `teamSize` input (default 2). Pass both to
+  `bracketsWrite(env).createBracket({ ..., kind, teamSize })`.
+- **`/me/team`** (new page + nav entry in `src/lib/nav.ts`):
+  - Determine the competitor's live-season bracket kind (direct D1 read — the
+    established klustered.dev pattern).
+  - Team edition, no team yet → "Name your team" form → POST → `formTeam` →
+    redirect to the team view.
+  - Team edition, on a team → show team name (rename if captain), roster, the
+    copyable invite link, and captain controls (regenerate / revoke link).
+  - Solo edition → "You're registered for {season} (Individual)" only.
+- **`/join/[token]`** (new page + API):
+  - Add `/join` to the auth-required prefixes in `src/middleware.ts` so
+    unauthenticated visitors are bounced to sign-in with `returnTo`.
+  - GET shows "Join {team} for {season}" with a confirm button; confirm POSTs to
+    `joinTeamViaInvite` with the logged-in user, then redirects to `/me/team`.
+  - Friendly errors for invalid/revoked token, already-on-a-team, team-full.
+- **`/me/profile`** (`src/pages/me/profile.astro`): fix the "edit in
+  `content/people/{slug}.mdx`" note so it does not show for self-applied
+  competitors whose `personSlug` has no content profile (the `getPerson` lookup
+  is already best-effort; the copy is the only issue).
+- **Mirror schema** in `src/db/schema.ts`: add `team_invites` and
+  `brackets.teamSize` so klustered.dev's direct D1 reads compile. (klustered.dev
+  reads D1 directly; those reads stay as-is and are not migrated to GraphQL in
+  this change.)
+
+## Data flow
+
+```
+Apply (website)
+  user → Apply button → /api/shows/klustered/apply
+    → BRACKETS_WRITE.selfRegisterCompetitor({ bracketId, userId, displayName })
+    → competitor (idempotent) → redirect back
+  Apply tab read → queryShowsApi(myParticipation, cookies) → gateway validates
+    Better Auth cookie via IDENTITY → forwards X-Gateway-User-Id → brackets
+    subgraph → "✓ Registered" + link to klustered.dev/me
+
+Form team (klustered.dev)
+  captain → /me/team → formTeam → team + captain member + invite token
+    → copyable klustered.dev/join/{token}
+
+Join (klustered.dev)
+  colleague → /join/{token} → sign in → joinTeamViaInvite
+    → competitor (if missing) + teamMember → /me/team
+
+Build bracket live (admin, out of scope)
+  admin draws formed teams/competitors into bracketEntries + matches on stream
+```
+
+## Deploy order (service-binding rule)
+
+1. `platform/brackets` — schema migration (`team_invites`, `brackets.teamSize`),
+   new write commands, read-model participation field. Deploy + apply D1
+   migrations first.
+2. `rawkode.academy/website` — add `BRACKETS_WRITE` binding, Apply rewrite,
+   cookie-forwarding read.
+3. `klustered.dev` — admin `kind`/`teamSize`, `/me/team`, `/join/{token}`,
+   schema mirror.
+
+Website PR CI preview-deploys and validates bindings, so the brackets service
+must be live before the website binding lands.
+
+## Testing
+
+- **brackets write-model**: unit/integration tests for `selfRegisterCompetitor`
+  (idempotency, slug dedupe), `formTeam` (one-team-per-season, captain role),
+  `joinTeamViaInvite` (token valid/revoked, team-full cap, already-on-team),
+  `renameTeam`/`revokeTeamInvite` ownership. Follow the existing `tests/` setup.
+- **brackets read-model**: `myParticipation` returns correctly for
+  authenticated vs anonymous (header present/absent), reflects team membership.
+- **website**: Apply tab renders signed-out / signed-in / registered states;
+  endpoint calls `selfRegisterCompetitor` with session identity; anonymous read
+  path unaffected.
+- **klustered.dev**: bracket creation persists `kind` + `teamSize`; `/me/team`
+  create + invite + roster; `/join/{token}` happy path and rejections.
+
+## Human action required
+
+- Confirm `platform-brackets-write-model` is deployed before merging the website
+  `BRACKETS_WRITE` binding (it already is, since klustered.dev binds it).
+- Apply the brackets D1 migration to the `platform-brackets` database.
+- No new secrets/vars expected (admin allowlist `KLUSTERED_ADMIN_IDS` already
+  exists; identity/session bindings already exist on both apps).
+
+## Open questions (resolve during planning)
+
+1. **Multiple brackets per season.** Apply targets a bracket and competitors are
+   season-scoped. If a live season ever has both a solo and a team bracket, how
+   is team-size / kind resolved for a competitor on `/me/team`? Current
+   assumption: one bracket per live season. Confirm we can rely on that, or pick
+   a rule (e.g., team features key off the season's team bracket).
+2. **Captain leaving.** If a captain `leaveTeam`s, do we promote the oldest
+   member, block until reassigned, or dissolve the team?
+3. **Where `myParticipation` hangs.** As a field on the federated `Show` entity
+   vs a root query. Prefer extending `Show` to match the existing read shape.
+4. **Invite link reuse vs per-invite.** One reusable link per team (revocable)
+   is assumed; confirm we don't need single-use tokens.
+
+## Out of scope
+
+- Building the live bracket (`bracketEntries`, matches) — the admin's on-stream
+  flow, unchanged here.
+- Migrating klustered.dev's direct D1 reads to GraphQL.
+- Profile editing beyond team name (display name / bio edits not requested).
+- The legacy `registrations` table and its admin approval UI (the new flow
+  bypasses it; left intact, not removed in this change).

--- a/env.cue
+++ b/env.cue
@@ -80,6 +80,14 @@ ci: provider: github: {
 	}
 }
 
+vcs: "cuenv-skills": {
+	url:       "https://github.com/cuenv/cuenv.git"
+	reference: "main"
+	vendor:    false
+	subdir:    ".agents/skills"
+	path:      ".agents/skills"
+}
+
 env: {
 	environment: production: {
 		CLOUDFLARE_ACCOUNT_ID: "0aeb879de8e3cdde5fb3d413025222ce"

--- a/projects/klustered.dev/src/db/schema.ts
+++ b/projects/klustered.dev/src/db/schema.ts
@@ -59,37 +59,10 @@ export const competitors = sqliteTable(
 			t.seasonId,
 			t.personSlug,
 		),
+		uniqueIndex("competitors_season_user_unique")
+			.on(t.seasonId, t.userId)
+			.where(sql`${t.userId} is not null`),
 	],
-);
-
-export const teams = sqliteTable(
-	"teams",
-	{
-		id: text("id").primaryKey(),
-		seasonId: text("season_id")
-			.notNull()
-			.references(() => seasons.id, { onDelete: "cascade" }),
-		name: text("name").notNull(),
-		slug: text("slug").notNull(),
-		createdAt: createdAt(),
-		updatedAt: updatedAt(),
-	},
-	(t) => [uniqueIndex("teams_season_slug_unique").on(t.seasonId, t.slug)],
-);
-
-export const teamMembers = sqliteTable(
-	"team_members",
-	{
-		teamId: text("team_id")
-			.notNull()
-			.references(() => teams.id, { onDelete: "cascade" }),
-		competitorId: text("competitor_id")
-			.notNull()
-			.references(() => competitors.id, { onDelete: "cascade" }),
-		role: text("role"),
-		createdAt: createdAt(),
-	},
-	(t) => [primaryKey({ columns: [t.teamId, t.competitorId] })],
 );
 
 export const scenarios = sqliteTable("scenarios", {
@@ -129,12 +102,88 @@ export const brackets = sqliteTable(
 			mode: "timestamp_ms",
 		}),
 		maxEntries: integer("max_entries").notNull().default(16),
+		teamSize: integer("team_size").notNull().default(2),
 		cadenceDays: integer("cadence_days").notNull().default(7),
 		createdAt: createdAt(),
 		updatedAt: updatedAt(),
 	},
 	(t) => [uniqueIndex("brackets_season_slug_unique").on(t.seasonId, t.slug)],
 );
+
+export const bracketApplications = sqliteTable(
+	"bracket_applications",
+	{
+		id: text("id").primaryKey(),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		competitorId: text("competitor_id")
+			.notNull()
+			.references(() => competitors.id, { onDelete: "cascade" }),
+		createdAt: createdAt(),
+	},
+	(t) => [
+		uniqueIndex("bracket_applications_bracket_competitor_unique").on(
+			t.bracketId,
+			t.competitorId,
+		),
+	],
+);
+
+export const teams = sqliteTable(
+	"teams",
+	{
+		id: text("id").primaryKey(),
+		seasonId: text("season_id")
+			.notNull()
+			.references(() => seasons.id, { onDelete: "cascade" }),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		slug: text("slug").notNull(),
+		createdAt: createdAt(),
+		updatedAt: updatedAt(),
+	},
+	(t) => [uniqueIndex("teams_bracket_slug_unique").on(t.bracketId, t.slug)],
+);
+
+export const teamMembers = sqliteTable(
+	"team_members",
+	{
+		teamId: text("team_id")
+			.notNull()
+			.references(() => teams.id, { onDelete: "cascade" }),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		competitorId: text("competitor_id")
+			.notNull()
+			.references(() => competitors.id, { onDelete: "cascade" }),
+		role: text("role"),
+		createdAt: createdAt(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.teamId, t.competitorId] }),
+		uniqueIndex("team_members_bracket_competitor_unique").on(
+			t.bracketId,
+			t.competitorId,
+		),
+	],
+);
+
+export const teamInvites = sqliteTable("team_invites", {
+	token: text("token").primaryKey(),
+	teamId: text("team_id")
+		.notNull()
+		.references(() => teams.id, { onDelete: "cascade" }),
+	bracketId: text("bracket_id")
+		.notNull()
+		.references(() => brackets.id, { onDelete: "cascade" }),
+	createdByUserId: text("created_by_user_id").notNull(),
+	createdAt: createdAt(),
+	revokedAt: integer("revoked_at", { mode: "timestamp_ms" }),
+});
 
 export const bracketBreaks = sqliteTable("bracket_breaks", {
 	id: text("id").primaryKey(),

--- a/projects/klustered.dev/src/lib/brackets-write.ts
+++ b/projects/klustered.dev/src/lib/brackets-write.ts
@@ -5,6 +5,35 @@
 export const SHOW_ID = "klustered";
 
 export interface BracketsWrite {
+	selfRegisterCompetitor(input: {
+		bracketId: string;
+		userId: string;
+		displayName: string;
+	}): Promise<{ competitorId: string; seasonId: string; bracketKind: string }>;
+	formTeam(input: {
+		bracketId: string;
+		name: string;
+		userId: string;
+	}): Promise<{ teamId: string; token: string }>;
+	joinTeamViaInvite(input: {
+		token: string;
+		userId: string;
+		displayName: string;
+	}): Promise<{ teamId: string; seasonId: string }>;
+	renameTeam(input: {
+		teamId: string;
+		name: string;
+		userId: string;
+	}): Promise<{ ok: true }>;
+	createTeamInvite(input: {
+		teamId: string;
+		userId: string;
+	}): Promise<{ token: string }>;
+	revokeTeamInvite(input: {
+		token: string;
+		userId: string;
+	}): Promise<{ ok: true }>;
+	leaveTeam(input: { teamId: string; userId: string }): Promise<{ ok: true }>;
 	submitRegistration(input: {
 		showId: string;
 		bracketId: string;
@@ -54,6 +83,7 @@ export interface BracketsWrite {
 		startsAt?: number | null;
 		registrationClosesAt?: number | null;
 		maxEntries?: number;
+		teamSize?: number;
 		cadenceDays?: number;
 	}): Promise<{ id: string }>;
 	deleteBracket(input: { id: string }): Promise<{ ok: true }>;
@@ -82,7 +112,7 @@ export interface BracketsWrite {
 	}): Promise<{ id: string }>;
 	deleteCompetitor(input: { id: string }): Promise<{ ok: true }>;
 	createTeam(input: {
-		seasonId: string;
+		bracketId: string;
 		slug: string;
 		name: string;
 	}): Promise<{ id: string }>;

--- a/projects/klustered.dev/src/lib/competitor.ts
+++ b/projects/klustered.dev/src/lib/competitor.ts
@@ -1,4 +1,4 @@
-import { eq, or, inArray, asc } from "drizzle-orm";
+import { asc, eq, inArray, or, type SQL } from "drizzle-orm";
 import { schema, type Database } from "@/db/client";
 
 export async function getCompetitorForUser(db: Database, userId: string) {
@@ -17,18 +17,37 @@ export async function getMyMatches(db: Database, competitorId: string) {
 			.where(eq(schema.teamMembers.competitorId, competitorId))
 			.all()
 	).map((r) => r.teamId);
+	const entryIds = (
+		await db
+			.select({ entryId: schema.bracketEntries.id })
+			.from(schema.bracketEntries)
+			.where(eq(schema.bracketEntries.competitorId, competitorId))
+			.all()
+	).map((r) => r.entryId);
 
-	if (teamIds.length === 0) return [];
+	if (teamIds.length === 0 && entryIds.length === 0) return [];
+
+	const matchFilters: SQL[] = [];
+	if (teamIds.length > 0) {
+		matchFilters.push(
+			inArray(schema.matches.teamAId, teamIds),
+			inArray(schema.matches.teamBId, teamIds),
+		);
+	}
+	if (entryIds.length > 0) {
+		matchFilters.push(
+			inArray(schema.matches.entryAId, entryIds),
+			inArray(schema.matches.entryBId, entryIds),
+		);
+	}
+	const matchFilter =
+		matchFilters.length === 1 ? matchFilters[0] : or(...matchFilters);
+	if (!matchFilter) return [];
 
 	return await db
 		.select()
 		.from(schema.matches)
-		.where(
-			or(
-				inArray(schema.matches.teamAId, teamIds),
-				inArray(schema.matches.teamBId, teamIds),
-			),
-		)
+		.where(matchFilter)
 		.orderBy(asc(schema.matches.scheduledAt))
 		.all();
 }

--- a/projects/klustered.dev/src/lib/nav.ts
+++ b/projects/klustered.dev/src/lib/nav.ts
@@ -11,6 +11,7 @@ export const ADMIN_NAV = [
 
 export const COMPETITOR_NAV = [
 	{ href: "/me", label: "Overview" },
+	{ href: "/me/team", label: "Team" },
 	{ href: "/me/matches", label: "My matches" },
 	{ href: "/me/profile", label: "Profile" },
 ] as const;

--- a/projects/klustered.dev/src/middleware.ts
+++ b/projects/klustered.dev/src/middleware.ts
@@ -27,6 +27,7 @@ declare global {
 const PUBLIC_PREFIXES = ["/api/auth/"];
 const ADMIN_PREFIX = "/admin";
 const COMPETITOR_PREFIX = "/me";
+const JOIN_PREFIX = "/join";
 
 // Admins are an explicit allowlist of id.rawkode.academy user ids (OIDC subs),
 // set via the KLUSTERED_ADMIN_IDS var. Everyone else who authenticates is a
@@ -66,7 +67,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	}
 
 	const requiresAuth =
-		pathname.startsWith(ADMIN_PREFIX) || pathname.startsWith(COMPETITOR_PREFIX);
+		pathname.startsWith(ADMIN_PREFIX) ||
+		pathname.startsWith(COMPETITOR_PREFIX) ||
+		pathname.startsWith(JOIN_PREFIX);
 
 	if (requiresAuth && !context.locals.user) {
 		return context.redirect(getSignInUrl(pathname), 302);

--- a/projects/klustered.dev/src/pages/admin/brackets.astro
+++ b/projects/klustered.dev/src/pages/admin/brackets.astro
@@ -12,6 +12,8 @@ const brackets = await db
 		id: schema.brackets.id,
 		slug: schema.brackets.slug,
 		name: schema.brackets.name,
+		kind: schema.brackets.kind,
+		teamSize: schema.brackets.teamSize,
 		status: schema.brackets.status,
 		seasonName: schema.seasons.name,
 	})
@@ -40,7 +42,7 @@ const seasons = await db
 				<form
 					method="POST"
 					action="/api/admin/brackets"
-					class="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+					class="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-6"
 				>
 					<label class="flex flex-col gap-1">
 						<span class="text-xs text-slate-400">Season</span>
@@ -71,6 +73,27 @@ const seasons = await db
 							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
 						/>
 					</label>
+					<label class="flex flex-col gap-1">
+						<span class="text-xs text-slate-400">Kind</span>
+						<select
+							name="kind"
+							required
+							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+						>
+							<option value="solo">Individual</option>
+							<option value="team">Team</option>
+						</select>
+					</label>
+					<label class="flex flex-col gap-1">
+						<span class="text-xs text-slate-400">Team size</span>
+						<input
+							type="number"
+							name="teamSize"
+							min="2"
+							value="2"
+							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+						/>
+					</label>
 					<div class="flex items-end">
 						<button
 							class="rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400"
@@ -90,6 +113,7 @@ const seasons = await db
 					<th class="px-6 py-3">Name</th>
 					<th class="px-6 py-3">Slug</th>
 					<th class="px-6 py-3">Season</th>
+					<th class="px-6 py-3">Kind</th>
 					<th class="px-6 py-3">Status</th>
 					<th class="px-6 py-3 text-right">Actions</th>
 				</tr>
@@ -98,7 +122,7 @@ const seasons = await db
 				{
 					brackets.length === 0 ? (
 						<tr>
-							<td colspan="5" class="px-6 py-6 text-center text-sm text-slate-500">
+							<td colspan="6" class="px-6 py-6 text-center text-sm text-slate-500">
 								No brackets yet.
 							</td>
 						</tr>
@@ -112,6 +136,9 @@ const seasons = await db
 								</td>
 								<td class="px-6 py-3 font-mono text-xs text-slate-400">{b.slug}</td>
 								<td class="px-6 py-3 text-slate-400">{b.seasonName}</td>
+								<td class="px-6 py-3 text-slate-300">
+									{b.kind === "team" ? `Team (${b.teamSize})` : "Individual"}
+								</td>
 								<td class="px-6 py-3">
 									<span class="rounded-full bg-slate-800 px-2 py-0.5 text-xs text-slate-300 capitalize">
 										{b.status}

--- a/projects/klustered.dev/src/pages/admin/brackets/[id].astro
+++ b/projects/klustered.dev/src/pages/admin/brackets/[id].astro
@@ -14,6 +14,8 @@ const bracket = await db
 		slug: schema.brackets.slug,
 		name: schema.brackets.name,
 		status: schema.brackets.status,
+		kind: schema.brackets.kind,
+		teamSize: schema.brackets.teamSize,
 		seasonId: schema.brackets.seasonId,
 		seasonName: schema.seasons.name,
 	})
@@ -35,7 +37,10 @@ const matches = await db
 		scheduledAt: schema.matches.scheduledAt,
 		teamAId: schema.matches.teamAId,
 		teamBId: schema.matches.teamBId,
+		entryAId: schema.matches.entryAId,
+		entryBId: schema.matches.entryBId,
 		winnerTeamId: schema.matches.winnerTeamId,
+		winnerEntryId: schema.matches.winnerEntryId,
 	})
 	.from(schema.matches)
 	.where(eq(schema.matches.bracketId, bracketId))
@@ -45,10 +50,19 @@ const matches = await db
 const teams = await db
 	.select({ id: schema.teams.id, name: schema.teams.name })
 	.from(schema.teams)
-	.where(eq(schema.teams.seasonId, bracket.seasonId))
+	.where(eq(schema.teams.bracketId, bracket.id))
 	.all();
 
 const teamMap = Object.fromEntries(teams.map((t) => [t.id, t.name]));
+
+const entries = await db
+	.select({ id: schema.bracketEntries.id, displayName: schema.bracketEntries.displayName })
+	.from(schema.bracketEntries)
+	.where(eq(schema.bracketEntries.bracketId, bracket.id))
+	.orderBy(asc(schema.bracketEntries.seed))
+	.all();
+
+const entryMap = Object.fromEntries(entries.map((e) => [e.id, e.displayName]));
 
 const rounds = matches.reduce<Record<number, typeof matches>>((acc, m) => {
 	(acc[m.roundNumber] ??= []).push(m);
@@ -58,8 +72,11 @@ const roundNumbers = Object.keys(rounds)
 	.map((n) => Number(n))
 	.sort((a, b) => a - b);
 
-const teamCount = teams.length;
-const canGenerate = matches.length === 0 && teamCount >= 2;
+const entryCount = entries.length;
+const canGenerate = matches.length === 0 && entryCount >= 2;
+
+const sideName = (teamId: string | null, entryId: string | null): string =>
+	(teamId ? teamMap[teamId] : null) ?? (entryId ? entryMap[entryId] : null) ?? "TBD";
 
 function formatScheduled(value: Date | null): string {
 	if (!value) return "TBD";
@@ -76,7 +93,8 @@ function formatScheduled(value: Date | null): string {
 	<section class="flex flex-wrap items-center gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 px-6 py-4 text-sm">
 		<span class="text-slate-300">Season: <strong>{bracket.seasonName}</strong></span>
 		<span class="text-slate-300">Status: <strong class="capitalize">{bracket.status}</strong></span>
-		<span class="text-slate-300">Teams in season: <strong>{teamCount}</strong></span>
+		<span class="text-slate-300">Kind: <strong>{bracket.kind === "team" ? `Team (${bracket.teamSize})` : "Individual"}</strong></span>
+		<span class="text-slate-300">Entries in bracket: <strong>{entryCount}</strong></span>
 		{
 			canGenerate && (
 				<form
@@ -95,7 +113,7 @@ function formatScheduled(value: Date | null): string {
 	{
 		roundNumbers.length === 0 ? (
 			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-400">
-				No matches yet. {canGenerate ? "Click Generate round 1 to seed the bracket from this season's teams." : "Add at least two teams to this season before generating round 1."}
+				No matches yet. {canGenerate ? "Click Generate round 1 to schedule matches from existing bracket entries." : "Seed at least two bracket entries before generating round 1."}
 			</section>
 		) : (
 			<section class="flex flex-col gap-6">
@@ -109,12 +127,12 @@ function formatScheduled(value: Date | null): string {
 								<li class="rounded-lg border border-slate-800 bg-slate-950/40 px-4 py-3 text-sm">
 									<div class="flex flex-wrap items-center justify-between gap-3">
 										<div class="flex items-center gap-2">
-											<span class={`font-medium ${m.winnerTeamId === m.teamAId ? "text-emerald-300" : "text-slate-100"}`}>
-												{m.teamAId ? teamMap[m.teamAId] ?? m.teamAId : "TBD"}
+											<span class={`font-medium ${(m.winnerTeamId && m.winnerTeamId === m.teamAId) || (m.winnerEntryId && m.winnerEntryId === m.entryAId) ? "text-emerald-300" : "text-slate-100"}`}>
+												{sideName(m.teamAId, m.entryAId)}
 											</span>
 											<span class="text-slate-500">vs</span>
-											<span class={`font-medium ${m.winnerTeamId === m.teamBId ? "text-emerald-300" : "text-slate-100"}`}>
-												{m.teamBId ? teamMap[m.teamBId] ?? m.teamBId : "TBD"}
+											<span class={`font-medium ${(m.winnerTeamId && m.winnerTeamId === m.teamBId) || (m.winnerEntryId && m.winnerEntryId === m.entryBId) ? "text-emerald-300" : "text-slate-100"}`}>
+												{sideName(m.teamBId, m.entryBId)}
 											</span>
 										</div>
 										<div class="flex items-center gap-3 text-xs text-slate-400">

--- a/projects/klustered.dev/src/pages/admin/matches/[id].astro
+++ b/projects/klustered.dev/src/pages/admin/matches/[id].astro
@@ -27,7 +27,7 @@ const bracket = await db
 const teams = await db
 	.select({ id: schema.teams.id, name: schema.teams.name })
 	.from(schema.teams)
-	.where(bracket ? eq(schema.teams.seasonId, bracket.seasonId) : eq(schema.teams.id, "_"))
+	.where(bracket ? eq(schema.teams.bracketId, bracket.id) : eq(schema.teams.id, "_"))
 	.orderBy(asc(schema.teams.name))
 	.all();
 

--- a/projects/klustered.dev/src/pages/admin/matches/[id]/live.astro
+++ b/projects/klustered.dev/src/pages/admin/matches/[id]/live.astro
@@ -18,6 +18,7 @@ if (!match) return Astro.redirect("/admin/matches", 303);
 const teams = await db
 	.select({ id: schema.teams.id, name: schema.teams.name })
 	.from(schema.teams)
+	.where(eq(schema.teams.bracketId, match.bracketId))
 	.orderBy(asc(schema.teams.name))
 	.all();
 const teamName = Object.fromEntries(teams.map((t) => [t.id, t.name]));
@@ -175,4 +176,3 @@ function formatElapsed(ms: number): string {
 		}
 	})();
 </script>
-

--- a/projects/klustered.dev/src/pages/admin/teams.astro
+++ b/projects/klustered.dev/src/pages/admin/teams.astro
@@ -1,6 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import PortalLayout from "@/layouts/PortalLayout.astro";
 import { getBracketsDb, schema } from "@/db/client";
 import { SHOW_ID } from "@/lib/brackets-write";
@@ -14,10 +14,13 @@ const teams = await db
 		slug: schema.teams.slug,
 		name: schema.teams.name,
 		seasonId: schema.teams.seasonId,
+		bracketId: schema.teams.bracketId,
 		seasonName: schema.seasons.name,
+		bracketName: schema.brackets.name,
 	})
 	.from(schema.teams)
 	.leftJoin(schema.seasons, eq(schema.teams.seasonId, schema.seasons.id))
+	.leftJoin(schema.brackets, eq(schema.teams.bracketId, schema.brackets.id))
 	.orderBy(desc(schema.teams.createdAt))
 	.all();
 
@@ -34,11 +37,16 @@ const countByTeam = memberCounts.reduce<Record<string, number>>((acc, row) => {
 	return acc;
 }, {});
 
-const seasons = await db
-	.select({ id: schema.seasons.id, name: schema.seasons.name })
-	.from(schema.seasons)
-	.where(eq(schema.seasons.showId, SHOW_ID))
-	.orderBy(desc(schema.seasons.createdAt))
+const teamBrackets = await db
+	.select({
+		id: schema.brackets.id,
+		name: schema.brackets.name,
+		seasonName: schema.seasons.name,
+	})
+	.from(schema.brackets)
+	.innerJoin(schema.seasons, eq(schema.brackets.seasonId, schema.seasons.id))
+	.where(and(eq(schema.seasons.showId, SHOW_ID), eq(schema.brackets.kind, "team")))
+	.orderBy(desc(schema.brackets.createdAt))
 	.all();
 ---
 
@@ -48,8 +56,8 @@ const seasons = await db
 			New team
 		</h2>
 		{
-			seasons.length === 0 ? (
-				<p class="mt-3 text-sm text-slate-400">Create a season first.</p>
+			teamBrackets.length === 0 ? (
+				<p class="mt-3 text-sm text-slate-400">Create a Team bracket first.</p>
 			) : (
 				<form
 					method="POST"
@@ -57,14 +65,14 @@ const seasons = await db
 					class="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
 				>
 					<label class="flex flex-col gap-1">
-						<span class="text-xs text-slate-400">Season</span>
+						<span class="text-xs text-slate-400">Team bracket</span>
 						<select
-							name="seasonId"
+							name="bracketId"
 							required
 							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
 						>
-							{seasons.map((s) => (
-								<option value={s.id}>{s.name}</option>
+							{teamBrackets.map((b) => (
+								<option value={b.id}>{b.seasonName} / {b.name}</option>
 							))}
 						</select>
 					</label>
@@ -104,6 +112,7 @@ const seasons = await db
 					<th class="px-6 py-3">Name</th>
 					<th class="px-6 py-3">Slug</th>
 					<th class="px-6 py-3">Season</th>
+					<th class="px-6 py-3">Bracket</th>
 					<th class="px-6 py-3">Members</th>
 					<th class="px-6 py-3 text-right">Actions</th>
 				</tr>
@@ -112,7 +121,7 @@ const seasons = await db
 				{
 					teams.length === 0 ? (
 						<tr>
-							<td colspan="5" class="px-6 py-6 text-center text-sm text-slate-500">
+							<td colspan="6" class="px-6 py-6 text-center text-sm text-slate-500">
 								No teams yet.
 							</td>
 						</tr>
@@ -126,6 +135,7 @@ const seasons = await db
 								</td>
 								<td class="px-6 py-3 font-mono text-xs text-slate-400">{t.slug}</td>
 								<td class="px-6 py-3 text-slate-400">{t.seasonName ?? t.seasonId}</td>
+								<td class="px-6 py-3 text-slate-400">{t.bracketName ?? t.bracketId}</td>
 								<td class="px-6 py-3 text-slate-300">{countByTeam[t.id] ?? 0}</td>
 								<td class="px-6 py-3 text-right">
 									<form method="POST" action={`/api/admin/teams/${t.id}/delete`}>

--- a/projects/klustered.dev/src/pages/admin/teams/[id].astro
+++ b/projects/klustered.dev/src/pages/admin/teams/[id].astro
@@ -34,7 +34,12 @@ const members = await db
 	.where(eq(schema.teamMembers.teamId, teamId))
 	.all();
 
-const memberIds = new Set(members.map((m) => m.competitorId));
+const bracketMemberships = await db
+	.select({ competitorId: schema.teamMembers.competitorId })
+	.from(schema.teamMembers)
+	.where(eq(schema.teamMembers.bracketId, team.bracketId))
+	.all();
+const bracketMemberIds = new Set(bracketMemberships.map((m) => m.competitorId));
 
 const seasonCompetitors = await db
 	.select({
@@ -47,7 +52,7 @@ const seasonCompetitors = await db
 	.orderBy(asc(schema.competitors.displayName))
 	.all();
 
-const eligible = seasonCompetitors.filter((c) => !memberIds.has(c.id));
+const eligible = seasonCompetitors.filter((c) => !bracketMemberIds.has(c.id));
 ---
 
 <PortalLayout title={team.name} section="admin" nav={[...ADMIN_NAV]}>

--- a/projects/klustered.dev/src/pages/api/admin/brackets.ts
+++ b/projects/klustered.dev/src/pages/api/admin/brackets.ts
@@ -13,12 +13,19 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 	const seasonId = String(form.get("seasonId") ?? "").trim();
 	const slug = String(form.get("slug") ?? "").trim();
 	const name = String(form.get("name") ?? "").trim();
+	const kindRaw = String(form.get("kind") ?? "team").trim();
+	const kind = kindRaw === "solo" ? "solo" : "team";
+	const teamSizeRaw = Number.parseInt(
+		String(form.get("teamSize") ?? "2").trim(),
+		10,
+	);
+	const teamSize = Number.isFinite(teamSizeRaw) && teamSizeRaw > 1 ? teamSizeRaw : 2;
 
 	if (!seasonId || !slug || !name) {
 		return new Response("seasonId, slug, name required", { status: 400 });
 	}
 
-	await bracketsWrite(env).createBracket({ seasonId, slug, name });
+	await bracketsWrite(env).createBracket({ seasonId, slug, name, kind, teamSize });
 
 	return redirect("/admin/brackets", 303);
 };

--- a/projects/klustered.dev/src/pages/api/admin/teams.ts
+++ b/projects/klustered.dev/src/pages/api/admin/teams.ts
@@ -10,15 +10,15 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 	}
 
 	const form = await request.formData();
-	const seasonId = String(form.get("seasonId") ?? "").trim();
+	const bracketId = String(form.get("bracketId") ?? "").trim();
 	const slug = String(form.get("slug") ?? "").trim();
 	const name = String(form.get("name") ?? "").trim();
 
-	if (!seasonId || !slug || !name) {
-		return new Response("seasonId, slug, name required", { status: 400 });
+	if (!bracketId || !slug || !name) {
+		return new Response("bracketId, slug, name required", { status: 400 });
 	}
 
-	await bracketsWrite(env).createTeam({ seasonId, slug, name });
+	await bracketsWrite(env).createTeam({ bracketId, slug, name });
 
 	return redirect("/admin/teams", 303);
 };

--- a/projects/klustered.dev/src/pages/api/join/[token].ts
+++ b/projects/klustered.dev/src/pages/api/join/[token].ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { bracketsWrite } from "@/lib/brackets-write";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+	const user = locals.user;
+	if (!user) return new Response("Unauthorized", { status: 401 });
+
+	const token = params.token;
+	if (!token) return new Response("missing token", { status: 400 });
+
+	const displayName = user.name?.trim() || user.email?.split("@")[0]?.trim() || user.id;
+
+	try {
+		await bracketsWrite(env).joinTeamViaInvite({
+			token,
+			userId: user.id,
+			displayName,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "could not join team";
+		return new Response(message, { status: 400 });
+	}
+
+	return redirect("/me/team", 303);
+};

--- a/projects/klustered.dev/src/pages/api/me/team.ts
+++ b/projects/klustered.dev/src/pages/api/me/team.ts
@@ -1,0 +1,63 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { bracketsWrite } from "@/lib/brackets-write";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+	const user = locals.user;
+	if (!user) return new Response("Unauthorized", { status: 401 });
+
+	const form = await request.formData();
+	const value = (name: string) => String(form.get(name) ?? "").trim();
+	const action = value("action");
+	const write = bracketsWrite(env);
+
+	try {
+		switch (action) {
+			case "create": {
+				const bracketId = value("bracketId");
+				const name = value("name");
+				if (!bracketId || !name) {
+					return new Response("bracketId and name required", { status: 400 });
+				}
+				await write.formTeam({ bracketId, name, userId: user.id });
+				break;
+			}
+			case "rename": {
+				const teamId = value("teamId");
+				const name = value("name");
+				if (!teamId || !name) {
+					return new Response("teamId and name required", { status: 400 });
+				}
+				await write.renameTeam({ teamId, name, userId: user.id });
+				break;
+			}
+			case "invite": {
+				const teamId = value("teamId");
+				if (!teamId) return new Response("teamId required", { status: 400 });
+				await write.createTeamInvite({ teamId, userId: user.id });
+				break;
+			}
+			case "revoke": {
+				const token = value("token");
+				if (!token) return new Response("token required", { status: 400 });
+				await write.revokeTeamInvite({ token, userId: user.id });
+				break;
+			}
+			case "leave": {
+				const teamId = value("teamId");
+				if (!teamId) return new Response("teamId required", { status: 400 });
+				await write.leaveTeam({ teamId, userId: user.id });
+				break;
+			}
+			default:
+				return new Response("invalid action", { status: 400 });
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "team update failed";
+		return new Response(message, { status: 400 });
+	}
+
+	return redirect("/me/team", 303);
+};

--- a/projects/klustered.dev/src/pages/join/[token].astro
+++ b/projects/klustered.dev/src/pages/join/[token].astro
@@ -1,0 +1,64 @@
+---
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import PortalLayout from "@/layouts/PortalLayout.astro";
+import { getBracketsDb, schema } from "@/db/client";
+import { COMPETITOR_NAV } from "@/lib/nav";
+
+const token = Astro.params.token!;
+const db = getBracketsDb(env.BRACKETS);
+
+const invite = await db
+	.select({
+		token: schema.teamInvites.token,
+		revokedAt: schema.teamInvites.revokedAt,
+		teamName: schema.teams.name,
+		seasonName: schema.seasons.name,
+		bracketName: schema.brackets.name,
+		bracketStatus: schema.brackets.status,
+		registrationClosesAt: schema.brackets.registrationClosesAt,
+	})
+	.from(schema.teamInvites)
+	.innerJoin(schema.teams, eq(schema.teamInvites.teamId, schema.teams.id))
+	.innerJoin(schema.brackets, eq(schema.teamInvites.bracketId, schema.brackets.id))
+	.innerJoin(schema.seasons, eq(schema.brackets.seasonId, schema.seasons.id))
+	.where(eq(schema.teamInvites.token, token))
+	.get();
+
+const valid = Boolean(
+	invite &&
+		!invite.revokedAt &&
+		invite.bracketStatus !== "finished" &&
+		(!invite.registrationClosesAt ||
+			invite.registrationClosesAt.getTime() > Date.now()),
+);
+---
+
+<PortalLayout title="Join team" section="me" nav={[...COMPETITOR_NAV]}>
+	<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+		{
+			!valid ? (
+				<>
+					<h2 class="text-lg font-semibold text-slate-100">Invite unavailable</h2>
+					<p class="mt-2 text-slate-400">
+						This invite link is invalid or has been revoked.
+					</p>
+				</>
+			) : (
+				<>
+					<h2 class="text-lg font-semibold text-slate-100">
+						Join {invite?.teamName}
+					</h2>
+					<p class="mt-2 text-slate-400">
+						{invite?.seasonName} / {invite?.bracketName}
+					</p>
+					<form method="POST" action={`/api/join/${token}`} class="mt-5">
+						<button class="rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400">
+							Join team
+						</button>
+					</form>
+				</>
+			)
+		}
+	</section>
+</PortalLayout>

--- a/projects/klustered.dev/src/pages/me/index.astro
+++ b/projects/klustered.dev/src/pages/me/index.astro
@@ -1,8 +1,66 @@
 ---
+import { env } from "cloudflare:workers";
+import { and, desc, eq } from "drizzle-orm";
 import PortalLayout from "@/layouts/PortalLayout.astro";
+import { getBracketsDb, schema } from "@/db/client";
+import { SHOW_ID } from "@/lib/brackets-write";
 import { COMPETITOR_NAV } from "@/lib/nav";
 
+const user = Astro.locals.user!;
 const roles = Astro.locals.roles;
+const db = getBracketsDb(env.BRACKETS);
+const now = Date.now();
+
+const brackets = await db
+	.select({
+		id: schema.brackets.id,
+		name: schema.brackets.name,
+		kind: schema.brackets.kind,
+		teamSize: schema.brackets.teamSize,
+		seasonId: schema.brackets.seasonId,
+		seasonName: schema.seasons.name,
+		status: schema.brackets.status,
+		registrationClosesAt: schema.brackets.registrationClosesAt,
+	})
+	.from(schema.brackets)
+	.innerJoin(schema.seasons, eq(schema.brackets.seasonId, schema.seasons.id))
+	.where(eq(schema.seasons.showId, SHOW_ID))
+	.orderBy(desc(schema.brackets.createdAt))
+	.all();
+
+const openBrackets = brackets.filter(
+	(b) =>
+		b.status !== "finished" &&
+		(!b.registrationClosesAt || b.registrationClosesAt.getTime() > now),
+);
+
+const cards = await Promise.all(
+	openBrackets.map(async (bracket) => {
+		const competitor = await db
+			.select()
+			.from(schema.competitors)
+			.where(
+				and(
+					eq(schema.competitors.seasonId, bracket.seasonId),
+					eq(schema.competitors.userId, user.id),
+				),
+			)
+			.get();
+		const application = competitor
+			? await db
+					.select({ id: schema.bracketApplications.id })
+					.from(schema.bracketApplications)
+					.where(
+						and(
+							eq(schema.bracketApplications.bracketId, bracket.id),
+							eq(schema.bracketApplications.competitorId, competitor.id),
+						),
+					)
+					.get()
+			: null;
+		return { ...bracket, applied: Boolean(application) };
+	}),
+);
 ---
 
 <PortalLayout title="My competitor area" section="me" nav={[...COMPETITOR_NAV]}>
@@ -17,11 +75,28 @@ const roles = Astro.locals.roles;
 		)
 	}
 
-	<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
-		<p>Your matches, schedule, and competitor profile live here.</p>
-		<p class="mt-3 text-slate-400">
-			Use Matches for upcoming and past fixtures. Use Profile to confirm which
-			public Klustered competitor record is linked to your account.
-		</p>
+	<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+		<h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">
+			Bracket entries
+		</h2>
+		{
+			cards.length === 0 ? (
+				<p class="mt-3 text-sm text-slate-400">No brackets are open right now.</p>
+			) : (
+				<div class="mt-4 grid gap-3 md:grid-cols-2">
+					{cards.map((card) => (
+						<div class="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+							<p class="text-xs uppercase tracking-wider text-slate-500">
+								{card.kind === "team" ? `Team (${card.teamSize})` : "Individual"}
+							</p>
+							<h3 class="mt-1 text-lg font-semibold text-slate-100">{card.name}</h3>
+							<p class="mt-2 text-sm text-slate-400">
+								{card.applied ? "Entered" : "Not entered"}
+							</p>
+						</div>
+					))}
+				</div>
+			)
+		}
 	</section>
 </PortalLayout>

--- a/projects/klustered.dev/src/pages/me/profile.astro
+++ b/projects/klustered.dev/src/pages/me/profile.astro
@@ -87,9 +87,15 @@ const person = competitor ? await getPerson(competitor.personSlug) : undefined;
 					)}
 				</dl>
 				{competitor.bio && <p class="mt-4 text-slate-400">{competitor.bio}</p>}
-				<p class="mt-4 text-xs text-slate-500">
-					Bio + public profile fields live in <code class="rounded bg-slate-800 px-1 py-0.5">content/people/{competitor.personSlug}.mdx</code> — open a PR to edit them.
-				</p>
+				{person ? (
+					<p class="mt-4 text-xs text-slate-500">
+						Bio + public profile fields live in <code class="rounded bg-slate-800 px-1 py-0.5">content/people/{competitor.personSlug}.mdx</code> — open a PR to edit them.
+					</p>
+				) : (
+					<p class="mt-4 text-xs text-slate-500">
+						This self-service competitor record does not have a public content profile yet.
+					</p>
+				)}
 			</section>
 		) : (
 			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">

--- a/projects/klustered.dev/src/pages/me/team.astro
+++ b/projects/klustered.dev/src/pages/me/team.astro
@@ -1,0 +1,249 @@
+---
+import { env } from "cloudflare:workers";
+import { and, desc, eq, isNull } from "drizzle-orm";
+import PortalLayout from "@/layouts/PortalLayout.astro";
+import { getBracketsDb, schema } from "@/db/client";
+import { COMPETITOR_NAV } from "@/lib/nav";
+import { SHOW_ID } from "@/lib/brackets-write";
+
+const user = Astro.locals.user!;
+const db = getBracketsDb(env.BRACKETS);
+const now = Date.now();
+
+const teamBrackets = await db
+	.select({
+		id: schema.brackets.id,
+		name: schema.brackets.name,
+		seasonId: schema.brackets.seasonId,
+		seasonName: schema.seasons.name,
+		status: schema.brackets.status,
+		teamSize: schema.brackets.teamSize,
+		registrationClosesAt: schema.brackets.registrationClosesAt,
+	})
+	.from(schema.brackets)
+	.innerJoin(schema.seasons, eq(schema.brackets.seasonId, schema.seasons.id))
+	.where(and(eq(schema.seasons.showId, SHOW_ID), eq(schema.brackets.kind, "team")))
+	.orderBy(desc(schema.brackets.createdAt))
+	.all();
+
+const teamBracket =
+	teamBrackets.find(
+		(b) =>
+			b.status !== "finished" &&
+			(!b.registrationClosesAt || b.registrationClosesAt.getTime() > now),
+	) ?? null;
+
+const competitor = teamBracket
+	? await db
+			.select()
+			.from(schema.competitors)
+			.where(
+				and(
+					eq(schema.competitors.seasonId, teamBracket.seasonId),
+					eq(schema.competitors.userId, user.id),
+				),
+			)
+			.get()
+	: null;
+
+const application =
+	teamBracket && competitor
+		? await db
+				.select({ id: schema.bracketApplications.id })
+				.from(schema.bracketApplications)
+				.where(
+					and(
+						eq(schema.bracketApplications.bracketId, teamBracket.id),
+						eq(schema.bracketApplications.competitorId, competitor.id),
+					),
+				)
+				.get()
+		: null;
+
+const membership =
+	teamBracket && competitor
+		? await db
+				.select({
+					teamId: schema.teamMembers.teamId,
+					role: schema.teamMembers.role,
+					teamName: schema.teams.name,
+					teamSlug: schema.teams.slug,
+				})
+				.from(schema.teamMembers)
+				.innerJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
+				.where(
+					and(
+						eq(schema.teamMembers.bracketId, teamBracket.id),
+						eq(schema.teamMembers.competitorId, competitor.id),
+					),
+				)
+				.get()
+		: null;
+
+const roster = membership
+	? await db
+			.select({
+				competitorId: schema.competitors.id,
+				displayName: schema.competitors.displayName,
+				personSlug: schema.competitors.personSlug,
+				role: schema.teamMembers.role,
+			})
+			.from(schema.teamMembers)
+			.innerJoin(schema.competitors, eq(schema.teamMembers.competitorId, schema.competitors.id))
+			.where(eq(schema.teamMembers.teamId, membership.teamId))
+			.all()
+	: [];
+
+const isCaptain = membership?.role === "captain";
+
+const activeInvite = isCaptain && membership
+	? await db
+			.select()
+			.from(schema.teamInvites)
+			.where(
+				and(
+					eq(schema.teamInvites.teamId, membership.teamId),
+					isNull(schema.teamInvites.revokedAt),
+				),
+			)
+			.get()
+	: null;
+
+const inviteUrl = activeInvite
+	? new URL(`/join/${activeInvite.token}`, Astro.url.origin).toString()
+	: null;
+---
+
+<PortalLayout title="Team" section="me" nav={[...COMPETITOR_NAV]}>
+	{
+		!teamBracket ? (
+			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+				No team bracket is open.
+			</section>
+		) : !competitor || !application ? (
+			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+				<p>You have not entered {teamBracket.name} yet.</p>
+				<a href="https://rawkode.academy/shows/klustered/apply" class="mt-4 inline-flex rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400">
+					Apply on Rawkode Academy
+				</a>
+			</section>
+		) : !membership ? (
+			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+				<h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">
+					Name your team
+				</h2>
+				<p class="mt-2 text-sm text-slate-400">
+					{teamBracket.seasonName} / {teamBracket.name} allows {teamBracket.teamSize} competitors per team.
+				</p>
+				<form method="POST" action="/api/me/team" class="mt-4 grid gap-3 sm:grid-cols-[1fr_auto]">
+					<input type="hidden" name="action" value="create" />
+					<input type="hidden" name="bracketId" value={teamBracket.id} />
+					<label class="flex flex-col gap-1">
+						<span class="text-xs text-slate-400">Team name</span>
+						<input
+							name="name"
+							required
+							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+						/>
+					</label>
+					<div class="flex items-end">
+						<button class="rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400">
+							Create team
+						</button>
+					</div>
+				</form>
+			</section>
+		) : (
+			<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+				<div class="flex flex-wrap items-start justify-between gap-4">
+					<div>
+						<p class="text-xs uppercase tracking-wider text-slate-500">{teamBracket.seasonName}</p>
+						<h2 class="mt-1 text-2xl font-semibold text-slate-100">{membership.teamName}</h2>
+						<p class="mt-1 text-sm text-slate-400">
+							{roster.length} of {teamBracket.teamSize} seats filled.
+						</p>
+					</div>
+					{isCaptain && (
+						<form method="POST" action="/api/me/team" class="flex gap-2">
+							<input type="hidden" name="action" value="rename" />
+							<input type="hidden" name="teamId" value={membership.teamId} />
+							<input
+								name="name"
+								value={membership.teamName}
+								required
+								class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+							/>
+							<button class="rounded-lg border border-slate-700 px-3 py-1.5 text-sm text-slate-200 hover:border-fuchsia-500">
+								Rename
+							</button>
+						</form>
+					)}
+				</div>
+
+				<div class="mt-6">
+					<h3 class="text-sm font-semibold uppercase tracking-wider text-slate-400">
+						Roster
+					</h3>
+					<ul class="mt-3 flex flex-col gap-2">
+						{roster.map((member) => (
+							<li class="rounded-lg border border-slate-800 bg-slate-950/40 px-4 py-2 text-sm">
+								<span class="text-slate-100">{member.displayName}</span>
+								<span class="ml-2 font-mono text-xs text-slate-500">{member.personSlug}</span>
+								{member.role && (
+									<span class="ml-2 rounded-full bg-fuchsia-500/15 px-2 py-0.5 text-xs text-fuchsia-200">
+										{member.role}
+									</span>
+								)}
+							</li>
+						))}
+					</ul>
+				</div>
+
+				{isCaptain && (
+					<div class="mt-6">
+						<h3 class="text-sm font-semibold uppercase tracking-wider text-slate-400">
+							Invite link
+						</h3>
+						{inviteUrl ? (
+							<input
+								readonly
+								value={inviteUrl}
+								class="mt-3 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs text-slate-200"
+							/>
+						) : (
+							<p class="mt-3 text-sm text-slate-400">No active invite link.</p>
+						)}
+						<div class="mt-3 flex flex-wrap gap-3">
+							<form method="POST" action="/api/me/team">
+								<input type="hidden" name="action" value="invite" />
+								<input type="hidden" name="teamId" value={membership.teamId} />
+								<button class="rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400">
+									Regenerate link
+								</button>
+							</form>
+							{inviteUrl && (
+								<form method="POST" action="/api/me/team">
+									<input type="hidden" name="action" value="revoke" />
+									<input type="hidden" name="token" value={activeInvite?.token} />
+									<button class="rounded-lg border border-slate-700 px-4 py-1.5 text-sm text-slate-200 hover:border-rose-500 hover:text-rose-200">
+										Revoke link
+									</button>
+								</form>
+							)}
+						</div>
+					</div>
+				)}
+
+				<div class="mt-6 flex flex-wrap gap-3">
+					<form method="POST" action="/api/me/team">
+						<input type="hidden" name="action" value="leave" />
+						<input type="hidden" name="teamId" value={membership.teamId} />
+						<button class="rounded-lg border border-slate-700 px-4 py-1.5 text-sm text-rose-300 hover:border-rose-500">
+							Leave team
+						</button>
+					</form>
+				</div>
+			</section>
+		)
+	}
+</PortalLayout>

--- a/projects/rawkode.academy/platform/brackets/data-model/integrations/zod.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/integrations/zod.ts
@@ -47,3 +47,49 @@ export const SetMatchLiveState = z.object({
 	state: z.enum(["live", "scheduled", "cancelled"]),
 });
 export type SetMatchLiveState = z.infer<typeof SetMatchLiveState>;
+
+export const SelfRegisterCompetitor = z.object({
+	bracketId: z.string().min(1),
+	userId: z.string().min(1),
+	displayName: z.string().min(1),
+});
+export type SelfRegisterCompetitor = z.infer<typeof SelfRegisterCompetitor>;
+
+export const FormTeam = z.object({
+	bracketId: z.string().min(1),
+	name: z.string().min(1),
+	userId: z.string().min(1),
+});
+export type FormTeam = z.infer<typeof FormTeam>;
+
+export const JoinTeamViaInvite = z.object({
+	token: z.string().min(1),
+	userId: z.string().min(1),
+	displayName: z.string().min(1),
+});
+export type JoinTeamViaInvite = z.infer<typeof JoinTeamViaInvite>;
+
+export const RenameTeam = z.object({
+	teamId: z.string().min(1),
+	name: z.string().min(1),
+	userId: z.string().min(1),
+});
+export type RenameTeam = z.infer<typeof RenameTeam>;
+
+export const CreateTeamInvite = z.object({
+	teamId: z.string().min(1),
+	userId: z.string().min(1),
+});
+export type CreateTeamInvite = z.infer<typeof CreateTeamInvite>;
+
+export const RevokeTeamInvite = z.object({
+	token: z.string().min(1),
+	userId: z.string().min(1),
+});
+export type RevokeTeamInvite = z.infer<typeof RevokeTeamInvite>;
+
+export const LeaveTeam = z.object({
+	teamId: z.string().min(1),
+	userId: z.string().min(1),
+});
+export type LeaveTeam = z.infer<typeof LeaveTeam>;

--- a/projects/rawkode.academy/platform/brackets/data-model/migrations/0001_bracket_scoped_applications.sql
+++ b/projects/rawkode.academy/platform/brackets/data-model/migrations/0001_bracket_scoped_applications.sql
@@ -1,0 +1,131 @@
+ALTER TABLE `brackets` ADD `team_size` integer DEFAULT 2 NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `competitors_season_user_unique` ON `competitors` (`season_id`,`user_id`) WHERE `user_id` is not null;
+--> statement-breakpoint
+DROP TABLE `match_results`;
+--> statement-breakpoint
+DROP TABLE `matches`;
+--> statement-breakpoint
+DROP TABLE `bracket_entries`;
+--> statement-breakpoint
+DROP TABLE `team_members`;
+--> statement-breakpoint
+DROP TABLE `teams`;
+--> statement-breakpoint
+CREATE TABLE `bracket_applications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`bracket_id` text NOT NULL,
+	`competitor_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`competitor_id`) REFERENCES `competitors`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bracket_applications_bracket_competitor_unique` ON `bracket_applications` (`bracket_id`,`competitor_id`);
+--> statement-breakpoint
+CREATE TABLE `teams` (
+	`id` text PRIMARY KEY NOT NULL,
+	`season_id` text NOT NULL,
+	`bracket_id` text NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`season_id`) REFERENCES `seasons`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `teams_bracket_slug_unique` ON `teams` (`bracket_id`,`slug`);
+--> statement-breakpoint
+CREATE TABLE `team_members` (
+	`team_id` text NOT NULL,
+	`bracket_id` text NOT NULL,
+	`competitor_id` text NOT NULL,
+	`role` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	PRIMARY KEY(`team_id`, `competitor_id`),
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`competitor_id`) REFERENCES `competitors`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `team_members_bracket_competitor_unique` ON `team_members` (`bracket_id`,`competitor_id`);
+--> statement-breakpoint
+CREATE TABLE `team_invites` (
+	`token` text PRIMARY KEY NOT NULL,
+	`team_id` text NOT NULL,
+	`bracket_id` text NOT NULL,
+	`created_by_user_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`revoked_at` integer,
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `bracket_entries` (
+	`id` text PRIMARY KEY NOT NULL,
+	`bracket_id` text NOT NULL,
+	`competitor_id` text,
+	`team_id` text,
+	`display_name` text NOT NULL,
+	`seed` integer NOT NULL,
+	`status` text DEFAULT 'confirmed' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`competitor_id`) REFERENCES `competitors`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bracket_entries_bracket_seed_unique` ON `bracket_entries` (`bracket_id`,`seed`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bracket_entries_bracket_competitor_unique` ON `bracket_entries` (`bracket_id`,`competitor_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bracket_entries_bracket_team_unique` ON `bracket_entries` (`bracket_id`,`team_id`);
+--> statement-breakpoint
+CREATE TABLE `matches` (
+	`id` text PRIMARY KEY NOT NULL,
+	`bracket_id` text NOT NULL,
+	`round_number` integer NOT NULL,
+	`position_in_round` integer NOT NULL,
+	`scheduled_at` integer,
+	`status` text DEFAULT 'scheduled' NOT NULL,
+	`team_a_id` text,
+	`team_b_id` text,
+	`entry_a_id` text,
+	`entry_b_id` text,
+	`scenario_id` text,
+	`judge_user_id` text,
+	`winner_team_id` text,
+	`winner_entry_id` text,
+	`started_at` integer,
+	`ended_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`bracket_id`) REFERENCES `brackets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`team_a_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`team_b_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`entry_a_id`) REFERENCES `bracket_entries`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`entry_b_id`) REFERENCES `bracket_entries`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`scenario_id`) REFERENCES `scenarios`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`winner_team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`winner_entry_id`) REFERENCES `bracket_entries`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `match_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`match_id` text NOT NULL,
+	`winner_team_id` text,
+	`winner_entry_id` text,
+	`time_to_resolve_seconds` integer,
+	`score_a` integer,
+	`score_b` integer,
+	`notes` text,
+	`recorded_at` integer NOT NULL,
+	`recorded_by_user_id` text,
+	FOREIGN KEY (`match_id`) REFERENCES `matches`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`winner_team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`winner_entry_id`) REFERENCES `bracket_entries`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `match_results_match_id_unique` ON `match_results` (`match_id`);

--- a/projects/rawkode.academy/platform/brackets/data-model/migrations/meta/_journal.json
+++ b/projects/rawkode.academy/platform/brackets/data-model/migrations/meta/_journal.json
@@ -1,13 +1,20 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1779656599321,
-      "tag": "0000_wakeful_tempest",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1779656599321,
+			"tag": "0000_wakeful_tempest",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1779667200000,
+			"tag": "0001_bracket_scoped_applications",
+			"breakpoints": true
+		}
+	]
 }

--- a/projects/rawkode.academy/platform/brackets/data-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/schema.ts
@@ -56,38 +56,14 @@ export const competitors = sqliteTable(
 		updatedAt: updatedAt(),
 	},
 	(t) => [
-		uniqueIndex("competitors_season_person_unique").on(t.seasonId, t.personSlug),
+		uniqueIndex("competitors_season_person_unique").on(
+			t.seasonId,
+			t.personSlug,
+		),
+		uniqueIndex("competitors_season_user_unique")
+			.on(t.seasonId, t.userId)
+			.where(sql`${t.userId} is not null`),
 	],
-);
-
-export const teams = sqliteTable(
-	"teams",
-	{
-		id: text("id").primaryKey(),
-		seasonId: text("season_id")
-			.notNull()
-			.references(() => seasons.id, { onDelete: "cascade" }),
-		name: text("name").notNull(),
-		slug: text("slug").notNull(),
-		createdAt: createdAt(),
-		updatedAt: updatedAt(),
-	},
-	(t) => [uniqueIndex("teams_season_slug_unique").on(t.seasonId, t.slug)],
-);
-
-export const teamMembers = sqliteTable(
-	"team_members",
-	{
-		teamId: text("team_id")
-			.notNull()
-			.references(() => teams.id, { onDelete: "cascade" }),
-		competitorId: text("competitor_id")
-			.notNull()
-			.references(() => competitors.id, { onDelete: "cascade" }),
-		role: text("role"),
-		createdAt: createdAt(),
-	},
-	(t) => [primaryKey({ columns: [t.teamId, t.competitorId] })],
 );
 
 export const scenarios = sqliteTable("scenarios", {
@@ -113,7 +89,9 @@ export const brackets = sqliteTable(
 			.references(() => seasons.id, { onDelete: "cascade" }),
 		name: text("name").notNull(),
 		slug: text("slug").notNull(),
-		kind: text("kind", { enum: ["solo", "team"] }).notNull().default("team"),
+		kind: text("kind", { enum: ["solo", "team"] })
+			.notNull()
+			.default("team"),
 		format: text("format", { enum: ["single_elimination"] })
 			.notNull()
 			.default("single_elimination"),
@@ -125,12 +103,88 @@ export const brackets = sqliteTable(
 			mode: "timestamp_ms",
 		}),
 		maxEntries: integer("max_entries").notNull().default(16),
+		teamSize: integer("team_size").notNull().default(2),
 		cadenceDays: integer("cadence_days").notNull().default(7),
 		createdAt: createdAt(),
 		updatedAt: updatedAt(),
 	},
 	(t) => [uniqueIndex("brackets_season_slug_unique").on(t.seasonId, t.slug)],
 );
+
+export const bracketApplications = sqliteTable(
+	"bracket_applications",
+	{
+		id: text("id").primaryKey(),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		competitorId: text("competitor_id")
+			.notNull()
+			.references(() => competitors.id, { onDelete: "cascade" }),
+		createdAt: createdAt(),
+	},
+	(t) => [
+		uniqueIndex("bracket_applications_bracket_competitor_unique").on(
+			t.bracketId,
+			t.competitorId,
+		),
+	],
+);
+
+export const teams = sqliteTable(
+	"teams",
+	{
+		id: text("id").primaryKey(),
+		seasonId: text("season_id")
+			.notNull()
+			.references(() => seasons.id, { onDelete: "cascade" }),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		slug: text("slug").notNull(),
+		createdAt: createdAt(),
+		updatedAt: updatedAt(),
+	},
+	(t) => [uniqueIndex("teams_bracket_slug_unique").on(t.bracketId, t.slug)],
+);
+
+export const teamMembers = sqliteTable(
+	"team_members",
+	{
+		teamId: text("team_id")
+			.notNull()
+			.references(() => teams.id, { onDelete: "cascade" }),
+		bracketId: text("bracket_id")
+			.notNull()
+			.references(() => brackets.id, { onDelete: "cascade" }),
+		competitorId: text("competitor_id")
+			.notNull()
+			.references(() => competitors.id, { onDelete: "cascade" }),
+		role: text("role"),
+		createdAt: createdAt(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.teamId, t.competitorId] }),
+		uniqueIndex("team_members_bracket_competitor_unique").on(
+			t.bracketId,
+			t.competitorId,
+		),
+	],
+);
+
+export const teamInvites = sqliteTable("team_invites", {
+	token: text("token").primaryKey(),
+	teamId: text("team_id")
+		.notNull()
+		.references(() => teams.id, { onDelete: "cascade" }),
+	bracketId: text("bracket_id")
+		.notNull()
+		.references(() => brackets.id, { onDelete: "cascade" }),
+	createdByUserId: text("created_by_user_id").notNull(),
+	createdAt: createdAt(),
+	revokedAt: integer("revoked_at", { mode: "timestamp_ms" }),
+});
 
 export const bracketBreaks = sqliteTable("bracket_breaks", {
 	id: text("id").primaryKey(),
@@ -168,7 +222,10 @@ export const bracketEntries = sqliteTable(
 			t.bracketId,
 			t.competitorId,
 		),
-		uniqueIndex("bracket_entries_bracket_team_unique").on(t.bracketId, t.teamId),
+		uniqueIndex("bracket_entries_bracket_team_unique").on(
+			t.bracketId,
+			t.teamId,
+		),
 	],
 );
 
@@ -185,8 +242,12 @@ export const matches = sqliteTable("matches", {
 	})
 		.notNull()
 		.default("scheduled"),
-	teamAId: text("team_a_id").references(() => teams.id, { onDelete: "set null" }),
-	teamBId: text("team_b_id").references(() => teams.id, { onDelete: "set null" }),
+	teamAId: text("team_a_id").references(() => teams.id, {
+		onDelete: "set null",
+	}),
+	teamBId: text("team_b_id").references(() => teams.id, {
+		onDelete: "set null",
+	}),
 	entryAId: text("entry_a_id").references(() => bracketEntries.id, {
 		onDelete: "set null",
 	}),

--- a/projects/rawkode.academy/platform/brackets/read-model/main.ts
+++ b/projects/rawkode.academy/platform/brackets/read-model/main.ts
@@ -15,6 +15,11 @@ export default {
 		const yoga = createYoga({
 			schema: getSchema(env),
 			graphqlEndpoint: "/",
+			context: ({ request }) => {
+				return {
+					userId: request.headers.get("X-Gateway-User-Id"),
+				};
+			},
 		});
 
 		return yoga.fetch(request, env, ctx);

--- a/projects/rawkode.academy/platform/brackets/read-model/schema.gql
+++ b/projects/rawkode.academy/platform/brackets/read-model/schema.gql
@@ -10,6 +10,7 @@ type Bracket {
   format: String
   status: String
   maxEntries: Int
+  teamSize: Int
   cadenceDays: Int
   startsAt: DateTime
   registrationClosesAt: DateTime
@@ -61,7 +62,31 @@ type MatchSide {
   seed: Int
 }
 
+type MyBracketParticipation {
+  bracketId: String
+  bracketSlug: String
+  bracketName: String
+  bracketKind: String
+  teamSize: Int
+  registrationClosesAt: DateTime
+  applied: Boolean
+  team: MyTeam
+}
+
+type MyParticipation {
+  brackets: [MyBracketParticipation!]
+}
+
+type MyTeam {
+  id: String
+  name: String
+  slug: String
+  isCaptain: Boolean
+  memberCount: Int
+}
+
 type Query {
+  myBracketParticipation(showId: String!): MyParticipation
   bracket(id: String!): Bracket
   bracketBySlug(showId: String!, seasonSlug: String!, bracketSlug: String!): Bracket
 }
@@ -77,4 +102,5 @@ type Show
   liveMatch: BracketMatch
   leaderboard(seasonSlug: String): [BracketStanding!]
   openBrackets: [Bracket!]
+  myParticipation: MyParticipation
 }

--- a/projects/rawkode.academy/platform/brackets/read-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/read-model/schema.ts
@@ -3,7 +3,7 @@ import schemaBuilder from "@pothos/core";
 import directivesPlugin from "@pothos/plugin-directives";
 import drizzlePlugin from "@pothos/plugin-drizzle";
 import federationPlugin from "@pothos/plugin-federation";
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { DateTimeResolver } from "graphql-scalars";
 import type { GraphQLSchema } from "graphql";
@@ -11,15 +11,43 @@ import * as s from "../data-model/schema";
 
 export interface PothosTypes {
 	DrizzleSchema: typeof s;
+	Context: BracketsReadContext;
 	Scalars: {
 		DateTime: { Input: Date; Output: Date };
 	};
 }
 
+export interface BracketsReadContext {
+	userId: string | null;
+}
+
 type MatchRow = typeof s.matches.$inferSelect;
 type BracketRow = typeof s.brackets.$inferSelect;
 type SeasonRow = typeof s.seasons.$inferSelect;
-type Side = { kind: "team" | "entry"; id: string; displayName: string; seed: number | null };
+type Side = {
+	kind: "team" | "entry";
+	id: string;
+	displayName: string;
+	seed: number | null;
+};
+type MyTeam = {
+	id: string;
+	name: string;
+	slug: string;
+	isCaptain: boolean;
+	memberCount: number;
+};
+type MyBracketParticipation = {
+	bracketId: string;
+	bracketSlug: string;
+	bracketName: string;
+	bracketKind: string;
+	teamSize: number;
+	registrationClosesAt: Date | null;
+	applied: boolean;
+	team: MyTeam | null;
+};
+type MyParticipation = { brackets: MyBracketParticipation[] };
 
 const createBuilder = (env: { DB: D1Database }) => {
 	const db = drizzle(env.DB);
@@ -36,7 +64,10 @@ const createBuilder = (env: { DB: D1Database }) => {
 	const seasonsForShow = (showId: string) =>
 		db.select().from(s.seasons).where(eq(s.seasons.showId, showId)).all();
 
-	const seasonIdsForShow = async (showId: string, seasonSlug?: string | null) => {
+	const seasonIdsForShow = async (
+		showId: string,
+		seasonSlug?: string | null,
+	) => {
 		const rows = await seasonsForShow(showId);
 		return rows
 			.filter((r) => (seasonSlug ? r.slug === seasonSlug : true))
@@ -87,7 +118,12 @@ const createBuilder = (env: { DB: D1Database }) => {
 				.where(eq(s.teams.id, teamId))
 				.get();
 			if (team)
-				return { kind: "team", id: team.id, displayName: team.name, seed: null };
+				return {
+					kind: "team",
+					id: team.id,
+					displayName: team.name,
+					seed: null,
+				};
 		}
 		return null;
 	};
@@ -169,6 +205,7 @@ const createBuilder = (env: { DB: D1Database }) => {
 			format: t.exposeString("format"),
 			status: t.exposeString("status"),
 			maxEntries: t.exposeInt("maxEntries"),
+			teamSize: t.exposeInt("teamSize"),
 			cadenceDays: t.exposeInt("cadenceDays"),
 			startsAt: t.field({
 				type: "DateTime",
@@ -228,15 +265,62 @@ const createBuilder = (env: { DB: D1Database }) => {
 	});
 
 	const standingRef = builder
-		.objectRef<{ id: string; displayName: string; wins: number; losses: number }>(
-			"BracketStanding",
-		)
+		.objectRef<{
+			id: string;
+			displayName: string;
+			wins: number;
+			losses: number;
+		}>("BracketStanding")
 		.implement({
 			fields: (t) => ({
 				id: t.exposeString("id"),
 				displayName: t.exposeString("displayName"),
 				wins: t.exposeInt("wins"),
 				losses: t.exposeInt("losses"),
+			}),
+		});
+
+	const myTeamRef = builder.objectRef<MyTeam>("MyTeam").implement({
+		fields: (t) => ({
+			id: t.exposeString("id"),
+			name: t.exposeString("name"),
+			slug: t.exposeString("slug"),
+			isCaptain: t.exposeBoolean("isCaptain"),
+			memberCount: t.exposeInt("memberCount"),
+		}),
+	});
+
+	const myBracketParticipationRef = builder
+		.objectRef<MyBracketParticipation>("MyBracketParticipation")
+		.implement({
+			fields: (t) => ({
+				bracketId: t.exposeString("bracketId"),
+				bracketSlug: t.exposeString("bracketSlug"),
+				bracketName: t.exposeString("bracketName"),
+				bracketKind: t.exposeString("bracketKind"),
+				teamSize: t.exposeInt("teamSize"),
+				registrationClosesAt: t.field({
+					type: "DateTime",
+					nullable: true,
+					resolve: (p) => p.registrationClosesAt,
+				}),
+				applied: t.exposeBoolean("applied"),
+				team: t.field({
+					type: myTeamRef,
+					nullable: true,
+					resolve: (p) => p.team,
+				}),
+			}),
+		});
+
+	const myParticipationRef = builder
+		.objectRef<MyParticipation>("MyParticipation")
+		.implement({
+			fields: (t) => ({
+				brackets: t.field({
+					type: [myBracketParticipationRef],
+					resolve: (p) => p.brackets,
+				}),
 			}),
 		});
 
@@ -263,7 +347,10 @@ const createBuilder = (env: { DB: D1Database }) => {
 		return matches.find((m) => m.status === "live") ?? null;
 	};
 
-	const showLeaderboard = async (showId: string, seasonSlug?: string | null) => {
+	const showLeaderboard = async (
+		showId: string,
+		seasonSlug?: string | null,
+	) => {
 		const matches = (await showSchedule(showId, seasonSlug)).filter(
 			(m) => m.status === "completed",
 		);
@@ -308,6 +395,92 @@ const createBuilder = (env: { DB: D1Database }) => {
 		);
 	};
 
+	const myParticipation = async (
+		showId: string,
+		userId?: string | null,
+	): Promise<MyParticipation> => {
+		const brackets = await openBrackets(showId);
+		const rows: MyBracketParticipation[] = [];
+
+		for (const bracket of brackets) {
+			let applied = false;
+			let team: MyTeam | null = null;
+
+			const competitor = userId
+				? await db
+						.select()
+						.from(s.competitors)
+						.where(
+							and(
+								eq(s.competitors.seasonId, bracket.seasonId),
+								eq(s.competitors.userId, userId),
+							),
+						)
+						.get()
+				: null;
+
+			if (competitor) {
+				const application = await db
+					.select({ id: s.bracketApplications.id })
+					.from(s.bracketApplications)
+					.where(
+						and(
+							eq(s.bracketApplications.bracketId, bracket.id),
+							eq(s.bracketApplications.competitorId, competitor.id),
+						),
+					)
+					.get();
+				applied = Boolean(application);
+
+				if (bracket.kind === "team") {
+					const membership = await db
+						.select({
+							role: s.teamMembers.role,
+							teamId: s.teamMembers.teamId,
+							teamName: s.teams.name,
+							teamSlug: s.teams.slug,
+						})
+						.from(s.teamMembers)
+						.innerJoin(s.teams, eq(s.teamMembers.teamId, s.teams.id))
+						.where(
+							and(
+								eq(s.teamMembers.bracketId, bracket.id),
+								eq(s.teamMembers.competitorId, competitor.id),
+							),
+						)
+						.get();
+					if (membership) {
+						const members = await db
+							.select({ competitorId: s.teamMembers.competitorId })
+							.from(s.teamMembers)
+							.where(eq(s.teamMembers.teamId, membership.teamId))
+							.all();
+						team = {
+							id: membership.teamId,
+							name: membership.teamName,
+							slug: membership.teamSlug,
+							isCaptain: membership.role === "captain",
+							memberCount: members.length,
+						};
+					}
+				}
+			}
+
+			rows.push({
+				bracketId: bracket.id,
+				bracketSlug: bracket.slug,
+				bracketName: bracket.name,
+				bracketKind: bracket.kind,
+				teamSize: bracket.teamSize,
+				registrationClosesAt: bracket.registrationClosesAt,
+				applied,
+				team,
+			});
+		}
+
+		return { brackets: rows };
+	};
+
 	// ---- federation: extend the Show entity owned by the website subgraph ----
 
 	builder
@@ -347,6 +520,10 @@ const createBuilder = (env: { DB: D1Database }) => {
 					type: [bracketRef],
 					resolve: (show) => openBrackets(show.id),
 				}),
+				myParticipation: t.field({
+					type: myParticipationRef,
+					resolve: (show, _args, ctx) => myParticipation(show.id, ctx.userId),
+				}),
 			}),
 		});
 
@@ -354,6 +531,11 @@ const createBuilder = (env: { DB: D1Database }) => {
 
 	builder.queryType({
 		fields: (t) => ({
+			myBracketParticipation: t.field({
+				type: myParticipationRef,
+				args: { showId: t.arg({ type: "String", required: true }) },
+				resolve: (_root, args, ctx) => myParticipation(args.showId, ctx.userId),
+			}),
 			bracket: t.field({
 				type: bracketRef,
 				nullable: true,
@@ -370,7 +552,10 @@ const createBuilder = (env: { DB: D1Database }) => {
 					bracketSlug: t.arg({ type: "String", required: true }),
 				},
 				resolve: async (_root, args) => {
-					const seasonIds = await seasonIdsForShow(args.showId, args.seasonSlug);
+					const seasonIds = await seasonIdsForShow(
+						args.showId,
+						args.seasonSlug,
+					);
 					if (seasonIds.length === 0) return null;
 					return db
 						.select()

--- a/projects/rawkode.academy/platform/brackets/read-model/wrangler.jsonc
+++ b/projects/rawkode.academy/platform/brackets/read-model/wrangler.jsonc
@@ -22,7 +22,7 @@
 			"service": "rawkode-tools-observability-collector"
 		}
 	],
-	"workers_dev": true,
+	"workers_dev": false,
 	"placement": {
 		"mode": "smart"
 	},

--- a/projects/rawkode.academy/platform/brackets/write-model/main.ts
+++ b/projects/rawkode.academy/platform/brackets/write-model/main.ts
@@ -1,11 +1,19 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
+import { createId } from "@paralleldrive/cuid2";
 import * as s from "../data-model/schema";
 import {
+	CreateTeamInvite,
 	DecideRegistration,
+	FormTeam,
 	GenerateBracket,
+	JoinTeamViaInvite,
+	LeaveTeam,
 	RecordResult,
+	RenameTeam,
+	RevokeTeamInvite,
+	SelfRegisterCompetitor,
 	SetMatchLiveState,
 	SubmitRegistration,
 } from "../data-model/integrations/zod";
@@ -43,6 +51,449 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 
 	async fetch(): Promise<Response> {
 		return new Response("ok", { headers: { "Content-Type": "text/plain" } });
+	}
+
+	private async getBracket(bracketId: string) {
+		const bracket = await this.db
+			.select()
+			.from(s.brackets)
+			.where(eq(s.brackets.id, bracketId))
+			.get();
+		if (!bracket || bracket.status === "finished") {
+			throw new Error("bracket not open");
+		}
+		return bracket;
+	}
+
+	private async getOpenBracket(bracketId: string) {
+		const bracket = await this.getBracket(bracketId);
+		if (
+			bracket.registrationClosesAt &&
+			bracket.registrationClosesAt.getTime() <= Date.now()
+		) {
+			throw new Error("registration closed");
+		}
+		return bracket;
+	}
+
+	private async uniqueCompetitorSlug(
+		seasonId: string,
+		displayName: string,
+	): Promise<string> {
+		const base = slugify(displayName) || "competitor";
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const slug = attempt === 0 ? base : `${base}-${attempt + 1}`;
+			const existing = await this.db
+				.select({ id: s.competitors.id })
+				.from(s.competitors)
+				.where(
+					and(
+						eq(s.competitors.seasonId, seasonId),
+						eq(s.competitors.personSlug, slug),
+					),
+				)
+				.get();
+			if (!existing) return slug;
+		}
+		return `${base}-${createId()}`;
+	}
+
+	private async uniqueTeamSlug(
+		bracketId: string,
+		name: string,
+		exceptTeamId?: string,
+	): Promise<string> {
+		const base = slugify(name) || "team";
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const slug = attempt === 0 ? base : `${base}-${attempt + 1}`;
+			const existing = await this.db
+				.select({ id: s.teams.id })
+				.from(s.teams)
+				.where(and(eq(s.teams.bracketId, bracketId), eq(s.teams.slug, slug)))
+				.get();
+			if (!existing || existing.id === exceptTeamId) return slug;
+		}
+		return `${base}-${createId()}`;
+	}
+
+	private async getOrCreateCompetitor(input: {
+		seasonId: string;
+		userId: string;
+		displayName: string;
+	}) {
+		const existing = await this.db
+			.select()
+			.from(s.competitors)
+			.where(
+				and(
+					eq(s.competitors.seasonId, input.seasonId),
+					eq(s.competitors.userId, input.userId),
+				),
+			)
+			.get();
+		if (existing) return existing;
+
+		const id = `cmp-${crypto.randomUUID()}`;
+		const personSlug = await this.uniqueCompetitorSlug(
+			input.seasonId,
+			input.displayName,
+		);
+		try {
+			await this.db.insert(s.competitors).values({
+				id,
+				seasonId: input.seasonId,
+				personSlug,
+				displayName: input.displayName,
+				userId: input.userId,
+			});
+		} catch {
+			const concurrent = await this.db
+				.select()
+				.from(s.competitors)
+				.where(
+					and(
+						eq(s.competitors.seasonId, input.seasonId),
+						eq(s.competitors.userId, input.userId),
+					),
+				)
+				.get();
+			if (concurrent) return concurrent;
+			throw new Error("could not create competitor");
+		}
+
+		const created = await this.db
+			.select()
+			.from(s.competitors)
+			.where(eq(s.competitors.id, id))
+			.get();
+		if (!created) throw new Error("could not create competitor");
+		return created;
+	}
+
+	private async ensureBracketApplication(
+		bracketId: string,
+		competitorId: string,
+	): Promise<void> {
+		await this.db
+			.insert(s.bracketApplications)
+			.values({
+				id: `app-${crypto.randomUUID()}`,
+				bracketId,
+				competitorId,
+			})
+			.onConflictDoNothing({
+				target: [
+					s.bracketApplications.bracketId,
+					s.bracketApplications.competitorId,
+				],
+			});
+	}
+
+	private async requireApplied(
+		bracketId: string,
+		competitorId: string,
+	): Promise<void> {
+		const application = await this.db
+			.select({ id: s.bracketApplications.id })
+			.from(s.bracketApplications)
+			.where(
+				and(
+					eq(s.bracketApplications.bracketId, bracketId),
+					eq(s.bracketApplications.competitorId, competitorId),
+				),
+			)
+			.get();
+		if (!application) throw new Error("apply before forming a team");
+	}
+
+	private async membershipForCompetitor(
+		bracketId: string,
+		competitorId: string,
+	) {
+		return this.db
+			.select()
+			.from(s.teamMembers)
+			.where(
+				and(
+					eq(s.teamMembers.bracketId, bracketId),
+					eq(s.teamMembers.competitorId, competitorId),
+				),
+			)
+			.get();
+	}
+
+	private async memberCount(teamId: string): Promise<number> {
+		const members = await this.db
+			.select({ competitorId: s.teamMembers.competitorId })
+			.from(s.teamMembers)
+			.where(eq(s.teamMembers.teamId, teamId))
+			.all();
+		return members.length;
+	}
+
+	private async requireTeamActor(
+		teamId: string,
+		userId: string,
+		requireCaptain = false,
+	) {
+		const team = await this.db
+			.select()
+			.from(s.teams)
+			.where(eq(s.teams.id, teamId))
+			.get();
+		if (!team) throw new Error("team not found");
+
+		const competitor = await this.db
+			.select()
+			.from(s.competitors)
+			.where(
+				and(
+					eq(s.competitors.seasonId, team.seasonId),
+					eq(s.competitors.userId, userId),
+				),
+			)
+			.get();
+		if (!competitor) throw new Error("competitor not found");
+
+		const membership = await this.db
+			.select()
+			.from(s.teamMembers)
+			.where(
+				and(
+					eq(s.teamMembers.teamId, teamId),
+					eq(s.teamMembers.competitorId, competitor.id),
+				),
+			)
+			.get();
+		if (!membership) throw new Error("not a team member");
+		if (requireCaptain && membership.role !== "captain") {
+			throw new Error("captain only");
+		}
+
+		return { team, competitor, membership };
+	}
+
+	private async mintTeamInvite(input: {
+		teamId: string;
+		bracketId: string;
+		createdByUserId: string;
+	}): Promise<{ token: string }> {
+		await this.db
+			.update(s.teamInvites)
+			.set({ revokedAt: new Date() })
+			.where(
+				and(
+					eq(s.teamInvites.teamId, input.teamId),
+					isNull(s.teamInvites.revokedAt),
+				),
+			);
+		const token = createId();
+		await this.db.insert(s.teamInvites).values({
+			token,
+			teamId: input.teamId,
+			bracketId: input.bracketId,
+			createdByUserId: input.createdByUserId,
+		});
+		return { token };
+	}
+
+	// ---- self-service applications and teams ----
+
+	async selfRegisterCompetitor(input: unknown): Promise<{
+		competitorId: string;
+		seasonId: string;
+		bracketKind: "solo" | "team";
+	}> {
+		const data = SelfRegisterCompetitor.parse(input);
+		const bracket = await this.getOpenBracket(data.bracketId);
+		const competitor = await this.getOrCreateCompetitor({
+			seasonId: bracket.seasonId,
+			userId: data.userId,
+			displayName: data.displayName,
+		});
+		await this.ensureBracketApplication(bracket.id, competitor.id);
+		return {
+			competitorId: competitor.id,
+			seasonId: bracket.seasonId,
+			bracketKind: bracket.kind,
+		};
+	}
+
+	async formTeam(input: unknown): Promise<{ teamId: string; token: string }> {
+		const data = FormTeam.parse(input);
+		const bracket = await this.getOpenBracket(data.bracketId);
+		if (bracket.kind !== "team") throw new Error("team bracket required");
+
+		const competitor = await this.db
+			.select()
+			.from(s.competitors)
+			.where(
+				and(
+					eq(s.competitors.seasonId, bracket.seasonId),
+					eq(s.competitors.userId, data.userId),
+				),
+			)
+			.get();
+		if (!competitor) throw new Error("competitor not found");
+		await this.requireApplied(bracket.id, competitor.id);
+
+		const existingMembership = await this.membershipForCompetitor(
+			bracket.id,
+			competitor.id,
+		);
+		if (existingMembership) throw new Error("already on a team");
+
+		const teamId = `team-${crypto.randomUUID()}`;
+		const slug = await this.uniqueTeamSlug(bracket.id, data.name);
+		await this.db.insert(s.teams).values({
+			id: teamId,
+			seasonId: bracket.seasonId,
+			bracketId: bracket.id,
+			name: data.name,
+			slug,
+		});
+		await this.db.insert(s.teamMembers).values({
+			teamId,
+			bracketId: bracket.id,
+			competitorId: competitor.id,
+			role: "captain",
+		});
+		const invite = await this.mintTeamInvite({
+			teamId,
+			bracketId: bracket.id,
+			createdByUserId: data.userId,
+		});
+		return { teamId, token: invite.token };
+	}
+
+	async joinTeamViaInvite(
+		input: unknown,
+	): Promise<{ teamId: string; seasonId: string }> {
+		const data = JoinTeamViaInvite.parse(input);
+		const invite = await this.db
+			.select()
+			.from(s.teamInvites)
+			.where(eq(s.teamInvites.token, data.token))
+			.get();
+		if (!invite || invite.revokedAt) throw new Error("invite not valid");
+
+		const team = await this.db
+			.select()
+			.from(s.teams)
+			.where(eq(s.teams.id, invite.teamId))
+			.get();
+		if (!team) throw new Error("team not found");
+
+		const bracket = await this.getOpenBracket(invite.bracketId);
+		if (bracket.kind !== "team") throw new Error("team bracket required");
+
+		const competitor = await this.getOrCreateCompetitor({
+			seasonId: team.seasonId,
+			userId: data.userId,
+			displayName: data.displayName,
+		});
+
+		const existingMembership = await this.membershipForCompetitor(
+			bracket.id,
+			competitor.id,
+		);
+		if (existingMembership) {
+			if (existingMembership.teamId !== team.id)
+				throw new Error("already on a team");
+			await this.ensureBracketApplication(bracket.id, competitor.id);
+			return { teamId: team.id, seasonId: team.seasonId };
+		}
+
+		if ((await this.memberCount(team.id)) >= bracket.teamSize) {
+			throw new Error("team full");
+		}
+
+		await this.db.insert(s.teamMembers).values({
+			teamId: team.id,
+			bracketId: bracket.id,
+			competitorId: competitor.id,
+			role: "member",
+		});
+		await this.ensureBracketApplication(bracket.id, competitor.id);
+		return { teamId: team.id, seasonId: team.seasonId };
+	}
+
+	async renameTeam(input: unknown): Promise<{ ok: true }> {
+		const data = RenameTeam.parse(input);
+		const { team } = await this.requireTeamActor(
+			data.teamId,
+			data.userId,
+			true,
+		);
+		const slug = await this.uniqueTeamSlug(team.bracketId, data.name, team.id);
+		await this.db
+			.update(s.teams)
+			.set({ name: data.name, slug })
+			.where(eq(s.teams.id, data.teamId));
+		return { ok: true };
+	}
+
+	async createTeamInvite(input: unknown): Promise<{ token: string }> {
+		const data = CreateTeamInvite.parse(input);
+		const { team } = await this.requireTeamActor(
+			data.teamId,
+			data.userId,
+			true,
+		);
+		return this.mintTeamInvite({
+			teamId: team.id,
+			bracketId: team.bracketId,
+			createdByUserId: data.userId,
+		});
+	}
+
+	async revokeTeamInvite(input: unknown): Promise<{ ok: true }> {
+		const data = RevokeTeamInvite.parse(input);
+		const invite = await this.db
+			.select()
+			.from(s.teamInvites)
+			.where(eq(s.teamInvites.token, data.token))
+			.get();
+		if (!invite) return { ok: true };
+		await this.requireTeamActor(invite.teamId, data.userId, true);
+		await this.db
+			.update(s.teamInvites)
+			.set({ revokedAt: new Date() })
+			.where(eq(s.teamInvites.token, data.token));
+		return { ok: true };
+	}
+
+	async leaveTeam(input: unknown): Promise<{ ok: true }> {
+		const data = LeaveTeam.parse(input);
+		const { team, competitor, membership } = await this.requireTeamActor(
+			data.teamId,
+			data.userId,
+		);
+		const count = await this.memberCount(team.id);
+		if (membership.role === "captain" && count > 1) {
+			throw new Error("captain cannot leave while team has members");
+		}
+		await this.db
+			.delete(s.teamMembers)
+			.where(
+				and(
+					eq(s.teamMembers.teamId, team.id),
+					eq(s.teamMembers.competitorId, competitor.id),
+				),
+			);
+		if (count <= 1) {
+			await this.db
+				.update(s.teamInvites)
+				.set({ revokedAt: new Date() })
+				.where(
+					and(
+						eq(s.teamInvites.teamId, team.id),
+						isNull(s.teamInvites.revokedAt),
+					),
+				);
+			await this.db.delete(s.teams).where(eq(s.teams.id, team.id));
+		}
+		return { ok: true };
 	}
 
 	// ---- registrations ----
@@ -127,7 +578,11 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 
 		const preferredSlot = registration.preferredSlot;
 		let seed: number | null = null;
-		if (preferredSlot && preferredSlot > 0 && preferredSlot <= bracket.maxEntries) {
+		if (
+			preferredSlot &&
+			preferredSlot > 0 &&
+			preferredSlot <= bracket.maxEntries
+		) {
 			const existingSlot = await db
 				.select({ id: s.bracketEntries.id })
 				.from(s.bracketEntries)
@@ -166,12 +621,16 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 			await db.insert(s.teams).values({
 				id: teamId,
 				seasonId: registration.seasonId,
+				bracketId: bracket.id,
 				name: teamName,
 				slug: `${slugify(teamName)}-${registration.id.slice(-6)}`,
 			});
-			await db
-				.insert(s.teamMembers)
-				.values({ teamId, competitorId, role: "captain" });
+			await db.insert(s.teamMembers).values({
+				teamId,
+				bracketId: bracket.id,
+				competitorId,
+				role: "captain",
+			});
 		}
 
 		await db.insert(s.bracketEntries).values({
@@ -204,7 +663,9 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 
 	async setMatchLiveState(input: unknown): Promise<{ ok: true }> {
 		const data = SetMatchLiveState.parse(input);
-		const patch: Partial<typeof s.matches.$inferInsert> = { status: data.state };
+		const patch: Partial<typeof s.matches.$inferInsert> = {
+			status: data.state,
+		};
 		if (data.state === "live") patch.startedAt = new Date();
 		await this.db
 			.update(s.matches)
@@ -244,6 +705,7 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		startsAt?: number | null;
 		registrationClosesAt?: number | null;
 		maxEntries?: number;
+		teamSize?: number;
 		cadenceDays?: number;
 	}): Promise<{ id: string }> {
 		const id = `bracket-${crypto.randomUUID()}`;
@@ -258,6 +720,7 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 				? new Date(input.registrationClosesAt)
 				: null,
 			maxEntries: input.maxEntries ?? 16,
+			teamSize: input.teamSize ?? 2,
 			cadenceDays: input.cadenceDays ?? 7,
 		});
 		return { id };
@@ -352,14 +815,17 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 	// ---- teams ----
 
 	async createTeam(input: {
-		seasonId: string;
+		bracketId: string;
 		slug: string;
 		name: string;
 	}): Promise<{ id: string }> {
+		const bracket = await this.getBracket(input.bracketId);
+		if (bracket.kind !== "team") throw new Error("team bracket required");
 		const id = `team-${crypto.randomUUID()}`;
 		await this.db.insert(s.teams).values({
 			id,
-			seasonId: input.seasonId,
+			seasonId: bracket.seasonId,
+			bracketId: bracket.id,
 			slug: input.slug,
 			name: input.name,
 		});
@@ -376,8 +842,15 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		competitorId: string;
 		role?: string | null;
 	}): Promise<{ ok: true }> {
+		const team = await this.db
+			.select()
+			.from(s.teams)
+			.where(eq(s.teams.id, input.teamId))
+			.get();
+		if (!team) throw new Error("team not found");
 		await this.db.insert(s.teamMembers).values({
 			teamId: input.teamId,
+			bracketId: team.bracketId,
 			competitorId: input.competitorId,
 			role: input.role ?? null,
 		});
@@ -433,11 +906,16 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		if (input.scenarioId !== undefined) patch.scenarioId = input.scenarioId;
 		if (input.judgeUserId !== undefined) patch.judgeUserId = input.judgeUserId;
 		if (input.scheduledAt !== undefined) {
-			patch.scheduledAt = input.scheduledAt ? new Date(input.scheduledAt) : null;
+			patch.scheduledAt = input.scheduledAt
+				? new Date(input.scheduledAt)
+				: null;
 		}
 		if (input.status !== undefined) patch.status = input.status;
 
-		await this.db.update(s.matches).set(patch).where(eq(s.matches.id, input.matchId));
+		await this.db
+			.update(s.matches)
+			.set(patch)
+			.where(eq(s.matches.id, input.matchId));
 		return { ok: true };
 	}
 }

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/endpoints.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/endpoints.ts
@@ -1,19 +1,12 @@
 import type { ShowEndpointModule, ShowPageContext } from "@/lib/shows/types";
 import { loadLiveMatch, loadSchedule } from "./queries";
 
-// The write-model RPC surface this plugin needs. Bound on the website worker
-// as BRACKETS_WRITE -> platform-brackets-write-model.
 interface BracketsWriteBinding {
-	submitRegistration(input: {
-		showId: string;
+	selfRegisterCompetitor(input: {
 		bracketId: string;
 		displayName: string;
-		email: string;
-		teamName?: string | null;
-		preferredSlot?: number | null;
-		message?: string | null;
-		userId?: string | null;
-	}): Promise<{ id: string }>;
+		userId: string;
+	}): Promise<{ competitorId: string; seasonId: string; bracketKind: string }>;
 }
 
 function escapeICS(value: string): string {
@@ -41,33 +34,33 @@ export function bracketEndpoints(showId: string): ShowEndpointModule[] {
 				if (!write) {
 					return new Response("registration unavailable", { status: 503 });
 				}
+				const user = ctx.locals.user;
+				if (!user) {
+					const returnTo = `/shows/${showId}/apply`;
+					return new Response(null, {
+						status: 303,
+						headers: {
+							Location: `/api/auth/sign-in?returnTo=${encodeURIComponent(returnTo)}`,
+						},
+					});
+				}
 
 				const form = await ctx.request.formData();
 				const bracketId = String(form.get("bracketId") ?? "").trim();
-				const displayName = String(form.get("displayName") ?? "").trim();
-				const email = String(form.get("email") ?? "").trim();
-				const teamName = String(form.get("teamName") ?? "").trim() || null;
-				const message = String(form.get("message") ?? "").trim() || null;
-				const slotRaw = String(form.get("preferredSlot") ?? "").trim();
-				const preferredSlot = slotRaw ? Number.parseInt(slotRaw, 10) : null;
+				const displayName =
+					user.name?.trim() || user.email?.split("@")[0]?.trim() || user.id;
 
-				if (!bracketId || !displayName || !email) {
-					return new Response("bracketId, displayName, email required", {
+				if (!bracketId) {
+					return new Response("bracketId required", {
 						status: 400,
 					});
 				}
 
 				try {
-					await write.submitRegistration({
-						showId,
+					await write.selfRegisterCompetitor({
 						bracketId,
 						displayName,
-						email,
-						teamName,
-						preferredSlot: Number.isFinite(preferredSlot)
-							? preferredSlot
-							: null,
-						message,
+						userId: user.id,
 					});
 				} catch {
 					return new Response("could not submit application", { status: 400 });

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/index.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/index.ts
@@ -11,8 +11,9 @@ import Schedule from "./pages/Schedule.astro";
 import {
 	loadBrackets,
 	loadLeaderboard,
-	loadOpenBrackets,
+	loadMyParticipation,
 	loadSchedule,
+	type BracketsReadBinding,
 } from "./queries";
 
 export type BracketPageSlug = "brackets" | "schedule" | "leaderboard" | "apply";
@@ -62,11 +63,19 @@ export const bracketPlugin: ShowPlugin<BracketPluginConfig> = (
 		apply: {
 			slug: "apply",
 			label: "Apply",
-			load: async (ctx) => ({
-				showId,
-				openBrackets: await loadOpenBrackets(showId),
-				submitted: ctx.url.searchParams.get("submitted") === "1",
-			}),
+			load: async (ctx) => {
+				const readModel =
+					(ctx.env.BRACKETS_READ as BracketsReadBinding | undefined) ?? null;
+				return {
+					showId,
+					isSignedIn: Boolean(ctx.locals.user),
+					participation: await loadMyParticipation(showId, {
+						readModel,
+						user: ctx.locals.user ? { id: ctx.locals.user.id } : null,
+					}),
+					submitted: ctx.url.searchParams.get("submitted") === "1",
+				};
+			},
 			meta: () => ({ title: "Apply to compete" }),
 			Component: Apply,
 		},

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Apply.astro
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Apply.astro
@@ -1,31 +1,42 @@
 ---
-import type { Bracket } from "../queries";
+import type { MyParticipation } from "../queries";
 
 interface Props {
 	showId: string;
-	openBrackets: Bracket[];
+	isSignedIn: boolean;
+	participation: MyParticipation;
 	submitted: boolean;
 }
 
-const { showId, openBrackets, submitted } = Astro.props;
-const hasTeamBracket = openBrackets.some((b) => b.kind === "team");
+const { showId, isSignedIn, participation, submitted } = Astro.props;
+const cards = participation.brackets;
+const applyPath = `/shows/${showId}/apply`;
+const signInUrl = `/api/auth/sign-in?returnTo=${encodeURIComponent(applyPath)}`;
 const actionUrl = `/api/shows/${showId}/apply`;
+const manageUrl = (kind: string) =>
+	kind === "team"
+		? "https://klustered.dev/me/team"
+		: "https://klustered.dev/me/profile";
+const manageLabel = (kind: string, hasTeam: boolean) => {
+	if (kind !== "team") return "Manage your profile";
+	return hasTeam ? "Manage your team" : "Set up your team";
+};
 ---
 
-<div class="mx-auto max-w-xl">
+<div class="mx-auto max-w-3xl">
 	{
 		submitted && (
 			<div
 				class="mb-6 rounded-sm border p-4 text-sm text-primary-content"
 				style="border-color: var(--surface-border); background: var(--surface-raised)"
 			>
-				Thanks for applying. We will be in touch once your entry is reviewed.
+				You are entered. Manage your Klustered details in the competitor portal.
 			</div>
 		)
 	}
 
 	{
-		openBrackets.length === 0 ? (
+		cards.length === 0 ? (
 			<div class="rounded-sm paper-card p-12 text-center">
 				<p class="text-lg font-medium text-secondary-content">
 					Applications are closed
@@ -35,78 +46,65 @@ const actionUrl = `/api/shows/${showId}/apply`;
 				</p>
 			</div>
 		) : (
-			<form method="POST" action={actionUrl} class="flex flex-col gap-4">
-				<label class="flex flex-col gap-1 text-sm">
-					<span class="font-medium text-primary-content">Bracket</span>
-					<select
-						name="bracketId"
-						required
-						class="rounded-sm border bg-transparent px-3 py-2 text-primary-content"
-						style="border-color: var(--surface-border)"
+			<div class="grid gap-4 md:grid-cols-2">
+				{cards.map((card) => (
+					<section
+						class="rounded-sm border p-5"
+						style="border-color: var(--surface-border); background: var(--surface-raised)"
 					>
-						{openBrackets.map((b) => (
-							<option value={b.id}>
-								{b.name} ({b.kind})
-							</option>
-						))}
-					</select>
-				</label>
+						<div class="flex items-start justify-between gap-4">
+							<div>
+								<p class="font-mono text-xs uppercase text-muted">
+									{card.bracketKind === "team" ? "Team" : "Individual"}
+								</p>
+								<h2 class="mt-1 text-xl font-semibold text-primary-content">
+									{card.bracketName}
+								</h2>
+							</div>
+							{card.applied && (
+								<span class="rounded-sm border px-2 py-1 font-mono text-xs uppercase text-primary-content" style="border-color: var(--surface-border)">
+									Entered
+								</span>
+							)}
+						</div>
 
-				<label class="flex flex-col gap-1 text-sm">
-					<span class="font-medium text-primary-content">Display name</span>
-					<input
-						type="text"
-						name="displayName"
-						required
-						class="rounded-sm border bg-transparent px-3 py-2 text-primary-content"
-						style="border-color: var(--surface-border)"
-					/>
-				</label>
+						{card.bracketKind === "team" && (
+							<p class="mt-3 text-sm text-muted">
+								Teams are capped at {card.teamSize} competitors.
+							</p>
+						)}
 
-				<label class="flex flex-col gap-1 text-sm">
-					<span class="font-medium text-primary-content">Email</span>
-					<input
-						type="email"
-						name="email"
-						required
-						class="rounded-sm border bg-transparent px-3 py-2 text-primary-content"
-						style="border-color: var(--surface-border)"
-					/>
-				</label>
-
-				{hasTeamBracket && (
-					<label class="flex flex-col gap-1 text-sm">
-						<span class="font-medium text-primary-content">
-							Team name (team brackets)
-						</span>
-						<input
-							type="text"
-							name="teamName"
-							class="rounded-sm border bg-transparent px-3 py-2 text-primary-content"
-							style="border-color: var(--surface-border)"
-						/>
-					</label>
-				)}
-
-				<label class="flex flex-col gap-1 text-sm">
-					<span class="font-medium text-primary-content">
-						Anything else? (optional)
-					</span>
-					<textarea
-						name="message"
-						rows="3"
-						class="rounded-sm border bg-transparent px-3 py-2 text-primary-content"
-						style="border-color: var(--surface-border)"
-					/>
-				</label>
-
-				<button
-					type="submit"
-					class="focus-ring mt-2 rounded-sm bg-primary px-5 py-2.5 font-semibold text-white"
-				>
-					Apply to compete
-				</button>
-			</form>
+						<div class="mt-5">
+							{!isSignedIn ? (
+								<a
+									href={signInUrl}
+									class="focus-ring inline-flex rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white"
+								>
+									Sign in to apply
+								</a>
+							) : card.applied ? (
+								<a
+									href={manageUrl(card.bracketKind)}
+									class="focus-ring inline-flex rounded-sm border px-4 py-2 text-sm font-semibold text-primary-content"
+									style="border-color: var(--surface-border)"
+								>
+									{manageLabel(card.bracketKind, Boolean(card.team))}
+								</a>
+							) : (
+								<form method="POST" action={actionUrl}>
+									<input type="hidden" name="bracketId" value={card.bracketId} />
+									<button
+										type="submit"
+										class="focus-ring rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white"
+									>
+										Apply
+									</button>
+								</form>
+							)}
+						</div>
+					</section>
+				))}
+			</div>
 		)
 	}
 </div>

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/queries.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/queries.ts
@@ -1,7 +1,5 @@
 import { queryShowsApi } from "@/lib/shows/client";
 
-// Shapes mirror the brackets subgraph fields federated onto `Show`.
-
 export interface BracketSide {
 	kind?: string;
 	id?: string;
@@ -31,10 +29,38 @@ export interface Bracket {
 	format: string;
 	status: string;
 	maxEntries: number;
+	teamSize?: number;
 	startsAt?: string | null;
 	registrationClosesAt?: string | null;
 	entries: BracketSide[];
 	matches: BracketMatch[];
+}
+
+export interface MyTeam {
+	id: string;
+	name: string;
+	slug: string;
+	isCaptain: boolean;
+	memberCount: number;
+}
+
+export interface MyBracketParticipation {
+	bracketId: string;
+	bracketSlug: string;
+	bracketName: string;
+	bracketKind: string;
+	teamSize: number;
+	registrationClosesAt: string | null;
+	applied: boolean;
+	team: MyTeam | null;
+}
+
+export interface MyParticipation {
+	brackets: MyBracketParticipation[];
+}
+
+export interface BracketsReadBinding {
+	fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
 }
 
 export interface Standing {
@@ -63,7 +89,7 @@ export async function loadBrackets(showId: string): Promise<Bracket[]> {
 		`query ShowBrackets($id: String!) {
 			showById(id: $id) {
 				brackets {
-					id slug name kind format status maxEntries startsAt registrationClosesAt
+					id slug name kind format status maxEntries teamSize startsAt registrationClosesAt
 					entries { kind id displayName seed }
 					matches { ${MATCH_FIELDS} }
 				}
@@ -100,12 +126,82 @@ export async function loadOpenBrackets(showId: string): Promise<Bracket[]> {
 	const data = await queryShowsApi<{ showById?: { openBrackets?: Bracket[] } }>(
 		`query ShowOpenBrackets($id: String!) {
 			showById(id: $id) {
-				openBrackets { id slug name kind maxEntries registrationClosesAt }
+				openBrackets { id slug name kind maxEntries teamSize registrationClosesAt }
 			}
 		}`,
 		{ id: showId },
 	);
 	return data?.showById?.openBrackets ?? [];
+}
+
+function participationFromBrackets(brackets: Bracket[]): MyParticipation {
+	return {
+		brackets: brackets.map((bracket) => ({
+			bracketId: bracket.id,
+			bracketSlug: bracket.slug,
+			bracketName: bracket.name,
+			bracketKind: bracket.kind,
+			teamSize: bracket.teamSize ?? 2,
+			registrationClosesAt: bracket.registrationClosesAt ?? null,
+			applied: false,
+			team: null,
+		})),
+	};
+}
+
+export async function loadMyParticipation(
+	showId: string,
+	options: {
+		readModel?: BracketsReadBinding | null;
+		user?: { id: string } | null;
+	} = {},
+): Promise<MyParticipation> {
+	const loadFallback = async () =>
+		participationFromBrackets(await loadOpenBrackets(showId));
+
+	if (!options.readModel) {
+		return loadFallback();
+	}
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (options.user) {
+		headers["X-Gateway-User-Id"] = options.user.id;
+	}
+
+	try {
+		const response = await options.readModel.fetch("https://internal/", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				query: `query MyBracketParticipation($showId: String!) {
+					myBracketParticipation(showId: $showId) {
+						brackets {
+							bracketId
+							bracketSlug
+							bracketName
+							bracketKind
+							teamSize
+							registrationClosesAt
+							applied
+							team { id name slug isCaptain memberCount }
+						}
+					}
+				}`,
+				variables: { showId },
+			}),
+		});
+		if (!response.ok) {
+			return loadFallback();
+		}
+		const json = (await response.json()) as {
+			data?: { myBracketParticipation?: MyParticipation };
+		};
+		return json.data?.myBracketParticipation ?? loadFallback();
+	} catch {
+		return loadFallback();
+	}
 }
 
 export async function loadLiveMatch(

--- a/projects/rawkode.academy/website/src/lib/shows/types.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/types.ts
@@ -10,6 +10,7 @@ export interface ShowPageContext {
 	request: Request;
 	url: URL;
 	env: ShowEnv;
+	locals: App.Locals;
 }
 
 export interface ShowPageMeta {

--- a/projects/rawkode.academy/website/src/pages/api/shows/[showId]/[...slug].ts
+++ b/projects/rawkode.academy/website/src/pages/api/shows/[showId]/[...slug].ts
@@ -5,7 +5,7 @@ import type { ShowEnv } from "@/lib/shows/types";
 
 export const prerender = false;
 
-export const ALL: APIRoute = async ({ params, request, url }) => {
+export const ALL: APIRoute = async ({ locals, params, request, url }) => {
 	const { showId, slug } = params;
 	if (!showId) return new Response(null, { status: 404 });
 
@@ -20,5 +20,6 @@ export const ALL: APIRoute = async ({ params, request, url }) => {
 		request,
 		url,
 		env: env as unknown as ShowEnv,
+		locals,
 	});
 };

--- a/projects/rawkode.academy/website/src/pages/shows/[showId]/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/shows/[showId]/[...slug].astro
@@ -27,6 +27,7 @@ const data = page.load
 			request: Astro.request,
 			url: Astro.url,
 			env: env as unknown as ShowEnv,
+			locals: Astro.locals,
 		})
 	: {};
 

--- a/projects/rawkode.academy/website/wrangler.jsonc
+++ b/projects/rawkode.academy/website/wrangler.jsonc
@@ -43,6 +43,14 @@
 			"service": "platform-watch-history-write-model"
 		},
 		{
+			"binding": "BRACKETS_READ",
+			"service": "platform-brackets-read-model"
+		},
+		{
+			"binding": "BRACKETS_WRITE",
+			"service": "platform-brackets-write-model"
+		},
+		{
 			"binding": "IDENTITY",
 			"service": "rawkode-academy-identity"
 		},


### PR DESCRIPTION
## Summary

- Adds bracket-scoped applications, teams, team members, and team invites to the brackets data model with a destructive migration intended for a D1 reset.
- Adds write-model RPCs for self-registration, team creation, invite creation/revocation, invite joining, team rename, and team leave flows.
- Updates the Rawkode Academy apply page to use a service-bound brackets read model and submit bracket-specific applications.
- Adds Klustered self-service team management, invite join pages, bracket-aware admin forms, and bracket-scoped match/team views.

## Notes

- This intentionally does not preserve backward compatibility for existing D1 data.
- Admin bracket entry seeding remains separate from self-service applications/teams by design.
- The brackets read model is set to service-binding-only behavior so user-scoped participation cannot be spoofed through public headers.

## Validation

- `bun run read-model/publish.ts` in `projects/rawkode.academy/platform/brackets`
- `bun run build` in `projects/rawkode.academy/api`
- `bun run build` in `projects/rawkode.academy/website`
- `bun run build` in `projects/klustered.dev`
- `git diff --check main`

## Review Passes

- Ran deslop review and fixed the real issues it surfaced.
- Ran thermo-nuclear code quality review and found no remaining structural blockers worth holding the PR for.