### PR TITLE
fix(rawkode.academy/identity): add local devenv so deploy resolves bun

### DIFF
--- a/projects/rawkode.academy/identity/devenv.lock
+++ b/projects/rawkode.academy/identity/devenv.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1779995347,
+        "narHash": "sha256-clASMT4ByGv5maS8xOgU1Y55R0pKUNMfSq5HEdJ6bV8=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "bb9f187856091b52f56220bb90ff4b40cfa80b52",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/projects/rawkode.academy/identity/devenv.nix
+++ b/projects/rawkode.academy/identity/devenv.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+{
+  name = "id.rawkode.academy";
+
+  dotenv.disableHint = true;
+
+  cachix.enable = false;
+
+  languages.nix.enable = true;
+
+  languages.javascript = {
+    enable = true;
+    package = pkgs.nodejs_24;
+  };
+  languages.typescript.enable = true;
+
+  packages = with pkgs; [
+    biome
+    bun
+    nixfmt-rfc-style
+  ];
+
+  enterShell = ''
+    bun install
+  ''
+  + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+    export LD_LIBRARY_PATH=${pkgs.libgccjit}/lib:$LD_LIBRARY_PATH
+
+    __patchTarget="./node_modules/@cloudflare/workerd-linux-64/bin/workerd"
+    if [[ -f "$__patchTarget" ]]; then
+      ${pkgs.patchelf}/bin/patchelf --set-interpreter ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 "$__patchTarget"
+    fi
+  '';
+}

--- a/projects/rawkode.academy/identity/devenv.yaml
+++ b/projects/rawkode.academy/identity/devenv.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-unstable

--- a/projects/rawkode.academy/identity/env.cue
+++ b/projects/rawkode.academy/identity/env.cue
@@ -6,6 +6,9 @@ schema.#Project
 
 name: "rawkode-academy-identity"
 
+runtime: schema.#DevenvRuntime
+hooks: onEnter: devenv: schema.#Devenv
+
 let _t = tasks
 
 ci: pipelines: {


### PR DESCRIPTION
## Summary

The `rawkode-academy-identity-default` production deploy pipeline has been failing on `main` with:

```
Task execution failed: Failed to spawn task 'build': No such file or directory (os error 2)
```

([failing run](https://github.com/rawkode-academy/rawkode-academy/actions/runs/26586079290/job/78332269441))

## Root cause

cuenv's `runtime: #DevenvRuntime` activates the devenv located in the **project's own directory** before spawning tasks, putting `bun` on `PATH`. The website does this with a local `devenv.nix`; identity had **no local devenv**, so on the Nix CI runner `bun` was never on `PATH` and every `command: "bun"` task (`build`, `migrations.remote`, `deploy`) failed to spawn with `ENOENT`. The build itself is fine — it passes locally (`bun run build` → astro check 0 errors + astro build succeed).

## Fix

Mirror the proven website setup:
- Add local `devenv.nix` (provides `bun`, biome, the workerd patchelf fix for Linux)
- Add `devenv.yaml` + generated `devenv.lock`
- Wire `runtime: schema.#DevenvRuntime` + `hooks: onEnter: devenv: schema.#Devenv` in `env.cue`

Existing per-task `hermetic: false` settings are retained, matching the website.

## Test plan

- [x] `bun run build` passes locally (astro check: 0 errors)
- [x] `devenv build` generates a valid `devenv.lock`
- [x] `cue fmt` clean; `cuenv env print` evaluates the config without error
- [ ] CI: the identity deploy pipeline spawns `bun` and completes

## Human action required

- After merge, confirm the `rawkode-academy-identity-default` deploy succeeds on `main`. If change-detection skips it, manually dispatch the identity deploy pipeline.

This PR was created with the assistance of a LLM.