### PR TITLE
chore(code): /r/<repo> git HTTPRoute for comtrya /r/ unify (draft, coupled to comtrya #136)

### DIFF
--- a/projects/code.rawkode.academy/gitops/httproute.yaml
+++ b/projects/code.rawkode.academy/gitops/httproute.yaml
@@ -11,6 +11,32 @@ spec:
   hostnames:
     - code.rawkode.academy
   rules:
+    # Git smart-HTTP under the unified /r/<repo> URL -> kernel.
+    # - POST /r/... covers git-upload-pack / git-receive-pack (core match).
+    # - GET /r/.../info/refs?service=git-* covers the advertisement
+    #   (queryParams match — EXTENDED Gateway-API feature; confirm Cilium
+    #   honors it on this cluster, else info/refs falls through to the SPA
+    #   and clone/fetch break). Everything else under /r/ is browse -> SPA.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /r
+          method: POST
+        - path:
+            type: PathPrefix
+            value: /r
+          queryParams:
+            - name: service
+              value: git-upload-pack
+        - path:
+            type: PathPrefix
+            value: /r
+          queryParams:
+            - name: service
+              value: git-receive-pack
+      backendRefs:
+        - name: comtrya-server
+          port: 80
     - matches:
         - path:
             type: PathPrefix
@@ -24,9 +50,6 @@ spec:
         - path:
             type: PathPrefix
             value: /_extensions
-        - path:
-            type: PathPrefix
-            value: /git
         - path:
             type: PathPrefix
             value: /events

--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:64a43b88dfc868bf2a5cc0333faebf17ab07d70656e2b4f0b3b53061c6d0af31
+    digest: sha256:c2cd9856b08c3b8ab0fe27b85809248d16232a37a64f3f3dd15d8b60b68c1248
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:21503bbf56c7e4ad86757caf6fc91c01fa9208c32e261085ade36d1eb8781ca2
+    digest: sha256:8e331fccac77e2a1dde6f1b77fd56124c1b38dacaa3d463e1e17d4705047a0ee
 
 patches:
   - patch: |-


### PR DESCRIPTION
Draft HTTPRoute change to multiplex /r/<repo> (browse=SPA, git markers=comtrya-server) for comtrya's /r/ URL unification (#127/#136). DO NOT MERGE until comtrya #136 is deployed, Cilium queryParams support confirmed, and git-clone/browser verified. See commit body.