### PR TITLE
fix(code): bump comtrya images to graceful-shutdown + login-button build

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:f039fc72f8094ebf7068ef649030edbcb13a5cb3e785c5243915663bb1726a61
+    digest: sha256:b9379525085817f5f34f690ca9a54ba831bf95a532180aca878a433190dfda41
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:db9998e872658d7d048980db2abb574e7ef19399081d3ebad96f3b18a3658beb
+    digest: sha256:90b0fc52c2052bc36db8e5e43ee5c5755db398cdb24275282ca3cbcdfa862575
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps the code.rawkode.academy comtrya images to the latest build (comtrya/comtrya main `084e6536`):

- **comtrya-server** → `sha256:b9379525` — adds the config-repo self-heal **and** the graceful-shutdown drain fix. The previous `f039fc72` self-terminated 30s after startup (the drain timeout wrapped the whole serve future), so the pod CrashLooped once it got far enough to listen.
- **comtrya-frontend** → `sha256:90b0fc52` — includes the OIDC "Sign in" button; the previous `db9998e8` predates it, so no button rendered.

Config repo already points at Codeberg (root `config.cue`) from the previous change.

After Flux reconciles: server stays up, `/auth/oidc/providers` serves the issuer, and the Sign in button renders.

This PR was created with the assistance of a LLM.