### PR TITLE
fix(code): bump comtrya to TNQ-round-3-batch-2 build (709ee8f)

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: code-rawkode-academy
 resources:
-  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=5258280fb35538ea7f71d3a698e4dbe7f6e017d0
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=709ee8faee87d40ff3dfcd2437eeb6e878a37001
   - namespace.yaml
   - external-secret.yaml
   - httproute.yaml
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:28df9e72cf51619f7aa54bc264e2e387f8b17c23ee3145229c588d8daa15fb07
+    digest: sha256:2c77924416feeda1a1fcb68970b2202a38904cfe97098016d5a6a96baa87953c
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:eca51a880a944ffe36ef73feb868e69711d345a5d36c976cf53e1a1586a5ce7d
+    digest: sha256:ee520f06b890a85e11275c3fdaf523ad0d697d4e74f98cb4569175503fff6fa5
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps comtrya from 5258280 → 709ee8f. Picks up 10 PRs from the round-3 TNQ remediation:

- [#160](https://github.com/comtrya/comtrya/pull/160) P1: reject `file://`/`git://` in clone-URL validator (SSRF), `stable_etag_token` rename, OCI post-pull byte cap
- [#161](https://github.com/comtrya/comtrya/pull/161) P1: wait on `git archive` child + surface stderr
- [#162](https://github.com/comtrya/comtrya/pull/162) P1: typed `StorageCreateError`/`StorageDeleteError`
- [#163](https://github.com/comtrya/comtrya/pull/163) P1: WIT pagination on relations/comments/events
- [#164](https://github.com/comtrya/comtrya/pull/164) P1 security: `/events` SSE cross-tenant + audit leak closed
- [#165](https://github.com/comtrya/comtrya/pull/165) P1 security: anonymous viewer-aggregate read leak closed
- [#166](https://github.com/comtrya/comtrya/pull/166) P1 perf: connectivity check memoized (DoS surface)
- [#168](https://github.com/comtrya/comtrya/pull/168) P2: dead method delete, OIDC Debug-secrets fix, defense-in-depth filter
- [#169](https://github.com/comtrya/comtrya/pull/169) P2: reject malformed attributes JSON loudly

Both digests verified against `ghcr.io/comtrya/{comtrya-server,comtrya-frontend}:sha-709ee8…` after the container-images workflow completed successfully on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)