### PR TITLE
fix(code): bump comtrya to TNQ-3 P1 batch 2 (58b43e2)

### DIFF
--- a/projects/code.rawkode.academy/gitops/kustomization.yaml
+++ b/projects/code.rawkode.academy/gitops/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: code-rawkode-academy
 resources:
-  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=2c4aa6566799c3d94ec819bdba9653dc90e3c811
+  - github.com/comtrya/comtrya/opt/kubernetes/base?ref=58b43e25761a16581cacae214fac6e4eac1153df
   - namespace.yaml
   - external-secret.yaml
   - httproute.yaml
 
 images:
   - name: ghcr.io/comtrya/comtrya-server
-    digest: sha256:aaa08c649ad1c4a86bf2e2a570d9a382df53f546995ca924de0e45082837c43b
+    digest: sha256:779863756f2652afd8f14c70a2bf078ddc1b3c3fca8332491bf70e0b9e365acd
   - name: ghcr.io/comtrya/comtrya-frontend
-    digest: sha256:908479f8f18591eacf00363f457a9e7fc1080f417635d440d4e4396d02e1e12b
+    digest: sha256:5e94cc600ceb7a5d36d4bcb027f1d2f79083695b60da28dd4c4932b4ccd53819
 
 patches:
   - patch: |-


### PR DESCRIPTION
## Summary
Ships the next TNQ-3 P1 batch to code.rawkode.academy:

- [comtrya#195](https://github.com/comtrya/comtrya/pull/195) AuthService outbox drain into the audit log
- [comtrya#196](https://github.com/comtrya/comtrya/pull/196) git archive stderr drain off-thread + reap on tar-spawn failure
- [comtrya#197](https://github.com/comtrya/comtrya/pull/197) pack streaming aborts on client disconnect (BrokenPipe)
- [comtrya#198](https://github.com/comtrya/comtrya/pull/198) fetch timeout bounds the live pack stream

## Test plan
- [ ] ArgoCD/Flux picks up the new digests
- [ ] code.rawkode.academy still serves
- [ ] No regressions in repo browse / git clone / login / SSE