### PR TITLE
fix(code): bump comtrya to security-fix + cleanup main (188af77)

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: code-rawkode-academy
 resources:
-  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=4659865d49577b5269b394f315ee95737ff0aad6
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=188af77c7c401d3fbef39878fde02e66a88818f7
   - namespace.yaml
   - external-secret.yaml
   - httproute.yaml
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:c2cd9856b08c3b8ab0fe27b85809248d16232a37a64f3f3dd15d8b60b68c1248
+    digest: sha256:5e0195724f8ac307b592c8d3738dea8ac9b6a7ad9aeff3480d98ac634bff3a1b
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:8e331fccac77e2a1dde6f1b77fd56124c1b38dacaa3d463e1e17d4705047a0ee
+    digest: sha256:0cad7c6c29bc6877580fb98b7b274856a600ace4dcd5fecd06eaaaaac7b17262
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps \`projects/code.rawkode.academy/gitops/kustomization.yaml\` to deploy 7 freshly-merged comtrya PRs.

## What's in this image

| comtrya PR | Type |
|---|---|
| [#146](https://github.com/comtrya/comtrya/pull/146) | P0 security — close storage→\`workspaces\` kernel-owned bypass |
| [#147](https://github.com/comtrya/comtrya/pull/147) | P1 security — block kernel cross-tenant collection iteration |
| [#149](https://github.com/comtrya/comtrya/pull/149) | Type-boundary — replace substring-matched storage errors with typed enums |
| [#148](https://github.com/comtrya/comtrya/pull/148) | Cleanup — delete dead \`authz\` module (-151 LOC) |
| [#150](https://github.com/comtrya/comtrya/pull/150) | Cleanup — delete dead JobQueue subsystem + orphan event types (-439 LOC) |
| [#151](https://github.com/comtrya/comtrya/pull/151) | Cleanup — delete dead extension manifest/capability/runtime model (-370 LOC) |
| [#152](https://github.com/comtrya/comtrya/pull/152) | Cleanup — trivial dead-code items from the round-2 P3 batch |

## Diff

- \`base?ref=4659865d…\` → \`base?ref=188af77c…\`. The \`opt/kubernetes/\` tree in comtrya has not changed since 4659865d (verified via \`git log 4659865d..188af77 -- opt/kubernetes/\`), so the ref bump is hygiene — same kustomize base evaluates to the same manifests.
- \`comtrya-server\` digest → \`sha256:5e0195724f8ac307b592c8d3738dea8ac9b6a7ad9aeff3480d98ac634bff3a1b\`
- \`comtrya-frontend\` digest → \`sha256:0cad7c6c29bc6877580fb98b7b274856a600ace4dcd5fecd06eaaaaac7b17262\`

Both digests verified against \`ghcr.io/comtrya/{comtrya-server,comtrya-frontend}:sha-188af77c7c401d3fbef39878fde02e66a88818f7\` after the container-images workflow completed successfully on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)