### PR TITLE
feat(rawkode.academy/identity): add per-app access roles

### DIFF
--- a/projects/code.rawkode.academy/config/config.cue
+++ b/projects/code.rawkode.academy/config/config.cue
@@ -19,7 +19,10 @@ oidc: issuers: [{
 	clientID:    "comtrya"
 	clientKind:  "public"
 	redirectURL: "https://code.rawkode.academy/auth/oidc/rawkode/callback"
-	allowed: domains: ["rawkode.academy"]
+	allowed: {
+		domains: ["rawkode.academy"]
+		groups:  ["admin", "maintainer"]
+	}
 }]
 
 storage: repositories: {

--- a/projects/rawkode.academy/identity/migrations/0013_add_access_assignments.sql
+++ b/projects/rawkode.academy/identity/migrations/0013_add_access_assignments.sql
@@ -1,0 +1,38 @@
+-- Seed Comtrya OAuth client for code.rawkode.academy.
+-- Trusted clients are configured in src/lib/auth.ts; the row keeps token FKs valid.
+INSERT INTO oauth_application (id, name, client_id, client_secret, redirect_urls, type, disabled, created_at, updated_at)
+VALUES (
+	'comtrya',
+	'Comtrya',
+	'comtrya',
+	'pkce-public-client-placeholder',
+	'["https://code.rawkode.academy/auth/oidc/rawkode/callback"]',
+	'public',
+	0,
+	unixepoch() * 1000,
+	unixepoch() * 1000
+)
+ON CONFLICT(client_id) DO NOTHING;
+--> statement-breakpoint
+CREATE TABLE `access_assignment` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`client_id` text NOT NULL,
+	`role` text NOT NULL,
+	`granted_by_user_id` text,
+	`reason` text,
+	`expires_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`granted_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `accessAssignment_userClientRole_unique` ON `access_assignment` (`user_id`,`client_id`,`role`);
+--> statement-breakpoint
+CREATE INDEX `accessAssignment_userId_idx` ON `access_assignment` (`user_id`);
+--> statement-breakpoint
+CREATE INDEX `accessAssignment_clientId_idx` ON `access_assignment` (`client_id`);
+--> statement-breakpoint
+CREATE INDEX `accessAssignment_role_idx` ON `access_assignment` (`role`);
+--> statement-breakpoint

--- a/projects/rawkode.academy/identity/migrations/meta/_journal.json
+++ b/projects/rawkode.academy/identity/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779703500000,
       "tag": "0012_add_verification_expires_at_index",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779982680000,
+      "tag": "0013_add_access_assignments",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/rawkode.academy/identity/src/components/admin/App.tsx
+++ b/projects/rawkode.academy/identity/src/components/admin/App.tsx
@@ -7,6 +7,7 @@ import { Layout } from "./Layout";
 import { OrganizationList, OrganizationCreate, OrganizationEdit, OrganizationShow } from "./organizations";
 import { MemberList, MemberCreate } from "./members";
 import { TeamList, TeamCreate } from "./teams";
+import { AccessList } from "./access";
 
 export function AdminApp() {
 	return (
@@ -43,6 +44,21 @@ export function AdminApp() {
 						},
 					},
 					{
+						name: "access-assignments",
+						list: "/access",
+						meta: {
+							label: "Access",
+						},
+					},
+					{
+						name: "access-applications",
+						list: "/access-applications",
+						meta: {
+							label: "Access Applications",
+							hide: true,
+						},
+					},
+					{
 						name: "users",
 						list: "/users",
 						meta: {
@@ -73,6 +89,7 @@ export function AdminApp() {
 							<Route index element={<TeamList />} />
 							<Route path="create" element={<TeamCreate />} />
 						</Route>
+						<Route path="/access" element={<AccessList />} />
 					</Route>
 				</Routes>
 			</Refine>

--- a/projects/rawkode.academy/identity/src/components/admin/Layout.tsx
+++ b/projects/rawkode.academy/identity/src/components/admin/Layout.tsx
@@ -13,6 +13,7 @@ const navItems = [
 	{ path: "/organizations", label: "Organizations", icon: "M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" },
 	{ path: "/members", label: "Members", icon: "M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" },
 	{ path: "/teams", label: "Teams", icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" },
+	{ path: "/access", label: "Access", icon: "M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586l6.257-6.257A6 6 0 1121 9z" },
 ];
 
 export function Layout() {

--- a/projects/rawkode.academy/identity/src/components/admin/access/List.tsx
+++ b/projects/rawkode.academy/identity/src/components/admin/access/List.tsx
@@ -1,0 +1,348 @@
+import { useCreate, useDelete, useList } from "@refinedev/core";
+import { useMemo, useState } from "react";
+import { Badge, Button, ConfirmModal, Input, Select, Table } from "../ui";
+
+interface AccessRole {
+	key: string;
+	label: string;
+	description: string;
+}
+
+interface AccessApplication {
+	id: string;
+	clientId: string;
+	name: string;
+	description: string;
+	roles: AccessRole[];
+}
+
+interface User {
+	id: string;
+	name: string;
+	email: string;
+	image?: string;
+}
+
+interface AccessAssignment {
+	id: string;
+	userId: string;
+	clientId: string;
+	role: string;
+	reason?: string;
+	expiresAt?: string | null;
+	createdAt: string;
+	userName: string;
+	userEmail: string;
+	userImage?: string;
+}
+
+export function AccessList() {
+	const [deleteId, setDeleteId] = useState<string | null>(null);
+	const [userSearch, setUserSearch] = useState("");
+	const [errors, setErrors] = useState<Record<string, string>>({});
+	const [formData, setFormData] = useState({
+		userId: "",
+		clientId: "comtrya",
+		role: "maintainer",
+		reason: "",
+		expiresAt: "",
+	});
+
+	const { result: appsResult } = useList<AccessApplication>({
+		resource: "access-applications",
+		pagination: { currentPage: 1, pageSize: 50 },
+	});
+	const applications = (appsResult?.data ?? []) as AccessApplication[];
+	const selectedApplication = applications.find(
+		(app) => app.clientId === formData.clientId,
+	);
+	const roleOptions = selectedApplication?.roles.map((role) => ({
+		value: role.key,
+		label: role.label,
+	})) ?? [];
+
+	const { result: usersResult, query: usersQuery } = useList<User>({
+		resource: "users",
+		pagination: { currentPage: 1, pageSize: 25 },
+		filters: userSearch
+			? [{ field: "q", operator: "contains", value: userSearch }]
+			: [],
+	});
+	const users = (usersResult?.data ?? []) as User[];
+	const selectedUser = users.find((user) => user.id === formData.userId);
+
+	const { result, query } = useList<AccessAssignment>({
+		resource: "access-assignments",
+		pagination: { currentPage: 1, pageSize: 50 },
+		sorters: [{ field: "createdAt", order: "desc" }],
+	});
+	const assignments = (result?.data ?? []) as AccessAssignment[];
+
+	const { mutate: createAssignment, mutation: createMutation } = useCreate();
+	const { mutate: deleteAssignment, mutation: deleteMutation } = useDelete();
+
+	const roleLabels = useMemo(() => {
+		return new Map(
+			applications.flatMap((app) =>
+				app.roles.map((role) => [`${app.clientId}:${role.key}`, role.label]),
+			),
+		);
+	}, [applications]);
+
+	const handleSubmit = (event: { preventDefault: () => void }) => {
+		event.preventDefault();
+
+		const nextErrors: Record<string, string> = {};
+		if (!formData.userId) nextErrors.userId = "User is required";
+		if (!formData.clientId) nextErrors.clientId = "Application is required";
+		if (!formData.role) nextErrors.role = "Role is required";
+		if (Object.keys(nextErrors).length > 0) {
+			setErrors(nextErrors);
+			return;
+		}
+
+		createAssignment(
+			{
+				resource: "access-assignments",
+				values: {
+					...formData,
+					expiresAt: formData.expiresAt || null,
+					reason: formData.reason || undefined,
+				},
+			},
+			{
+				onSuccess: () => {
+					setErrors({});
+					setFormData((prev) => ({
+						...prev,
+						userId: "",
+						reason: "",
+						expiresAt: "",
+					}));
+				},
+				onError: (error) => {
+					setErrors({ form: error.message });
+				},
+			},
+		);
+	};
+
+	const handleDelete = () => {
+		if (!deleteId) return;
+		deleteAssignment(
+			{ resource: "access-assignments", id: deleteId },
+			{ onSuccess: () => setDeleteId(null) },
+		);
+	};
+
+	const columns = [
+		{
+			key: "user",
+			header: "User",
+			render: (assignment: AccessAssignment) => (
+				<div className="flex items-center gap-2">
+					{assignment.userImage && (
+						<img
+							src={assignment.userImage}
+							alt={assignment.userName}
+							className="w-8 h-8 rounded-full"
+						/>
+					)}
+					<div>
+						<div className="font-medium">{assignment.userName}</div>
+						<div className="text-sm text-gray-500">{assignment.userEmail}</div>
+					</div>
+				</div>
+			),
+		},
+		{
+			key: "application",
+			header: "Application",
+			render: (assignment: AccessAssignment) => (
+				<div>
+					<div className="font-medium">
+						{applications.find((app) => app.clientId === assignment.clientId)?.name ??
+							assignment.clientId}
+					</div>
+					<div className="text-sm text-gray-500">{assignment.clientId}</div>
+				</div>
+			),
+		},
+		{
+			key: "role",
+			header: "Role",
+			render: (assignment: AccessAssignment) => (
+				<Badge variant={assignment.role === "admin" ? "warning" : "info"}>
+					{roleLabels.get(`${assignment.clientId}:${assignment.role}`) ??
+						assignment.role}
+				</Badge>
+			),
+		},
+		{
+			key: "expiresAt",
+			header: "Expires",
+			render: (assignment: AccessAssignment) => (
+				<span className="text-gray-500">
+					{assignment.expiresAt
+						? new Date(assignment.expiresAt).toLocaleDateString()
+						: "Never"}
+				</span>
+			),
+		},
+		{
+			key: "actions",
+			header: "Actions",
+			render: (assignment: AccessAssignment) => (
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => setDeleteId(assignment.id)}
+				>
+					Remove
+				</Button>
+			),
+		},
+	];
+
+	return (
+		<div>
+			<div className="mb-6">
+				<h2 className="text-2xl font-bold text-gray-900">Access</h2>
+				<p className="text-gray-600 mt-1">
+					Assign roles to users per application. OIDC claims only include roles
+					for the requesting application.
+				</p>
+			</div>
+
+			<form
+				onSubmit={handleSubmit}
+				className="mb-8 grid grid-cols-1 lg:grid-cols-5 gap-4 p-4 border rounded-lg bg-gray-50"
+			>
+				<Select
+					label="Application"
+					value={formData.clientId}
+					onChange={(event) => {
+						const nextApplication = applications.find(
+							(app) => app.clientId === event.target.value,
+						);
+						setFormData((prev) => ({
+							...prev,
+							clientId: event.target.value,
+							role: nextApplication?.roles[0]?.key ?? "",
+						}));
+					}}
+					options={applications.map((app) => ({
+						value: app.clientId,
+						label: app.name,
+					}))}
+					error={errors.clientId}
+				/>
+
+				<div className="space-y-1 lg:col-span-2">
+					<Input
+						label="User"
+						placeholder="Search by name or email..."
+						value={userSearch}
+						onChange={(event) => setUserSearch(event.target.value)}
+						error={errors.userId}
+					/>
+					{usersQuery.isLoading ? (
+						<div className="text-sm text-gray-500">Loading users...</div>
+					) : users.length > 0 ? (
+						<div className="max-h-40 overflow-y-auto border rounded-md bg-white">
+							{users.map((user) => (
+								<button
+									key={user.id}
+									type="button"
+									onClick={() =>
+										setFormData((prev) => ({ ...prev, userId: user.id }))
+									}
+									className={`w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 ${
+										formData.userId === user.id ? "bg-blue-50" : ""
+									}`}
+								>
+									{user.image && (
+										<img
+											src={user.image}
+											alt={user.name}
+											className="w-8 h-8 rounded-full"
+										/>
+									)}
+									<div>
+										<div className="font-medium">{user.name}</div>
+										<div className="text-sm text-gray-500">{user.email}</div>
+									</div>
+								</button>
+							))}
+						</div>
+					) : userSearch ? (
+						<div className="text-sm text-gray-500">No users found</div>
+					) : null}
+					{selectedUser && (
+						<div className="text-sm text-blue-700">
+							Selected {selectedUser.name} ({selectedUser.email})
+						</div>
+					)}
+				</div>
+
+				<Select
+					label="Role"
+					value={formData.role}
+					onChange={(event) =>
+						setFormData((prev) => ({ ...prev, role: event.target.value }))
+					}
+					options={roleOptions}
+					error={errors.role}
+				/>
+
+				<Input
+					label="Expires"
+					type="date"
+					value={formData.expiresAt}
+					onChange={(event) =>
+						setFormData((prev) => ({ ...prev, expiresAt: event.target.value }))
+					}
+				/>
+
+				<div className="lg:col-span-4">
+					<Input
+						label="Reason"
+						placeholder="Optional"
+						value={formData.reason}
+						onChange={(event) =>
+							setFormData((prev) => ({ ...prev, reason: event.target.value }))
+						}
+					/>
+				</div>
+
+				<div className="flex items-end">
+					<Button type="submit" disabled={createMutation.isPending}>
+						{createMutation.isPending ? "Assigning..." : "Assign Role"}
+					</Button>
+				</div>
+
+				{errors.form && (
+					<p className="lg:col-span-5 text-sm text-red-600">{errors.form}</p>
+				)}
+			</form>
+
+			<Table
+				columns={columns}
+				data={assignments}
+				loading={query.isLoading}
+				emptyMessage="No access assignments found"
+			/>
+
+			<ConfirmModal
+				isOpen={!!deleteId}
+				onClose={() => setDeleteId(null)}
+				onConfirm={handleDelete}
+				title="Remove Access"
+				message="Are you sure you want to remove this role assignment?"
+				confirmLabel="Remove"
+				variant="danger"
+				loading={deleteMutation.isPending}
+			/>
+		</div>
+	);
+}

--- a/projects/rawkode.academy/identity/src/components/admin/access/index.ts
+++ b/projects/rawkode.academy/identity/src/components/admin/access/index.ts
@@ -1,0 +1,1 @@
+export { AccessList } from "./List";

--- a/projects/rawkode.academy/identity/src/db/schema.ts
+++ b/projects/rawkode.academy/identity/src/db/schema.ts
@@ -1,5 +1,11 @@
 import { relations, sql } from "drizzle-orm";
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -254,6 +260,40 @@ export const invitation = sqliteTable(
   ],
 );
 
+export const accessAssignment = sqliteTable(
+  "access_assignment",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    clientId: text("client_id").notNull(),
+    role: text("role").notNull(),
+    grantedByUserId: text("granted_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    reason: text("reason"),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("accessAssignment_userClientRole_unique").on(
+      table.userId,
+      table.clientId,
+      table.role,
+    ),
+    index("accessAssignment_userId_idx").on(table.userId),
+    index("accessAssignment_clientId_idx").on(table.clientId),
+    index("accessAssignment_role_idx").on(table.role),
+  ],
+);
+
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
@@ -263,6 +303,12 @@ export const userRelations = relations(user, ({ many }) => ({
   teamMembers: many(teamMember),
   members: many(member),
   invitations: many(invitation),
+  accessAssignments: many(accessAssignment, {
+    relationName: "accessAssignmentUser",
+  }),
+  grantedAccessAssignments: many(accessAssignment, {
+    relationName: "accessAssignmentGranter",
+  }),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -362,3 +408,19 @@ export const invitationRelations = relations(invitation, ({ one }) => ({
     references: [user.id],
   }),
 }));
+
+export const accessAssignmentRelations = relations(
+  accessAssignment,
+  ({ one }) => ({
+    user: one(user, {
+      fields: [accessAssignment.userId],
+      references: [user.id],
+      relationName: "accessAssignmentUser",
+    }),
+    grantedBy: one(user, {
+      fields: [accessAssignment.grantedByUserId],
+      references: [user.id],
+      relationName: "accessAssignmentGranter",
+    }),
+  }),
+);

--- a/projects/rawkode.academy/identity/src/lib/access-applications.ts
+++ b/projects/rawkode.academy/identity/src/lib/access-applications.ts
@@ -1,0 +1,45 @@
+export interface AccessRole {
+	key: string;
+	label: string;
+	description: string;
+}
+
+export interface AccessApplication {
+	clientId: string;
+	name: string;
+	description: string;
+	roles: AccessRole[];
+}
+
+export const ACCESS_APPLICATIONS: AccessApplication[] = [
+	{
+		clientId: "comtrya",
+		name: "Rawkode Academy Code",
+		description: "code.rawkode.academy Comtrya instance",
+		roles: [
+			{
+				key: "admin",
+				label: "Admin",
+				description: "Can access Comtrya admin surfaces.",
+			},
+			{
+				key: "maintainer",
+				label: "Maintainer",
+				description: "Can maintain code.rawkode.academy content and repositories.",
+			},
+		],
+	},
+];
+
+export function findAccessApplication(
+	clientId: string,
+): AccessApplication | undefined {
+	return ACCESS_APPLICATIONS.find((app) => app.clientId === clientId);
+}
+
+export function findAccessRole(
+	clientId: string,
+	role: string,
+): AccessRole | undefined {
+	return findAccessApplication(clientId)?.roles.find((item) => item.key === role);
+}

--- a/projects/rawkode.academy/identity/src/lib/access-claims.ts
+++ b/projects/rawkode.academy/identity/src/lib/access-claims.ts
@@ -1,0 +1,40 @@
+import { and, asc, eq, gt, isNull, or } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import * as schema from "../db/schema";
+
+const ROLE_NAMESPACE = "https://rawkode.academy/roles";
+const CLIENT_NAMESPACE = "https://rawkode.academy/client_id";
+
+export async function getUserAccessClaims(
+	db: DrizzleD1Database<typeof schema>,
+	userId: string,
+	clientId: string,
+): Promise<Record<string, unknown>> {
+	const now = new Date();
+	const rows = await db
+		.select({ role: schema.accessAssignment.role })
+		.from(schema.accessAssignment)
+		.where(
+			and(
+				eq(schema.accessAssignment.userId, userId),
+				eq(schema.accessAssignment.clientId, clientId),
+				or(
+					isNull(schema.accessAssignment.expiresAt),
+					gt(schema.accessAssignment.expiresAt, now),
+				),
+			),
+		)
+		.orderBy(asc(schema.accessAssignment.role));
+
+	const roles = [...new Set(rows.map((row) => row.role))];
+	if (roles.length === 0) {
+		return {};
+	}
+
+	return {
+		roles,
+		groups: roles,
+		[ROLE_NAMESPACE]: roles,
+		[CLIENT_NAMESPACE]: clientId,
+	};
+}

--- a/projects/rawkode.academy/identity/src/lib/auth.ts
+++ b/projects/rawkode.academy/identity/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, oidcProvider, organization } from "better-auth/plugins";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "../db/schema";
 import {
@@ -12,6 +12,7 @@ import {
 	contributor,
 	member,
 } from "./access-control";
+import { getUserAccessClaims } from "./access-claims";
 import { captureAuthEvent } from "./analytics";
 
 type SecretsStoreSecret =
@@ -80,6 +81,31 @@ export const createAuth = async (env: AuthEnv) => {
 			oidcProvider({
 				loginPage: "/auth/sign-in/social",
 				useJWTPlugin: true,
+				scopes: ["openid", "profile", "email", "offline_access", "roles", "groups"],
+				metadata: {
+					scopes_supported: [
+						"openid",
+						"profile",
+						"email",
+						"offline_access",
+						"roles",
+						"groups",
+					],
+					claims_supported: [
+						"sub",
+						"aud",
+						"email",
+						"email_verified",
+						"name",
+						"picture",
+						"roles",
+						"groups",
+						"https://rawkode.academy/roles",
+						"https://rawkode.academy/client_id",
+					],
+				},
+				getAdditionalUserInfoClaim: async (user, _scopes, client) =>
+					getUserAccessClaims(db, user.id, client.clientId),
 				trustedClients: [
 					{
 						clientId: "rawkode-academy-website",
@@ -215,6 +241,7 @@ export const createAuth = async (env: AuthEnv) => {
 			"http://localhost:4322",
 			"https://rawkode.chat",
 			"http://localhost:3000",
+			"https://code.rawkode.academy",
 		],
 
 		databaseHooks: {

--- a/projects/rawkode.academy/identity/src/pages/api/admin/access-applications.ts
+++ b/projects/rawkode.academy/identity/src/pages/api/admin/access-applications.ts
@@ -1,0 +1,20 @@
+import type { APIRoute } from "astro";
+import { ACCESS_APPLICATIONS } from "../../../lib/access-applications";
+import { checkAdminAuth } from "../../../lib/admin-auth";
+
+export const prerender = false;
+
+export const GET: APIRoute = async (context) => {
+	const authCheck = await checkAdminAuth(context);
+	if (!authCheck.authorized) {
+		return authCheck.response;
+	}
+
+	return Response.json({
+		data: ACCESS_APPLICATIONS.map((app) => ({
+			id: app.clientId,
+			...app,
+		})),
+		total: ACCESS_APPLICATIONS.length,
+	});
+};

--- a/projects/rawkode.academy/identity/src/pages/api/admin/access-assignments.ts
+++ b/projects/rawkode.academy/identity/src/pages/api/admin/access-assignments.ts
@@ -1,0 +1,241 @@
+import type { APIRoute } from "astro";
+import { drizzle } from "drizzle-orm/d1";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { sql, eq, and, or, asc, desc } from "drizzle-orm";
+import * as schema from "../../../db/schema";
+import {
+	findAccessApplication,
+	findAccessRole,
+} from "../../../lib/access-applications";
+import { checkAdminAuth } from "../../../lib/admin-auth";
+import type { AuthEnv } from "../../../lib/auth";
+
+export const prerender = false;
+
+interface CreateAccessAssignmentBody {
+	userId: string;
+	clientId: string;
+	role: string;
+	reason?: string;
+	expiresAt?: string | null;
+}
+
+const selectAssignment = {
+	id: schema.accessAssignment.id,
+	userId: schema.accessAssignment.userId,
+	clientId: schema.accessAssignment.clientId,
+	role: schema.accessAssignment.role,
+	reason: schema.accessAssignment.reason,
+	expiresAt: schema.accessAssignment.expiresAt,
+	createdAt: schema.accessAssignment.createdAt,
+	updatedAt: schema.accessAssignment.updatedAt,
+	userName: schema.user.name,
+	userEmail: schema.user.email,
+	userImage: schema.user.image,
+	grantedByUserId: schema.accessAssignment.grantedByUserId,
+};
+
+async function revokeClientTokens(
+	db: DrizzleD1Database<typeof schema>,
+	userId: string,
+	clientId: string,
+) {
+	await db
+		.delete(schema.oauthAccessToken)
+		.where(
+			and(
+				eq(schema.oauthAccessToken.userId, userId),
+				eq(schema.oauthAccessToken.clientId, clientId),
+			),
+		);
+}
+
+/**
+ * GET /api/admin/access-assignments
+ * List per-application role assignments with pagination, sorting, and filtering.
+ */
+export const GET: APIRoute = async (context) => {
+	const authCheck = await checkAdminAuth(context);
+	if (!authCheck.authorized) {
+		return authCheck.response;
+	}
+
+	const env = context.locals.runtime.env as AuthEnv;
+	const db = drizzle(env.DB, { schema });
+	const url = new URL(context.request.url);
+
+	const start = parseInt(url.searchParams.get("_start") || "0", 10);
+	const end = parseInt(url.searchParams.get("_end") || "25", 10);
+	const limit = end - start;
+	const sortField = url.searchParams.get("_sort") || "createdAt";
+	const sortOrder = url.searchParams.get("_order") || "desc";
+
+	const ids = url.searchParams.get("ids");
+	const userId = url.searchParams.get("userId");
+	const clientId = url.searchParams.get("clientId");
+	const role = url.searchParams.get("role");
+
+	let conditions: ReturnType<typeof eq>[] = [];
+	if (ids) {
+		const idList = ids.split(",");
+		conditions.push(or(...idList.map((id) => eq(schema.accessAssignment.id, id)))!);
+	}
+	if (userId) {
+		conditions.push(eq(schema.accessAssignment.userId, userId));
+	}
+	if (clientId) {
+		conditions.push(eq(schema.accessAssignment.clientId, clientId));
+	}
+	if (role) {
+		conditions.push(eq(schema.accessAssignment.role, role));
+	}
+
+	const whereClause =
+		conditions.length > 0 ? and(...conditions) : undefined;
+
+	const assignmentsQuery = db
+		.select(selectAssignment)
+		.from(schema.accessAssignment)
+		.innerJoin(schema.user, eq(schema.accessAssignment.userId, schema.user.id));
+
+	let query = whereClause
+		? assignmentsQuery.where(whereClause).$dynamic()
+		: assignmentsQuery.$dynamic();
+
+	const sortColumn =
+		sortField === "userName"
+			? schema.user.name
+			: sortField === "clientId"
+				? schema.accessAssignment.clientId
+				: sortField === "role"
+					? schema.accessAssignment.role
+					: schema.accessAssignment.createdAt;
+
+	query =
+		sortOrder === "asc"
+			? query.orderBy(asc(sortColumn))
+			: query.orderBy(desc(sortColumn));
+
+	const countQuery = db
+		.select({ count: sql<number>`count(*)` })
+		.from(schema.accessAssignment);
+	const countResult = whereClause
+		? await countQuery.where(whereClause)
+		: await countQuery;
+	const total = countResult[0]?.count ?? 0;
+
+	const data = await query.limit(limit).offset(start);
+	return Response.json({ data, total });
+};
+
+/**
+ * POST /api/admin/access-assignments
+ * Assign a per-application role to a user.
+ */
+export const POST: APIRoute = async (context) => {
+	const authCheck = await checkAdminAuth(context);
+	if (!authCheck.authorized) {
+		return authCheck.response;
+	}
+
+	const env = context.locals.runtime.env as AuthEnv;
+	const db = drizzle(env.DB, { schema });
+	const body = (await context.request.json()) as CreateAccessAssignmentBody;
+
+	if (!body.userId || !body.clientId || !body.role) {
+		return new Response("userId, clientId, and role are required", {
+			status: 400,
+		});
+	}
+
+	const application = findAccessApplication(body.clientId);
+	if (!application) {
+		return new Response("Unknown application clientId", { status: 400 });
+	}
+
+	const accessRole = findAccessRole(body.clientId, body.role);
+	if (!accessRole) {
+		return new Response(
+			`Invalid role for ${application.name}. Must be one of: ${application.roles
+				.map((role) => role.key)
+				.join(", ")}`,
+			{ status: 400 },
+		);
+	}
+
+	const [user] = await db
+		.select()
+		.from(schema.user)
+		.where(eq(schema.user.id, body.userId))
+		.limit(1);
+	if (!user) {
+		return new Response("User not found", { status: 404 });
+	}
+
+	const expiresAt =
+		body.expiresAt === undefined || body.expiresAt === null || body.expiresAt === ""
+			? null
+			: new Date(body.expiresAt);
+	if (expiresAt && Number.isNaN(expiresAt.getTime())) {
+		return new Response("expiresAt must be a valid date", { status: 400 });
+	}
+
+	const [existing] = await db
+		.select()
+		.from(schema.accessAssignment)
+		.where(
+			and(
+				eq(schema.accessAssignment.userId, body.userId),
+				eq(schema.accessAssignment.clientId, body.clientId),
+				eq(schema.accessAssignment.role, body.role),
+			),
+		)
+		.limit(1);
+
+	if (existing) {
+		const [updated] = await db
+			.update(schema.accessAssignment)
+			.set({
+				reason: body.reason || null,
+				expiresAt,
+				grantedByUserId: authCheck.userId,
+				updatedAt: new Date(),
+			})
+			.where(eq(schema.accessAssignment.id, existing.id))
+			.returning();
+		await revokeClientTokens(db, body.userId, body.clientId);
+
+		return Response.json({
+			...updated,
+			userName: user.name,
+			userEmail: user.email,
+			userImage: user.image,
+		});
+	}
+
+	const [assignment] = await db
+		.insert(schema.accessAssignment)
+		.values({
+			id: crypto.randomUUID(),
+			userId: body.userId,
+			clientId: body.clientId,
+			role: body.role,
+			reason: body.reason || null,
+			expiresAt,
+			grantedByUserId: authCheck.userId,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		})
+		.returning();
+	await revokeClientTokens(db, body.userId, body.clientId);
+
+	return Response.json(
+		{
+			...assignment,
+			userName: user.name,
+			userEmail: user.email,
+			userImage: user.image,
+		},
+		{ status: 201 },
+	);
+};

--- a/projects/rawkode.academy/identity/src/pages/api/admin/access-assignments/[id].ts
+++ b/projects/rawkode.academy/identity/src/pages/api/admin/access-assignments/[id].ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from "astro";
+import { drizzle } from "drizzle-orm/d1";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { eq, and } from "drizzle-orm";
+import * as schema from "../../../../db/schema";
+import { checkAdminAuth } from "../../../../lib/admin-auth";
+import type { AuthEnv } from "../../../../lib/auth";
+
+export const prerender = false;
+
+async function revokeClientTokens(
+	db: DrizzleD1Database<typeof schema>,
+	userId: string,
+	clientId: string,
+) {
+	await db
+		.delete(schema.oauthAccessToken)
+		.where(
+			and(
+				eq(schema.oauthAccessToken.userId, userId),
+				eq(schema.oauthAccessToken.clientId, clientId),
+			),
+		);
+}
+
+/**
+ * DELETE /api/admin/access-assignments/:id
+ * Remove a per-application role assignment from a user.
+ */
+export const DELETE: APIRoute = async (context) => {
+	const authCheck = await checkAdminAuth(context);
+	if (!authCheck.authorized) {
+		return authCheck.response;
+	}
+
+	const { id } = context.params;
+	if (!id) {
+		return new Response("Access assignment ID is required", { status: 400 });
+	}
+
+	const env = context.locals.runtime.env as AuthEnv;
+	const db = drizzle(env.DB, { schema });
+
+	const [existing] = await db
+		.select()
+		.from(schema.accessAssignment)
+		.where(eq(schema.accessAssignment.id, id))
+		.limit(1);
+	if (!existing) {
+		return new Response("Access assignment not found", { status: 404 });
+	}
+
+	await db
+		.delete(schema.accessAssignment)
+		.where(eq(schema.accessAssignment.id, id));
+	await revokeClientTokens(db, existing.userId, existing.clientId);
+
+	return new Response(null, { status: 204 });
+};


### PR DESCRIPTION
## Summary
- add identity admin access assignments scoped per OIDC client/application
- emit per-client roles/groups OIDC claims for requesting clients
- configure code.rawkode.academy to accept comtrya admin/maintainer groups

## Validation
- `bun run build` in projects/rawkode.academy/identity using isolated package install (workspace install is blocked by unrelated missing workspace deps)
- `cue export ./...` in projects/code.rawkode.academy/config
- `kubectl kustomize ./gitops` in projects/code.rawkode.academy
- migration SQL applied against sqlite memory database

## Follow-up
- Comtrya currently needs an upstream change to parse custom OIDC `groups` from ID tokens; working that PR separately.