### PR TITLE
fix(code): bump comtrya-server to RFC3339-timestamp OIDC fix

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:6670f9115100920990b6f73867e8d8ad844455181accd5257ddc664a91d488b9
+    digest: sha256:6566fa8969e98dac19a4573c0de873b858d1cd05fa06a4df8d7e3b95d365f398
   - name: ghcr.io/comtrya/comtrya-frontend
     digest: sha256:90b0fc52c2052bc36db8e5e43ee5c5755db398cdb24275282ca3cbcdfa862575
 


### PR DESCRIPTION
Bumps comtrya-server to `sha256:6566fa89` (comtrya main e6b8207e), which enables openidconnect's `accept-rfc3339-timestamps` so it can parse better-auth id_tokens (`updated_at` is an RFC3339 string, not a NumericDate). Fixes the code.rawkode.academy sign-in ("Failed to parse server response").

This PR was created with the assistance of a LLM.