### PR TITLE
feat(code): deploy comtrya instance

### DIFF
--- a/.github/workflows/code-rawkode-academy-gitops-oci.yml
+++ b/.github/workflows/code-rawkode-academy-gitops-oci.yml
@@ -1,0 +1,41 @@
+name: code-rawkode-academy-gitops-oci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/code-rawkode-academy-gitops-oci.yml
+      - projects/code.rawkode.academy/gitops/**
+  workflow_dispatch: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+  packages: write
+jobs:
+  publish:
+    name: publish-gitops-oci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Flux CLI
+        run: curl -s https://fluxcd.io/install.sh | sudo bash
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push GitOps OCI artifact
+        run: |
+          flux push artifact oci://ghcr.io/rawkode-academy/code-rawkode-academy/gitops:${{ github.sha }} \
+            --path="./projects/code.rawkode.academy/gitops" \
+            --source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}"
+          flux tag artifact oci://ghcr.io/rawkode-academy/code-rawkode-academy/gitops:${{ github.sha }} \
+            --tag=latest

--- a/projects/code.rawkode.academy/config/config.cue
+++ b/projects/code.rawkode.academy/config/config.cue
@@ -1,0 +1,38 @@
+package comtrya
+
+instance: {
+	id:          "code-rawkode-academy"
+	name:        "Rawkode Academy Code"
+	publicURL:   "https://code.rawkode.academy"
+	environment: "production"
+	allowedOrigins: ["https://code.rawkode.academy"]
+}
+
+database: {
+	kind: "sqlite"
+	url:  "sqlite:///app/data/metadata/comtrya.db"
+}
+
+oidc: issuers: [{
+	id:          "rawkode"
+	issuerURL:   "https://id.rawkode.academy"
+	clientID:    "comtrya"
+	clientKind:  "public"
+	redirectURL: "https://code.rawkode.academy/auth/oidc/rawkode/callback"
+	allowed: domains: ["rawkode.academy"]
+}]
+
+storage: repositories: {
+	default: "local"
+	backends: local: {
+		kind: "local"
+		path: "/app/data/repositories"
+	}
+}
+
+authz: kind: "spicedb"
+
+workspaces: default: {
+	name:       "Rawkode Academy"
+	visibility: "PRIVATE"
+}

--- a/projects/code.rawkode.academy/config/cue.mod/module.cue
+++ b/projects/code.rawkode.academy/config/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "rawkode.academy/code/config"
+language: version: "v0.10.0"

--- a/projects/code.rawkode.academy/env.cue
+++ b/projects/code.rawkode.academy/env.cue
@@ -1,0 +1,28 @@
+package cuenv
+
+import "github.com/cuenv/cuenv/schema"
+
+schema.#Project & {
+	name: "code-rawkode-academy"
+
+	let _t = tasks
+
+	tasks: {
+		gitops: schema.#TaskGroup & {
+			type: "group"
+
+			render: schema.#Task & {
+				command: "kubectl"
+				args: ["kustomize", "./gitops"]
+				inputs: ["gitops/**"]
+			}
+
+			publish: schema.#Task & {
+				command: "bash"
+				args: ["-c", "flux push artifact oci://ghcr.io/rawkode-academy/code-rawkode-academy/gitops:${GITHUB_SHA:-local} --path=./gitops --source=${GITHUB_SERVER_URL:-https://github.com}/rawkode-academy/rawkode-academy --revision=${GITHUB_REF_NAME:-local}@sha1:${GITHUB_SHA:-local} && flux tag artifact oci://ghcr.io/rawkode-academy/code-rawkode-academy/gitops:${GITHUB_SHA:-local} --tag=latest"]
+				inputs: ["gitops/**"]
+				dependsOn: [_t.gitops.render]
+			}
+		}
+	}
+}

--- a/projects/code.rawkode.academy/gitops/external-secret.yaml
+++ b/projects/code.rawkode.academy/gitops/external-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: comtrya-server-secrets
+  namespace: code-rawkode-academy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: comtrya-server-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: COMTRYA_OPERATOR_CODE
+      remoteRef:
+        key: /projects/code-rawkode-academy/COMTRYA_OPERATOR_CODE

--- a/projects/code.rawkode.academy/gitops/httproute.yaml
+++ b/projects/code.rawkode.academy/gitops/httproute.yaml
@@ -1,0 +1,44 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: code-rawkode-academy
+  namespace: code-rawkode-academy
+spec:
+  parentRefs:
+    - name: rawkode-cloud
+      namespace: gateway
+      sectionName: https-code-rawkode-academy
+  hostnames:
+    - code.rawkode.academy
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /graphql
+        - path:
+            type: PathPrefix
+            value: /api
+        - path:
+            type: PathPrefix
+            value: /auth
+        - path:
+            type: PathPrefix
+            value: /_extensions
+        - path:
+            type: PathPrefix
+            value: /git
+        - path:
+            type: PathPrefix
+            value: /events
+        - path:
+            type: PathPrefix
+            value: /healthz
+        - path:
+            type: PathPrefix
+            value: /readyz
+      backendRefs:
+        - name: comtrya-server
+          port: 80
+    - backendRefs:
+        - name: comtrya-frontend
+          port: 80

--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -1,0 +1,48 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: code-rawkode-academy
+resources:
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=4659865d49577b5269b394f315ee95737ff0aad6
+  - namespace.yaml
+  - external-secret.yaml
+  - httproute.yaml
+
+images:
+  - name: ghcr.io/comtrya/comtrya-server
+    digest: sha256:3938d1404b38f4769dbbdf79eaa9546cc7c62fb73c0069b74bf099896f6d0fce
+  - name: ghcr.io/comtrya/comtrya-frontend
+    digest: sha256:6f0db8db82bb7a33e450c31f748b8e715e6e6255736510e52d5432c6f0048333
+
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: comtrya
+      $patch: delete
+  - patch: |-
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: comtrya-server-secrets
+      $patch: delete
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: comtrya-server-config
+      data:
+        COMTRYA_CONFIG_REPO_URL: https://github.com/rawkode-academy/rawkode-academy.git
+        COMTRYA_CONFIG_REPO_REF: main
+        COMTRYA_CONFIG_REPO_PATH: projects/code.rawkode.academy/config
+        COMTRYA_CONFIG_REPO_USERNAME: null
+  - patch: |-
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: comtrya-data
+      spec:
+        storageClassName: openebs-single-replica
+        resources:
+          requests:
+            storage: 20Gi

--- a/projects/code.rawkode.academy/gitops/namespace.yaml
+++ b/projects/code.rawkode.academy/gitops/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-rawkode-academy

--- a/projects/rawkode.academy/identity/astro.config.mjs
+++ b/projects/rawkode.academy/identity/astro.config.mjs
@@ -4,6 +4,16 @@ import cloudflare from '@astrojs/cloudflare';
 import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
 
+/** @typedef {Parameters<typeof defineConfig>[0]} AstroUserConfig */
+/** @typedef {NonNullable<NonNullable<AstroUserConfig['vite']>['plugins']>} AstroVitePlugins */
+
+/**
+ * @param {unknown} plugins
+ * @returns {AstroVitePlugins}
+ */
+const asAstroVitePlugins = (plugins) =>
+  /** @type {AstroVitePlugins} */ (plugins);
+
 // https://astro.build/config
 export default defineConfig({
   output: 'server',
@@ -14,7 +24,11 @@ export default defineConfig({
   }),
   integrations: [react()],
   vite: {
-    plugins: [tailwindcss()],
+    // The workspace contains Astro 5/Vite 6 and Astro 6/Vite 7 projects.
+    // @tailwindcss/vite resolves its peer types through the Vite 7 side, while
+    // this identity project builds on Astro 5's Vite 6. Runtime plugin shape is
+    // compatible; keep the cast at the config boundary.
+    plugins: asAstroVitePlugins(tailwindcss()),
     resolve: {
       // Use react-dom/server.edge instead of react-dom/server.browser for React 19.
       // Without this, MessageChannel from node:worker_threads needs to be polyfilled.

--- a/projects/rawkode.academy/identity/src/lib/auth.ts
+++ b/projects/rawkode.academy/identity/src/lib/auth.ts
@@ -154,6 +154,20 @@ export const createAuth = async (env: AuthEnv) => {
 						skipConsent: true,
 						metadata: null,
 					},
+					{
+						clientId: "comtrya",
+						name: "Comtrya",
+						type: "public",
+						// Workaround for https://github.com/better-auth/better-auth/issues/6651
+						// Better Auth incorrectly requires a secret for ID token signing even for public clients
+						clientSecret: "pkce-public-client-placeholder",
+						redirectUrls: [
+							"https://code.rawkode.academy/auth/oidc/rawkode/callback",
+						],
+						disabled: false,
+						skipConsent: true,
+						metadata: null,
+					},
 				],
 			}),
 			organization({

--- a/projects/rawkode.academy/identity/src/pages/.well-known/openid-configuration.ts
+++ b/projects/rawkode.academy/identity/src/pages/.well-known/openid-configuration.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from "astro";
+import { createAuth } from "../../lib/auth";
+
+const handler: APIRoute = async (context) => {
+	const env = context.locals.runtime.env;
+	const auth = await createAuth(env);
+	const url = new URL(context.request.url);
+	url.pathname = "/auth/.well-known/openid-configuration";
+	return auth.handler(new Request(url.toString(), context.request));
+};
+
+export const GET = handler;
+
+export const prerender = false;

--- a/projects/rawkode.cloud/gitops/code-rawkode-academy/flux-kustomization.yaml
+++ b/projects/rawkode.cloud/gitops/code-rawkode-academy/flux-kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: code-rawkode-academy
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: code-rawkode-academy

--- a/projects/rawkode.cloud/gitops/code-rawkode-academy/kustomization.yaml
+++ b/projects/rawkode.cloud/gitops/code-rawkode-academy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - oci-repository.yaml
+  - flux-kustomization.yaml

--- a/projects/rawkode.cloud/gitops/code-rawkode-academy/oci-repository.yaml
+++ b/projects/rawkode.cloud/gitops/code-rawkode-academy/oci-repository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: code-rawkode-academy
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: oci://ghcr.io/rawkode-academy/code-rawkode-academy/gitops
+  ref:
+    tag: latest

--- a/projects/rawkode.cloud/gitops/gateway/gateway.yaml
+++ b/projects/rawkode.cloud/gitops/gateway/gateway.yaml
@@ -36,6 +36,17 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-code-rawkode-academy
+      protocol: HTTPS
+      port: 443
+      hostname: code.rawkode.academy
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: code-rawkode-academy-tls
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: teleport-passthrough
       protocol: TLS
       port: 443

--- a/projects/rawkode.cloud/gitops/kustomization.yaml
+++ b/projects/rawkode.cloud/gitops/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - gateway
   - teleport
   - rawkode-chat
+  - code-rawkode-academy
   - rocko


### PR DESCRIPTION
## Summary

- adds the `code.rawkode.academy` Comtrya deployment project and CUE config
- imports the reusable Comtrya Kustomize base from the merged Comtrya main commit instead of copying server/frontend manifests
- keeps Rawkode-owned GitOps resources to ExternalSecret, HTTPRoute, config/PVC patches, and Flux wiring
- adds the Rawkode Identity OIDC client and root discovery proxy for Comtrya
- uses the public config repository path without config repo username/token secrets

## Dependency

- Comtrya base support was merged in comtrya/comtrya#61 as `4659865d49577b5269b394f315ee95737ff0aad6`

## Validation

- `kubectl kustomize projects/code.rawkode.academy/gitops`
- `kubectl kustomize projects/rawkode.cloud/gitops`
- `cue export ./projects/code.rawkode.academy/config`
