### PR TITLE
fix(code): bump comtrya to TNQ-2-fixes build (9930145)

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: code-rawkode-academy
 resources:
-  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=709ee8faee87d40ff3dfcd2437eeb6e878a37001
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=9930145b78902cb7c26653aa2a1f900048afca9b
   - namespace.yaml
   - external-secret.yaml
   - httproute.yaml
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:2c77924416feeda1a1fcb68970b2202a38904cfe97098016d5a6a96baa87953c
+    digest: sha256:ad21c93703ab1f05888ba59b7004cf56a86b8f5dc4b02431abae3c9d00ef79bf
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:ee520f06b890a85e11275c3fdaf523ad0d697d4e74f98cb4569175503fff6fa5
+    digest: sha256:52fd1a242c93b31ae67d5ee0d2a5c27da75c6c8e0796ee3e0ec3971d112aafca
 
 patches:
   - patch: |-


### PR DESCRIPTION
Bumps comtrya 709ee8f → 9930145. Picks up 10 PRs including:

- [#171](https://github.com/comtrya/comtrya/pull/171) **P0 security**: rate-limit fingerprint uses validated principal (closes bearer-iteration brute-force bypass)
- [#172](https://github.com/comtrya/comtrya/pull/172) **P0**: `comtrya` no-args prints help instead of panicking
- [#173-178](https://github.com/comtrya/comtrya/pull/173) cleanup, typed wire struct, docs, SDK type fix, fmt
- [#179](https://github.com/comtrya/comtrya/pull/179) **P1 security**: events.append source_uri impersonation closed
- [#180](https://github.com/comtrya/comtrya/pull/180) **P1 security**: comments.post cross-thread reply hole closed

Server + frontend digests verified against `ghcr.io/comtrya/{comtrya-server,comtrya-frontend}:sha-9930145` after the container-images workflow completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)