### PR TITLE
fix(klustered.dev): restore competition registration flow

### DIFF
--- a/projects/klustered.dev/src/db/schema.ts
+++ b/projects/klustered.dev/src/db/schema.ts
@@ -106,7 +106,12 @@ export const bracketApplications = sqliteTable(
 		competitorId: text("competitor_id")
 			.notNull()
 			.references(() => competitors.id, { onDelete: "cascade" }),
+		status: text("status", { enum: ["pending", "approved", "rejected"] })
+			.notNull()
+			.default("pending"),
 		createdAt: createdAt(),
+		reviewedAt: integer("reviewed_at", { mode: "timestamp_ms" }),
+		reviewedByUserId: text("reviewed_by_user_id"),
 	},
 	(t) => [
 		uniqueIndex("bracket_applications_bracket_competitor_unique").on(

--- a/projects/klustered.dev/src/lib/brackets-write.ts
+++ b/projects/klustered.dev/src/lib/brackets-write.ts
@@ -49,6 +49,11 @@ export interface BracketsWrite {
 		decision: "approved" | "rejected";
 		reviewedByUserId: string;
 	}): Promise<{ ok: true }>;
+	decideApplication(input: {
+		applicationId: string;
+		decision: "approved" | "rejected";
+		reviewedByUserId: string;
+	}): Promise<{ ok: true }>;
 	generateBracket(input: {
 		bracketId: string;
 		startsAt?: number | null;
@@ -74,6 +79,14 @@ export interface BracketsWrite {
 		startDate?: number | null;
 		endDate?: number | null;
 	}): Promise<{ id: string }>;
+	updateSeason(input: {
+		id: string;
+		slug?: string | null;
+		name?: string | null;
+		status?: "interest" | "active" | "finished" | null;
+		startDate?: number | null;
+		endDate?: number | null;
+	}): Promise<{ ok: true }>;
 	deleteSeason(input: { id: string }): Promise<{ ok: true }>;
 	createBracket(input: {
 		seasonId: string;
@@ -86,7 +99,20 @@ export interface BracketsWrite {
 		teamSize?: number;
 		cadenceDays?: number;
 	}): Promise<{ id: string }>;
+	updateBracket(input: {
+		id: string;
+		status?: "draft" | "active" | "finished" | null;
+		startsAt?: number | null;
+		registrationClosesAt?: number | null;
+	}): Promise<{ ok: true }>;
 	deleteBracket(input: { id: string }): Promise<{ ok: true }>;
+	createBracketEntry(input: {
+		bracketId: string;
+		competitorId?: string | null;
+		teamId?: string | null;
+		seed?: number | null;
+	}): Promise<{ id: string }>;
+	deleteBracketEntry(input: { id: string }): Promise<{ ok: true }>;
 	createBracketBreak(input: {
 		bracketId: string;
 		label: string;

--- a/projects/klustered.dev/src/pages/admin/brackets.astro
+++ b/projects/klustered.dev/src/pages/admin/brackets.astro
@@ -170,12 +170,22 @@ function formatDateTime(value: Date | null): string {
 									{b.kind === "team" ? `Team (${b.teamSize})` : "Individual"}
 								</td>
 								<td class="px-6 py-3">
-									<span class="rounded-full bg-slate-800 px-2 py-0.5 text-xs text-slate-300 capitalize">
-										{b.status}
-									</span>
+									<form method="POST" action={`/api/admin/brackets/${b.id}/update`} class="flex items-center gap-2">
+										<select
+											name="status"
+											class="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+										>
+											<option value="draft" selected={b.status === "draft"}>Draft</option>
+											<option value="active" selected={b.status === "active"}>Active</option>
+											<option value="finished" selected={b.status === "finished"}>Finished</option>
+										</select>
+										<button class="text-xs text-fuchsia-300 underline-offset-4 hover:underline">
+											Save
+										</button>
+									</form>
 								</td>
 								<td class="px-6 py-3 text-right">
-									<form method="POST" action={`/api/admin/brackets/${b.id}/delete`}>
+									<form method="POST" action={`/api/admin/brackets/${b.id}/delete`} onsubmit="return confirm('Delete this bracket?')">
 										<button class="text-xs text-rose-400 underline-offset-4 hover:underline">
 											Delete
 										</button>

--- a/projects/klustered.dev/src/pages/admin/brackets/[id].astro
+++ b/projects/klustered.dev/src/pages/admin/brackets/[id].astro
@@ -60,6 +60,10 @@ const entries = await db
 	.select({
 		id: schema.bracketEntries.id,
 		displayName: schema.bracketEntries.displayName,
+		seed: schema.bracketEntries.seed,
+		status: schema.bracketEntries.status,
+		competitorId: schema.bracketEntries.competitorId,
+		teamId: schema.bracketEntries.teamId,
 	})
 	.from(schema.bracketEntries)
 	.where(eq(schema.bracketEntries.bracketId, bracket.id))
@@ -67,6 +71,16 @@ const entries = await db
 	.all();
 
 const entryMap = Object.fromEntries(entries.map((e) => [e.id, e.displayName]));
+const competitors = await db
+	.select({
+		id: schema.competitors.id,
+		displayName: schema.competitors.displayName,
+		personSlug: schema.competitors.personSlug,
+	})
+	.from(schema.competitors)
+	.where(eq(schema.competitors.seasonId, bracket.seasonId))
+	.orderBy(asc(schema.competitors.displayName))
+	.all();
 
 const rounds = matches.reduce<Record<number, typeof matches>>((acc, m) => {
 	(acc[m.roundNumber] ??= []).push(m);
@@ -78,6 +92,11 @@ const roundNumbers = Object.keys(rounds)
 
 const entryCount = entries.length;
 const canGenerate = matches.length === 0 && entryCount >= 2;
+const canManageEntries = matches.length === 0;
+const enteredCompetitorIds = new Set(entries.map((e) => e.competitorId).filter(Boolean));
+const enteredTeamIds = new Set(entries.map((e) => e.teamId).filter(Boolean));
+const availableCompetitors = competitors.filter((c) => !enteredCompetitorIds.has(c.id));
+const availableTeams = teams.filter((t) => !enteredTeamIds.has(t.id));
 
 const sideName = (teamId: string | null, entryId: string | null): string =>
 	(teamId ? teamMap[teamId] : null) ??
@@ -98,7 +117,20 @@ function formatScheduled(value: Date | null): string {
 
 	<section class="flex flex-wrap items-center gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 px-6 py-4 text-sm">
 		<span class="text-slate-300">Season: <strong>{bracket.seasonName}</strong></span>
-		<span class="text-slate-300">Status: <strong class="capitalize">{bracket.status}</strong></span>
+		<form method="POST" action={`/api/admin/brackets/${bracket.id}/update`} class="flex items-center gap-2 text-slate-300">
+			<span>Status:</span>
+			<select
+				name="status"
+				class="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+			>
+				<option value="draft" selected={bracket.status === "draft"}>Draft</option>
+				<option value="active" selected={bracket.status === "active"}>Active</option>
+				<option value="finished" selected={bracket.status === "finished"}>Finished</option>
+			</select>
+			<button class="text-xs text-fuchsia-300 underline-offset-4 hover:underline">
+				Save
+			</button>
+		</form>
 		<span class="text-slate-300">Kind: <strong>{bracket.kind === "team" ? `Team (${bracket.teamSize})` : "Individual"}</strong></span>
 		<span class="text-slate-300">Starts: <strong>{formatScheduled(bracket.startsAt)}</strong></span>
 		<span class="text-slate-300">Entries in bracket: <strong>{entryCount}</strong></span>
@@ -115,6 +147,125 @@ function formatScheduled(value: Date | null): string {
 				</form>
 			)
 		}
+	</section>
+
+	<section class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+		<div class="flex flex-wrap items-start justify-between gap-4">
+			<div>
+				<h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">
+					Entries
+				</h2>
+				<p class="mt-1 text-sm text-slate-500">
+					Seed approved applicants, teams, or competitors before generating matches.
+				</p>
+			</div>
+			{!canManageEntries && (
+				<span class="rounded-full bg-slate-800 px-3 py-1 text-xs text-slate-400">
+					Locked after generation
+				</span>
+			)}
+		</div>
+
+		<div class="mt-4 overflow-hidden rounded-lg border border-slate-800">
+			<table class="w-full text-left text-sm">
+				<thead class="bg-slate-950/60 text-xs uppercase tracking-wider text-slate-400">
+					<tr>
+						<th class="px-4 py-2">Seed</th>
+						<th class="px-4 py-2">Entry</th>
+						<th class="px-4 py-2">Status</th>
+						<th class="px-4 py-2 text-right">Actions</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-slate-800 bg-slate-950/30">
+					{entries.length === 0 ? (
+						<tr>
+							<td colspan="4" class="px-4 py-4 text-center text-sm text-slate-500">
+								No entries seeded yet.
+							</td>
+						</tr>
+					) : (
+						entries.map((entry) => (
+							<tr>
+								<td class="px-4 py-2 font-mono text-xs text-slate-400">
+									{entry.seed}
+								</td>
+								<td class="px-4 py-2 text-slate-100">{entry.displayName}</td>
+								<td class="px-4 py-2">
+									<span class="rounded-full bg-slate-800 px-2 py-0.5 text-xs capitalize text-slate-300">
+										{entry.status}
+									</span>
+								</td>
+								<td class="px-4 py-2 text-right">
+									{canManageEntries && (
+										<form method="POST" action={`/api/admin/brackets/${bracket.id}/entries/${entry.id}/delete`} onsubmit="return confirm('Remove this bracket entry?')">
+											<button class="text-xs text-rose-400 underline-offset-4 hover:underline">
+												Remove
+											</button>
+										</form>
+									)}
+								</td>
+							</tr>
+						))
+					)}
+				</tbody>
+			</table>
+		</div>
+
+		{canManageEntries && (
+			<form
+				method="POST"
+				action={`/api/admin/brackets/${bracket.id}/entries`}
+				class="mt-4 grid gap-3 sm:grid-cols-4"
+			>
+				<label class="flex flex-col gap-1 sm:col-span-2">
+					<span class="text-xs text-slate-400">
+						{bracket.kind === "team" ? "Team" : "Competitor"}
+					</span>
+					{bracket.kind === "team" ? (
+						<select
+							name="teamId"
+							required
+							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+						>
+							<option value="">Select team</option>
+							{availableTeams.map((team) => (
+								<option value={team.id}>{team.name}</option>
+							))}
+						</select>
+					) : (
+						<select
+							name="competitorId"
+							required
+							class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+						>
+							<option value="">Select competitor</option>
+							{availableCompetitors.map((competitor) => (
+								<option value={competitor.id}>{competitor.displayName}</option>
+							))}
+						</select>
+					)}
+				</label>
+				<label class="flex flex-col gap-1">
+					<span class="text-xs text-slate-400">Seed</span>
+					<input
+						type="number"
+						name="seed"
+						min="1"
+						max={entries.length + Math.max(availableCompetitors.length, availableTeams.length) + 1}
+						placeholder={String(entryCount + 1)}
+						class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-1.5 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+					/>
+				</label>
+				<div class="flex items-end">
+					<button
+						class="rounded-lg bg-fuchsia-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-fuchsia-400 disabled:cursor-not-allowed disabled:bg-slate-700"
+						disabled={bracket.kind === "team" ? availableTeams.length === 0 : availableCompetitors.length === 0}
+					>
+						Add entry
+					</button>
+				</div>
+			</form>
+		)}
 	</section>
 
 	{

--- a/projects/klustered.dev/src/pages/admin/registrations.astro
+++ b/projects/klustered.dev/src/pages/admin/registrations.astro
@@ -1,25 +1,47 @@
 ---
 import { env } from "cloudflare:workers";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import PortalLayout from "@/layouts/PortalLayout.astro";
 import { getBracketsDb, schema } from "@/db/client";
 import { ADMIN_NAV } from "@/lib/nav";
 
 const db = getBracketsDb(env.BRACKETS);
-const registrations = await db
+const applications = await db
 	.select({
-		id: schema.registrations.id,
-		seasonId: schema.registrations.seasonId,
+		id: schema.bracketApplications.id,
+		seasonId: schema.brackets.seasonId,
 		seasonName: schema.seasons.name,
-		displayName: schema.registrations.displayName,
-		email: schema.registrations.email,
-		message: schema.registrations.message,
-		status: schema.registrations.status,
-		submittedAt: schema.registrations.submittedAt,
+		bracketName: schema.brackets.name,
+		bracketKind: schema.brackets.kind,
+		displayName: schema.competitors.displayName,
+		userId: schema.competitors.userId,
+		status: schema.bracketApplications.status,
+		submittedAt: schema.bracketApplications.createdAt,
+		teamId: schema.teams.id,
+		teamName: schema.teams.name,
 	})
-	.from(schema.registrations)
-	.leftJoin(schema.seasons, eq(schema.registrations.seasonId, schema.seasons.id))
-	.orderBy(desc(schema.registrations.submittedAt))
+	.from(schema.bracketApplications)
+	.innerJoin(
+		schema.brackets,
+		eq(schema.bracketApplications.bracketId, schema.brackets.id),
+	)
+	.innerJoin(schema.seasons, eq(schema.brackets.seasonId, schema.seasons.id))
+	.innerJoin(
+		schema.competitors,
+		eq(schema.bracketApplications.competitorId, schema.competitors.id),
+	)
+	.leftJoin(
+		schema.teamMembers,
+		and(
+			eq(schema.teamMembers.bracketId, schema.bracketApplications.bracketId),
+			eq(
+				schema.teamMembers.competitorId,
+				schema.bracketApplications.competitorId,
+			),
+		),
+	)
+	.leftJoin(schema.teams, eq(schema.teamMembers.teamId, schema.teams.id))
+	.orderBy(desc(schema.bracketApplications.createdAt))
 	.all();
 
 function formatDate(value: Date | null): string {
@@ -36,7 +58,7 @@ const statusClass: Record<string, string> = {
 
 <PortalLayout title="Registrations" section="admin" nav={[...ADMIN_NAV]}>
 	<p class="text-sm text-slate-400">
-		Applications submitted via the public site's <code class="rounded bg-slate-800 px-1 py-0.5 text-xs">/apply</code> form. Approve or reject — approved entries can then be turned into competitors and added to teams.
+		Applications submitted by signed-in members on the public site. Approving an application seeds it into the bracket when the required competitor or team exists.
 	</p>
 
 	<section class="overflow-hidden rounded-2xl border border-slate-800">
@@ -45,32 +67,40 @@ const statusClass: Record<string, string> = {
 				<tr>
 					<th class="px-6 py-3">Submitted</th>
 					<th class="px-6 py-3">Season</th>
+					<th class="px-6 py-3">Bracket</th>
 					<th class="px-6 py-3">Applicant</th>
-					<th class="px-6 py-3">Email</th>
 					<th class="px-6 py-3">Status</th>
 					<th class="px-6 py-3 text-right">Actions</th>
 				</tr>
 			</thead>
 			<tbody class="divide-y divide-slate-800 bg-slate-950/40">
 				{
-					registrations.length === 0 ? (
+					applications.length === 0 ? (
 						<tr>
 							<td colspan="6" class="px-6 py-6 text-center text-sm text-slate-500">
 								No applications yet.
 							</td>
 						</tr>
 					) : (
-						registrations.map((r) => (
+						applications.map((r) => {
+							const canApprove = r.bracketKind !== "team" || Boolean(r.teamId);
+							return (
 							<tr>
 								<td class="px-6 py-3 text-slate-400">{formatDate(r.submittedAt)}</td>
 								<td class="px-6 py-3 text-slate-400">{r.seasonName}</td>
 								<td class="px-6 py-3">
-									<div class="text-slate-100">{r.displayName}</div>
-									{r.message && (
-										<div class="mt-1 text-xs text-slate-400">{r.message}</div>
-									)}
+									<div class="text-slate-100">{r.bracketName}</div>
+									<div class="mt-1 text-xs capitalize text-slate-400">{r.bracketKind}</div>
 								</td>
-								<td class="px-6 py-3 font-mono text-xs text-slate-300">{r.email}</td>
+								<td class="px-6 py-3">
+									<div class="text-slate-100">{r.displayName}</div>
+									{r.teamName ? (
+										<div class="mt-1 text-xs text-slate-400">Team: {r.teamName}</div>
+									) : r.bracketKind === "team" ? (
+										<div class="mt-1 text-xs text-amber-300">No team yet</div>
+									) : null}
+									{r.userId && <div class="mt-1 font-mono text-xs text-slate-500">{r.userId}</div>}
+								</td>
 								<td class="px-6 py-3">
 									<span class={`rounded-full px-2 py-0.5 text-xs capitalize ${statusClass[r.status]}`}>
 										{r.status}
@@ -78,13 +108,16 @@ const statusClass: Record<string, string> = {
 								</td>
 								<td class="px-6 py-3">
 									<div class="flex justify-end gap-3 text-xs">
-										{r.status !== "approved" && (
+										{r.status !== "approved" && canApprove && (
 											<form method="POST" action={`/api/admin/registrations/${r.id}/decide`}>
 												<input type="hidden" name="status" value="approved" />
 												<button class="text-emerald-300 underline-offset-4 hover:underline">
 													Approve
 												</button>
 											</form>
+										)}
+										{r.status !== "approved" && !canApprove && (
+											<span class="text-slate-500">Awaiting team</span>
 										)}
 										{r.status !== "rejected" && (
 											<form method="POST" action={`/api/admin/registrations/${r.id}/decide`}>
@@ -97,7 +130,8 @@ const statusClass: Record<string, string> = {
 									</div>
 								</td>
 							</tr>
-						))
+							);
+						})
 					)
 				}
 			</tbody>

--- a/projects/klustered.dev/src/pages/admin/seasons.astro
+++ b/projects/klustered.dev/src/pages/admin/seasons.astro
@@ -93,13 +93,23 @@ function formatDate(value: Date | null): string {
 								<td class="px-6 py-3 font-mono text-xs text-slate-300">{s.slug}</td>
 								<td class="px-6 py-3">{s.name}</td>
 								<td class="px-6 py-3">
-									<span class="rounded-full bg-slate-800 px-2 py-0.5 text-xs text-slate-300">
-										{s.status}
-									</span>
+									<form method="POST" action={`/api/admin/seasons/${s.id}/update`} class="flex items-center gap-2">
+										<select
+											name="status"
+											class="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-100 focus:border-fuchsia-500 focus:outline-none"
+										>
+											<option value="interest" selected={s.status === "interest"}>Interest</option>
+											<option value="active" selected={s.status === "active"}>Active</option>
+											<option value="finished" selected={s.status === "finished"}>Finished</option>
+										</select>
+										<button class="text-xs text-fuchsia-300 underline-offset-4 hover:underline">
+											Save
+										</button>
+									</form>
 								</td>
 								<td class="px-6 py-3 text-slate-400">{formatDate(s.createdAt)}</td>
 								<td class="px-6 py-3 text-right">
-									<form method="POST" action={`/api/admin/seasons/${s.id}/delete`}>
+									<form method="POST" action={`/api/admin/seasons/${s.id}/delete`} onsubmit="return confirm('Delete this season?')">
 										<button class="text-xs text-rose-400 underline-offset-4 hover:underline">
 											Delete
 										</button>

--- a/projects/klustered.dev/src/pages/api/admin/brackets/[id]/entries.ts
+++ b/projects/klustered.dev/src/pages/api/admin/brackets/[id]/entries.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { bracketsWrite } from "@/lib/brackets-write";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
+	if (!locals.roles.includes("admin")) {
+		return new Response("Forbidden", { status: 403 });
+	}
+
+	const bracketId = params.id;
+	if (!bracketId) return new Response("missing bracket id", { status: 400 });
+
+	const form = await request.formData();
+	const competitorId = String(form.get("competitorId") ?? "").trim() || null;
+	const teamId = String(form.get("teamId") ?? "").trim() || null;
+	const seedRaw = Number.parseInt(String(form.get("seed") ?? "").trim(), 10);
+	const seed = Number.isFinite(seedRaw) && seedRaw > 0 ? seedRaw : null;
+
+	await bracketsWrite(env).createBracketEntry({
+		bracketId,
+		competitorId,
+		teamId,
+		seed,
+	});
+
+	return redirect(`/admin/brackets/${bracketId}`, 303);
+};

--- a/projects/klustered.dev/src/pages/api/admin/brackets/[id]/entries/[entryId]/delete.ts
+++ b/projects/klustered.dev/src/pages/api/admin/brackets/[id]/entries/[entryId]/delete.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { bracketsWrite } from "@/lib/brackets-write";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+	if (!locals.roles.includes("admin")) {
+		return new Response("Forbidden", { status: 403 });
+	}
+
+	const bracketId = params.id;
+	const entryId = params.entryId;
+	if (!bracketId || !entryId) {
+		return new Response("missing bracket or entry id", { status: 400 });
+	}
+
+	await bracketsWrite(env).deleteBracketEntry({ id: entryId });
+
+	return redirect(`/admin/brackets/${bracketId}`, 303);
+};

--- a/projects/klustered.dev/src/pages/api/admin/brackets/[id]/update.ts
+++ b/projects/klustered.dev/src/pages/api/admin/brackets/[id]/update.ts
@@ -4,11 +4,11 @@ import { bracketsWrite } from "@/lib/brackets-write";
 
 export const prerender = false;
 
-const VALID = ["approved", "rejected"] as const;
-type Decision = (typeof VALID)[number];
+const VALID_STATUS = ["draft", "active", "finished"] as const;
+type Status = (typeof VALID_STATUS)[number];
 
-function isDecision(v: string): v is Decision {
-	return (VALID as readonly string[]).includes(v);
+function isStatus(value: string): value is Status {
+	return (VALID_STATUS as readonly string[]).includes(value);
 }
 
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
@@ -21,15 +21,11 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
 
 	const form = await request.formData();
 	const status = String(form.get("status") ?? "").trim();
-	if (!isDecision(status)) {
+	if (!isStatus(status)) {
 		return new Response("invalid status", { status: 400 });
 	}
 
-	await bracketsWrite(env).decideApplication({
-		applicationId: id,
-		decision: status,
-		reviewedByUserId: locals.user?.id ?? "",
-	});
+	await bracketsWrite(env).updateBracket({ id, status });
 
-	return redirect("/admin/registrations", 303);
+	return redirect(request.headers.get("Referer") ?? "/admin/brackets", 303);
 };

--- a/projects/klustered.dev/src/pages/api/admin/seasons/[id]/update.ts
+++ b/projects/klustered.dev/src/pages/api/admin/seasons/[id]/update.ts
@@ -4,11 +4,11 @@ import { bracketsWrite } from "@/lib/brackets-write";
 
 export const prerender = false;
 
-const VALID = ["approved", "rejected"] as const;
-type Decision = (typeof VALID)[number];
+const VALID_STATUS = ["interest", "active", "finished"] as const;
+type Status = (typeof VALID_STATUS)[number];
 
-function isDecision(v: string): v is Decision {
-	return (VALID as readonly string[]).includes(v);
+function isStatus(value: string): value is Status {
+	return (VALID_STATUS as readonly string[]).includes(value);
 }
 
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
@@ -21,15 +21,11 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
 
 	const form = await request.formData();
 	const status = String(form.get("status") ?? "").trim();
-	if (!isDecision(status)) {
+	if (!isStatus(status)) {
 		return new Response("invalid status", { status: 400 });
 	}
 
-	await bracketsWrite(env).decideApplication({
-		applicationId: id,
-		decision: status,
-		reviewedByUserId: locals.user?.id ?? "",
-	});
+	await bracketsWrite(env).updateSeason({ id, status });
 
-	return redirect("/admin/registrations", 303);
+	return redirect("/admin/seasons", 303);
 };

--- a/projects/rawkode.academy/codegen/platform-service.cue
+++ b/projects/rawkode.academy/codegen/platform-service.cue
@@ -573,6 +573,9 @@ import (
 				const yoga = createYoga({
 					schema: getSchema(env),
 					graphqlEndpoint: "/",
+					context: ({ request }) => ({
+						userId: request.headers.get("X-Gateway-User-Id"),
+					}),
 				});
 
 				return yoga.fetch(request, env, ctx);

--- a/projects/rawkode.academy/platform/brackets/data-model/integrations/zod.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/integrations/zod.ts
@@ -23,6 +23,13 @@ export const DecideRegistration = z.object({
 });
 export type DecideRegistration = z.infer<typeof DecideRegistration>;
 
+export const DecideApplication = z.object({
+	applicationId: z.string().min(1),
+	decision: z.enum(["approved", "rejected"]),
+	reviewedByUserId: z.string().min(1),
+});
+export type DecideApplication = z.infer<typeof DecideApplication>;
+
 export const GenerateBracket = z.object({
 	bracketId: z.string().min(1),
 	// Optional override of the first match time; defaults to bracket.startsAt.

--- a/projects/rawkode.academy/platform/brackets/data-model/migrations/0003_application_status.sql
+++ b/projects/rawkode.academy/platform/brackets/data-model/migrations/0003_application_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `bracket_applications` ADD `status` text DEFAULT 'pending' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `bracket_applications` ADD `reviewed_at` integer;
+--> statement-breakpoint
+ALTER TABLE `bracket_applications` ADD `reviewed_by_user_id` text;

--- a/projects/rawkode.academy/platform/brackets/data-model/migrations/meta/_journal.json
+++ b/projects/rawkode.academy/platform/brackets/data-model/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1779734400000,
 			"tag": "0002_remove_scenarios_and_default_team_size",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1779740000000,
+			"tag": "0003_application_status",
+			"breakpoints": true
 		}
 	]
 }

--- a/projects/rawkode.academy/platform/brackets/data-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/data-model/schema.ts
@@ -107,7 +107,12 @@ export const bracketApplications = sqliteTable(
 		competitorId: text("competitor_id")
 			.notNull()
 			.references(() => competitors.id, { onDelete: "cascade" }),
+		status: text("status", { enum: ["pending", "approved", "rejected"] })
+			.notNull()
+			.default("pending"),
 		createdAt: createdAt(),
+		reviewedAt: integer("reviewed_at", { mode: "timestamp_ms" }),
+		reviewedByUserId: text("reviewed_by_user_id"),
 	},
 	(t) => [
 		uniqueIndex("bracket_applications_bracket_competitor_unique").on(

--- a/projects/rawkode.academy/platform/brackets/read-model/schema.ts
+++ b/projects/rawkode.academy/platform/brackets/read-model/schema.ts
@@ -353,7 +353,10 @@ const createBuilder = (env: { DB: D1Database }) => {
 
 			if (competitor) {
 				const application = await db
-					.select({ id: s.bracketApplications.id })
+					.select({
+						id: s.bracketApplications.id,
+						status: s.bracketApplications.status,
+					})
 					.from(s.bracketApplications)
 					.where(
 						and(
@@ -362,7 +365,7 @@ const createBuilder = (env: { DB: D1Database }) => {
 						),
 					)
 					.get();
-				applied = Boolean(application);
+				applied = Boolean(application && application.status !== "rejected");
 
 				if (bracket.kind === "team") {
 					const membership = await db

--- a/projects/rawkode.academy/platform/brackets/write-model/main.ts
+++ b/projects/rawkode.academy/platform/brackets/write-model/main.ts
@@ -5,6 +5,7 @@ import { createId } from "@paralleldrive/cuid2";
 import * as s from "../data-model/schema";
 import {
 	CreateTeamInvite,
+	DecideApplication,
 	DecideRegistration,
 	FormTeam,
 	GenerateBracket,
@@ -174,6 +175,33 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		bracketId: string,
 		competitorId: string,
 	): Promise<void> {
+		const existing = await this.db
+			.select({
+				id: s.bracketApplications.id,
+				status: s.bracketApplications.status,
+			})
+			.from(s.bracketApplications)
+			.where(
+				and(
+					eq(s.bracketApplications.bracketId, bracketId),
+					eq(s.bracketApplications.competitorId, competitorId),
+				),
+			)
+			.get();
+		if (existing) {
+			if (existing.status === "rejected") {
+				await this.db
+					.update(s.bracketApplications)
+					.set({
+						status: "pending",
+						reviewedAt: null,
+						reviewedByUserId: null,
+					})
+					.where(eq(s.bracketApplications.id, existing.id));
+			}
+			return;
+		}
+
 		await this.db
 			.insert(s.bracketApplications)
 			.values({
@@ -194,7 +222,10 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		competitorId: string,
 	): Promise<void> {
 		const application = await this.db
-			.select({ id: s.bracketApplications.id })
+			.select({
+				id: s.bracketApplications.id,
+				status: s.bracketApplications.status,
+			})
 			.from(s.bracketApplications)
 			.where(
 				and(
@@ -203,7 +234,9 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 				),
 			)
 			.get();
-		if (!application) throw new Error("apply before forming a team");
+		if (!application || application.status === "rejected") {
+			throw new Error("apply before forming a team");
+		}
 	}
 
 	private async membershipForCompetitor(
@@ -229,6 +262,45 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 			.where(eq(s.teamMembers.teamId, teamId))
 			.all();
 		return members.length;
+	}
+
+	private async nextAvailableSeed(
+		bracketId: string,
+		maxEntries: number,
+		preferredSeed?: number | null,
+	): Promise<number> {
+		if (preferredSeed && preferredSeed > 0 && preferredSeed <= maxEntries) {
+			const existingSlot = await this.db
+				.select({ id: s.bracketEntries.id })
+				.from(s.bracketEntries)
+				.where(
+					and(
+						eq(s.bracketEntries.bracketId, bracketId),
+						eq(s.bracketEntries.seed, preferredSeed),
+					),
+				)
+				.get();
+			if (!existingSlot) return preferredSeed;
+		}
+
+		const lastEntry = await this.db
+			.select({ seed: s.bracketEntries.seed })
+			.from(s.bracketEntries)
+			.where(eq(s.bracketEntries.bracketId, bracketId))
+			.orderBy(desc(s.bracketEntries.seed))
+			.get();
+		const seed = (lastEntry?.seed ?? 0) + 1;
+		if (seed > maxEntries) throw new Error("bracket full");
+		return seed;
+	}
+
+	private async requireEntriesEditable(bracketId: string): Promise<void> {
+		const match = await this.db
+			.select({ id: s.matches.id })
+			.from(s.matches)
+			.where(eq(s.matches.bracketId, bracketId))
+			.get();
+		if (match) throw new Error("entries locked after matches are generated");
 	}
 
 	private async requireTeamActor(
@@ -551,6 +623,101 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		return { ok: true };
 	}
 
+	async decideApplication(input: unknown): Promise<{ ok: true }> {
+		const data = DecideApplication.parse(input);
+
+		if (data.decision === "approved") {
+			await this.createBracketEntryFromApplication(data.applicationId);
+		}
+
+		await this.db
+			.update(s.bracketApplications)
+			.set({
+				status: data.decision,
+				reviewedAt: new Date(),
+				reviewedByUserId: data.reviewedByUserId,
+			})
+			.where(eq(s.bracketApplications.id, data.applicationId));
+
+		return { ok: true };
+	}
+
+	private async createBracketEntryFromApplication(
+		applicationId: string,
+	): Promise<void> {
+		const application = await this.db
+			.select({
+				id: s.bracketApplications.id,
+				bracketId: s.bracketApplications.bracketId,
+				competitorId: s.bracketApplications.competitorId,
+				bracketKind: s.brackets.kind,
+				maxEntries: s.brackets.maxEntries,
+				competitorName: s.competitors.displayName,
+				teamId: s.teams.id,
+				teamName: s.teams.name,
+			})
+			.from(s.bracketApplications)
+			.innerJoin(
+				s.brackets,
+				eq(s.bracketApplications.bracketId, s.brackets.id),
+			)
+			.innerJoin(
+				s.competitors,
+				eq(s.bracketApplications.competitorId, s.competitors.id),
+			)
+			.leftJoin(
+				s.teamMembers,
+				and(
+					eq(s.teamMembers.bracketId, s.bracketApplications.bracketId),
+					eq(s.teamMembers.competitorId, s.bracketApplications.competitorId),
+				),
+			)
+			.leftJoin(s.teams, eq(s.teamMembers.teamId, s.teams.id))
+			.where(eq(s.bracketApplications.id, applicationId))
+			.get();
+		if (!application) throw new Error("application not found");
+
+		const existing = await this.db
+			.select({ id: s.bracketEntries.id })
+			.from(s.bracketEntries)
+			.where(
+				application.bracketKind === "team"
+					? and(
+							eq(s.bracketEntries.bracketId, application.bracketId),
+							eq(s.bracketEntries.teamId, application.teamId ?? ""),
+						)
+					: and(
+							eq(s.bracketEntries.bracketId, application.bracketId),
+							eq(s.bracketEntries.competitorId, application.competitorId),
+						),
+			)
+			.get();
+		if (existing) return;
+
+		if (application.bracketKind === "team" && !application.teamId) {
+			throw new Error("team required before approving application");
+		}
+
+		await this.requireEntriesEditable(application.bracketId);
+		const seed = await this.nextAvailableSeed(
+			application.bracketId,
+			application.maxEntries,
+		);
+		await this.db.insert(s.bracketEntries).values({
+			id: `entry-${application.id}`,
+			bracketId: application.bracketId,
+			competitorId:
+				application.bracketKind === "solo" ? application.competitorId : null,
+			teamId: application.bracketKind === "team" ? application.teamId : null,
+			displayName:
+				application.bracketKind === "team"
+					? (application.teamName ?? application.competitorName)
+					: application.competitorName,
+			seed,
+			status: "confirmed",
+		});
+	}
+
 	private async createBracketEntryFromRegistration(
 		registrationId: string,
 	): Promise<void> {
@@ -697,6 +864,33 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 		return { id };
 	}
 
+	async updateSeason(input: {
+		id: string;
+		slug?: string | null;
+		name?: string | null;
+		status?: "interest" | "active" | "finished" | null;
+		startDate?: number | null;
+		endDate?: number | null;
+	}): Promise<{ ok: true }> {
+		const patch: Partial<typeof s.seasons.$inferInsert> = {};
+		if (input.slug) patch.slug = input.slug;
+		if (input.name) patch.name = input.name;
+		if (input.status) patch.status = input.status;
+		if (input.startDate !== undefined) {
+			patch.startDate = input.startDate ? new Date(input.startDate) : null;
+		}
+		if (input.endDate !== undefined) {
+			patch.endDate = input.endDate ? new Date(input.endDate) : null;
+		}
+		if (Object.keys(patch).length > 0) {
+			await this.db
+				.update(s.seasons)
+				.set(patch)
+				.where(eq(s.seasons.id, input.id));
+		}
+		return { ok: true };
+	}
+
 	async createBracket(input: {
 		seasonId: string;
 		name: string;
@@ -727,6 +921,107 @@ export class BracketsWriteModel extends WorkerEntrypoint<Env> {
 			cadenceDays: input.cadenceDays ?? 7,
 		});
 		return { id };
+	}
+
+	async updateBracket(input: {
+		id: string;
+		status?: "draft" | "active" | "finished" | null;
+		startsAt?: number | null;
+		registrationClosesAt?: number | null;
+	}): Promise<{ ok: true }> {
+		const patch: Partial<typeof s.brackets.$inferInsert> = {};
+		if (input.status) patch.status = input.status;
+		if (input.startsAt !== undefined) {
+			if (!input.startsAt) throw new Error("startsAt required");
+			patch.startsAt = new Date(input.startsAt);
+		}
+		if (input.registrationClosesAt !== undefined) {
+			patch.registrationClosesAt = input.registrationClosesAt
+				? new Date(input.registrationClosesAt)
+				: null;
+		}
+		if (Object.keys(patch).length > 0) {
+			await this.db
+				.update(s.brackets)
+				.set(patch)
+				.where(eq(s.brackets.id, input.id));
+		}
+		return { ok: true };
+	}
+
+	async createBracketEntry(input: {
+		bracketId: string;
+		competitorId?: string | null;
+		teamId?: string | null;
+		seed?: number | null;
+	}): Promise<{ id: string }> {
+		const bracket = await this.getBracket(input.bracketId);
+		await this.requireEntriesEditable(bracket.id);
+		const seed = await this.nextAvailableSeed(
+			bracket.id,
+			bracket.maxEntries,
+			input.seed,
+		);
+
+		let competitorId: string | null = null;
+		let teamId: string | null = null;
+		let displayName: string;
+		if (bracket.kind === "team") {
+			if (!input.teamId) throw new Error("teamId required");
+			const team = await this.db
+				.select()
+				.from(s.teams)
+				.where(
+					and(
+						eq(s.teams.id, input.teamId),
+						eq(s.teams.bracketId, bracket.id),
+					),
+				)
+				.get();
+			if (!team) throw new Error("team not found");
+			teamId = team.id;
+			displayName = team.name;
+		} else {
+			if (!input.competitorId) throw new Error("competitorId required");
+			const competitor = await this.db
+				.select()
+				.from(s.competitors)
+				.where(
+					and(
+						eq(s.competitors.id, input.competitorId),
+						eq(s.competitors.seasonId, bracket.seasonId),
+					),
+				)
+				.get();
+			if (!competitor) throw new Error("competitor not found");
+			competitorId = competitor.id;
+			displayName = competitor.displayName;
+		}
+
+		const id = `entry-${crypto.randomUUID()}`;
+		await this.db.insert(s.bracketEntries).values({
+			id,
+			bracketId: bracket.id,
+			competitorId,
+			teamId,
+			displayName,
+			seed,
+			status: "confirmed",
+		});
+		return { id };
+	}
+
+	async deleteBracketEntry(input: { id: string }): Promise<{ ok: true }> {
+		const entry = await this.db
+			.select({ bracketId: s.bracketEntries.bracketId })
+			.from(s.bracketEntries)
+			.where(eq(s.bracketEntries.id, input.id))
+			.get();
+		if (entry) await this.requireEntriesEditable(entry.bracketId);
+		await this.db
+			.delete(s.bracketEntries)
+			.where(eq(s.bracketEntries.id, input.id));
+		return { ok: true };
 	}
 
 	async createBracketBreak(input: {

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/index.ts
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/index.ts
@@ -76,7 +76,6 @@ export const bracketPlugin: ShowPlugin<BracketPluginConfig> = (
 		apply: {
 			slug: "apply",
 			label: "Apply",
-			hidden: true,
 			load: async (ctx) => {
 				const readModel = requireBracketsReadBinding(ctx.env);
 				return {

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Apply.astro
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Apply.astro
@@ -30,7 +30,7 @@ const manageLabel = (kind: string, hasTeam: boolean) => {
 				class="mb-6 rounded-sm border p-4 text-sm text-primary-content"
 				style="border-color: var(--surface-border); background: var(--surface-raised)"
 			>
-				You are entered. Manage your Klustered details in the competitor portal.
+				Application saved. Current entry status is reflected below.
 			</div>
 		)
 	}
@@ -97,7 +97,7 @@ const manageLabel = (kind: string, hasTeam: boolean) => {
 										type="submit"
 										class="focus-ring rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white"
 									>
-										Apply
+										Apply for {card.bracketKind === "team" ? "Team" : "Individual"}
 									</button>
 								</form>
 							)}

--- a/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Seasons.astro
+++ b/projects/rawkode.academy/website/src/lib/shows/plugins/bracket/pages/Seasons.astro
@@ -60,7 +60,7 @@ function fmtRange(season: BracketSeason): string {
 						<div class="mt-5 grid gap-3 md:grid-cols-2">
 							{season.brackets.map((bracket) => (
 								<a
-									href={`/shows/${showId}/brackets`}
+									href={`/shows/${showId}/apply`}
 									class="focus-ring rounded-sm border p-4 transition-colors hover:border-primary"
 									style="border-color: var(--surface-border)"
 								>
@@ -81,6 +81,9 @@ function fmtRange(season: BracketSeason): string {
 									</div>
 									<p class="mt-3 text-sm text-muted">
 										Starts {fmt(bracket.startsAt)}
+									</p>
+									<p class="mt-3 text-sm font-medium text-primary-content">
+										Apply or manage entry
 									</p>
 								</a>
 							))}


### PR DESCRIPTION
## What
- Route signed-in public applications into the canonical bracket_applications queue and show Apply in Klustered navigation.
- Preserve X-Gateway-User-Id in generated read-model workers by fixing platform-service.cue.
- Add admin review, season/bracket status updates, entry seeding/removal, and delete confirmations.
- Add an application-status migration so review state survives database resets and approvals create bracket entries.

## Why
Logged-in members could submit applications but admin review read the legacy registrations table, so applications never appeared for approval and brackets stayed empty. Admin also had no controls to activate seasons/brackets or seed entries before generating matches.

## Impact
Admins can now approve/reject member applications, seed entries, activate seasons/brackets, and generate once enough entries exist. Public Klustered pages expose the Apply path and signed-in application state can resolve through the gateway user header.

## Checks
- cuenv sync codegen --check
- bun run build (projects/klustered.dev)
- bun run build (projects/rawkode.academy/website)
- WRANGLER_LOG_PATH=/private/tmp/wrangler-read.log bun x wrangler deploy --dry-run --config read-model/wrangler.jsonc
- WRANGLER_LOG_PATH=/private/tmp/wrangler-write.log bun x wrangler deploy --dry-run --config write-model/wrangler.jsonc
- Browser local check attempted; public page is blocked locally by BRACKETS_READ 503 and admin login is blocked by invalid localhost redirect URI, so live browser flow needs the deployed preview/production service bindings.