### PR TITLE
fix(code): bump comtrya to P1/P2-hardening build

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:64a43b88dfc868bf2a5cc0333faebf17ab07d70656e2b4f0b3b53061c6d0af31
+    digest: sha256:c2cd9856b08c3b8ab0fe27b85809248d16232a37a64f3f3dd15d8b60b68c1248
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:21503bbf56c7e4ad86757caf6fc91c01fa9208c32e261085ade36d1eb8781ca2
+    digest: sha256:8e331fccac77e2a1dde6f1b77fd56124c1b38dacaa3d463e1e17d4705047a0ee
 
 patches:
   - patch: |-


### PR DESCRIPTION
Deploys comtrya main f5db339 (round-2 P1+P2 hardening: rate limiting, constant-time codes, storage pagination, OIDC fixes, OCI size cap, schema-collision guard, etc.). server c2cd9856 / frontend 8e331fcc. Reconcile-once after merge.