### PR TITLE
fix(code): bump comtrya to pure-Rust-push + PAT-auth build

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:6566fa8969e98dac19a4573c0de873b858d1cd05fa06a4df8d7e3b95d365f398
+    digest: sha256:3b218de4fd621a3ceb4621671fbaad7b0a0528687b9e8f5564212ce89585574f
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:90b0fc52c2052bc36db8e5e43ee5c5755db398cdb24275282ca3cbcdfa862575
+    digest: sha256:0144c2fcaea6d8416d19318a903032f4bfe4d9610e9d8badc0c7c238476ebf8b
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps comtrya-server/frontend digests in code.rawkode.academy gitops to the current comtrya main build (#131, c72aa80): pure-Rust receive-pack push, PAT push auth, and the thermo-nuclear quality sweep.

- server  -> sha256:3b218de4fd621a3ceb4621671fbaad7b0a0528687b9e8f5564212ce89585574f
- frontend -> sha256:0144c2fcaea6d8416d19318a903032f4bfe4d9610e9d8badc0c7c238476ebf8b

Digests verified: ghcr.io/comtrya/comtrya-server:latest == :sha-c72aa80 == 3b218de4. Base k8s ref unchanged.

The code-rawkode-academy Flux Kustomization is currently suspended; after this lands and the gitops OCI artifact republishes, I will reconcile-once (resume -> reconcile -> re-suspend) to roll it out.