### PR TITLE
fix(code): bump comtrya to TNQ-round-3-security build (5258280)

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: code-rawkode-academy
 resources:
-  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=188af77c7c401d3fbef39878fde02e66a88818f7
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=5258280fb35538ea7f71d3a698e4dbe7f6e017d0
   - namespace.yaml
   - external-secret.yaml
   - httproute.yaml
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:5e0195724f8ac307b592c8d3738dea8ac9b6a7ad9aeff3480d98ac634bff3a1b
+    digest: sha256:28df9e72cf51619f7aa54bc264e2e387f8b17c23ee3145229c588d8daa15fb07
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:0cad7c6c29bc6877580fb98b7b274856a600ace4dcd5fecd06eaaaaac7b17262
+    digest: sha256:eca51a880a944ffe36ef73feb868e69711d345a5d36c976cf53e1a1586a5ce7d
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps comtrya from 188af77 → 5258280. Picks up 6 PRs including the round-3 security fixes:

- [#154](https://github.com/comtrya/comtrya/pull/154) P0/P1 comments authorRef impersonation + edit/delete authz + relations.delete authz
- [#155](https://github.com/comtrya/comtrya/pull/155) git-http cleanup
- [#156](https://github.com/comtrya/comtrya/pull/156) cli hardening
- [#157](https://github.com/comtrya/comtrya/pull/157) ext_pull_requests atomic PR-number CAS
- [#158](https://github.com/comtrya/comtrya/pull/158) drop legacy v1 schemaVersion back-compat
- [#159](https://github.com/comtrya/comtrya/pull/159) audit trail completeness

Critical security ships: comment impersonation, comment edit/delete by non-author, relation.delete by non-owner — all closed in prod after this lands.

`opt/kubernetes/base` ref bumped (no kustomize-layer changes vs prior ref); server + frontend digests refreshed from `ghcr.io/comtrya/{comtrya-server,comtrya-frontend}:sha-5258280…` after the container-images workflow completed successfully on the merge commit.

Comtrya main has since moved through additional P1 fixes (#160-164); a follow-up bump will ship those once the container build for that SHA completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)