### PR TITLE
[codex] Improve prose readability

### DIFF
--- a/content/news/2026-06-01-cloud-native-ai-infra-digest/index.mdx
+++ b/content/news/2026-06-01-cloud-native-ai-infra-digest/index.mdx
@@ -11,15 +11,15 @@ technologies:
   - cncf
 ---
 
-### Miasma abuses npm trusted publishing across Red Hat cloud packages
+### Miasma turns npm trusted publishing against Red Hat cloud packages
 
-SafeDep and Wiz published June 1 research on Miasma, a supply-chain attack against packages in the `@redhat-cloud-services` npm namespace.
+SafeDep and Wiz disclosed Miasma on June 1: an npm supply-chain attack against packages in the `@redhat-cloud-services` namespace.
 
-SafeDep reports that the attacker used short-lived `oidc-*` branches in three RedHatInsights repositories, rewrote trusted publishing workflows, and published tampered packages with valid npm provenance. The important failure mode is not "no provenance"; it is provenance that proves the artifact came from a registered repository and workflow path while missing the branch-authorization boundary operators expected.
+The attacker did not bypass provenance. They made provenance point at the wrong thing. According to SafeDep, short-lived `oidc-*` branches were added to three RedHatInsights repositories, trusted-publishing workflows were changed, and modified packages were pushed with valid npm provenance. The missing control was branch authorization: the registry could prove which repository and workflow produced the artifact, but not that the publish came from a protected branch operators trusted.
 
-The injected package payload ran through `preinstall`, downloaded Bun when needed, and scanned for cloud, Kubernetes, npm, GitHub, Vault, and password-manager credentials. Wiz lists affected package versions separately and says most malicious versions had been revoked by its 13:00 UTC update, with two remaining at the time of writing.
+The malicious packages executed during `preinstall`. They downloaded Bun when it was not already present, then scanned for cloud, Kubernetes, npm, GitHub, Vault, and password-manager credentials. Wiz says most affected versions had been revoked by its 13:00 UTC update, with two still remaining at publication time.
 
-For platform teams, the operational takeaway is to treat trusted publishing configuration as a deployable security boundary: bind publish workflows to protected branches or environments where the registry supports it, and add package-install controls that can block known-bad versions before CI executes lifecycle scripts.
+Platform teams should treat trusted-publishing configuration as production infrastructure. Bind publish workflows to protected branches or environments wherever the registry supports it, and block known-bad package versions before CI can run lifecycle scripts.
 
 **Sources:** [SafeDep](https://safedep.io/redhat-cloud-services-hit-by-mini-shai-hulud-npm-worm/), [Wiz](https://www.wiz.io/blog/miasma-supply-chain-attack-targeting-redhat-npm-packages) - June 1, 2026
 

--- a/projects/rawkode.academy/website/src/components/news/CVEAlert.astro
+++ b/projects/rawkode.academy/website/src/components/news/CVEAlert.astro
@@ -44,10 +44,17 @@ const {
 
 <style>
 	.cve-alert {
-		background: oklch(0.18 0.07 40);
-		color: var(--editorial-paper);
+		--cve-alert-bg: oklch(0.17 0.055 35);
+		--cve-alert-foreground: oklch(0.97 0.01 85);
+		--cve-alert-foreground-soft: oklch(0.92 0.018 75);
+		--cve-alert-foreground-muted: oklch(0.87 0.012 75);
+		--cve-alert-accent: oklch(0.91 0.12 52);
+		--cve-alert-rule: oklch(0.92 0.018 75 / 0.34);
+
+		background: var(--cve-alert-bg);
+		color: var(--cve-alert-foreground);
 		padding: 1.5rem 1.4rem;
-		border: 1px solid oklch(0.6 0.16 30);
+		border: 1px solid oklch(0.76 0.13 40);
 	}
 
 	.cve-alert__head {
@@ -58,11 +65,11 @@ const {
 	}
 
 	.cve-alert__head :global(.m-label) {
-		color: oklch(0.85 0.13 40) !important;
+		color: var(--cve-alert-accent) !important;
 	}
 
 	.cve-alert__head :global(.m-label):last-child {
-		color: oklch(1 0 0 / 0.6) !important;
+		color: var(--cve-alert-foreground-muted) !important;
 	}
 
 	.cve-alert__warn {
@@ -74,7 +81,7 @@ const {
 		font-family: var(--font-jetbrains-mono), monospace;
 		font-size: 0.6875rem;
 		letter-spacing: 0.12em;
-		color: oklch(0.85 0.13 40);
+		color: var(--cve-alert-foreground-soft);
 		margin-bottom: 0.625rem;
 	}
 
@@ -85,9 +92,7 @@ const {
 		font-size: 1.625rem;
 		line-height: 1.1;
 		letter-spacing: -0.02em;
-		/* Override the @layer base h2 ink color — this h2 sits on a
-		 rust-toned dark panel, so it needs the paper foreground. */
-		color: var(--editorial-paper);
+		color: var(--cve-alert-foreground);
 		margin: 0 0 0.875rem;
 		text-wrap: balance;
 	}
@@ -96,7 +101,7 @@ const {
 		font-family: var(--font-inter-tight), sans-serif;
 		font-size: 0.875rem;
 		line-height: 1.5;
-		color: oklch(1 0 0 / 0.78);
+		color: var(--cve-alert-foreground-soft);
 		margin: 0 0 1.125rem;
 		text-wrap: pretty;
 	}
@@ -106,11 +111,11 @@ const {
 		justify-content: space-between;
 		align-items: baseline;
 		padding-top: 0.875rem;
-		border-top: 1px solid oklch(1 0 0 / 0.18);
+		border-top: 1px solid var(--cve-alert-rule);
 	}
 
 	.cve-alert__footer :global(.m-label) {
-		color: oklch(1 0 0 / 0.55) !important;
+		color: var(--cve-alert-foreground-muted) !important;
 	}
 
 	.cve-alert__cta {
@@ -119,7 +124,7 @@ const {
 		font-weight: 500;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
-		color: var(--editorial-paper);
+		color: var(--cve-alert-accent);
 		text-decoration: none;
 	}
 	.cve-alert__cta:hover { text-decoration: underline; text-underline-offset: 3px; }

--- a/projects/rawkode.academy/website/src/components/ui/EditorialShell.astro
+++ b/projects/rawkode.academy/website/src/components/ui/EditorialShell.astro
@@ -408,12 +408,20 @@ const { eyebrow, title, lede, compact = false } = Astro.props as Props;
 	}
 
 	.editorial-prose code {
-		border: 1px solid var(--editorial-hairline);
-		border-radius: 4px;
-		padding: 0.1rem 0.3rem;
-		background: var(--editorial-paper-deep);
-		color: var(--editorial-ink);
-		font-size: 0.9em;
+		font-family: var(--font-jetbrains-mono), monospace;
+		font-size: 0.85em;
+		font-weight: 500;
+		line-height: inherit;
+		padding: 0 0.12em 0.03em;
+		background: color-mix(in oklab, currentColor 4%, transparent);
+		border: 0;
+		border-radius: 2px;
+		color: inherit;
+		overflow-wrap: anywhere;
+		word-break: normal;
+		hyphens: none;
+		box-decoration-break: clone;
+		-webkit-box-decoration-break: clone;
 	}
 
 	.editorial-prose pre {
@@ -422,6 +430,13 @@ const { eyebrow, title, lede, compact = false } = Astro.props as Props;
 		border-radius: 6px;
 		background: var(--editorial-paper-deep);
 		padding: 1rem;
+	}
+
+	.editorial-prose pre code {
+		padding: 0;
+		background: transparent;
+		border: 0;
+		overflow-wrap: normal;
 	}
 
 	@media (min-width: 720px) {

--- a/projects/rawkode.academy/website/src/components/video/comments.vue
+++ b/projects/rawkode.academy/website/src/components/video/comments.vue
@@ -166,10 +166,7 @@ const formatContent = (content: string): string => {
 	return content
 		.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
 		.replace(/\*(.*?)\*/g, "<em>$1</em>")
-		.replace(
-			/`(.*?)`/g,
-			'<code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">$1</code>',
-		)
+		.replace(/`(.*?)`/g, "<code>$1</code>")
 		.replace(/\n/g, "<br>");
 };
 
@@ -182,9 +179,5 @@ onMounted(() => {
 @reference "../../styles/global.css";
 .comments-section {
  max-width: 100%;
-}
-
-.prose code {
- @apply bg-gray-100 dark:bg-gray-700 px-1 rounded text-sm;
 }
 </style>

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -229,37 +229,6 @@ const categoryTrail = tags[0]?.label;
 		margin-bottom: 1rem;
 	}
 
-	.news-detail__body :global(.news-prose code) {
-		font-size: 0.85em;
-		font-weight: 500;
-		line-height: inherit;
-		color: inherit;
-		padding: 0 0.12em 0.03em;
-		background: color-mix(in oklab, currentColor 4%, transparent);
-		border: 0;
-		border-radius: 2px;
-		overflow-wrap: anywhere;
-		word-break: normal;
-		hyphens: none;
-		box-decoration-break: clone;
-		-webkit-box-decoration-break: clone;
-	}
-
-	.news-detail__body :global(.news-prose :is(h1, h2, h3, h4) code) {
-		font-size: 0.85em;
-		font-weight: inherit;
-		padding: 0;
-		background: transparent;
-		border: 0;
-	}
-
-	.news-detail__body :global(.news-prose pre code) {
-		padding: 0;
-		background: transparent;
-		border: 0;
-		overflow-wrap: normal;
-	}
-
 	.news-detail__tags {
 		display: flex;
 		flex-wrap: wrap;

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -150,7 +150,7 @@ const categoryTrail = tags[0]?.label;
 		</ArticleHeader>
 
 		<div class="news-detail__body">
-			<article class="prose">
+			<article class="prose news-prose">
 				<Content />
 			</article>
 
@@ -189,13 +189,75 @@ const categoryTrail = tags[0]?.label;
 	}
 
 	.news-detail__body {
-		max-width: 70rem;
+		max-width: 54rem;
 		margin: 0 auto;
 		padding: var(--space-section-pad-y) var(--space-section-pad-x) var(--space-page-pad-bottom);
 	}
 
 	.news-detail__body :global(.prose) {
-		max-width: 46rem;
+		max-width: 100%;
+	}
+
+	.news-detail__body :global(.news-prose) {
+		font-size: 1rem;
+		line-height: 1.72;
+		color: var(--editorial-ink);
+	}
+
+	.news-detail__body :global(.news-prose h3) {
+		font-family: var(--font-inter-tight), sans-serif;
+		font-style: normal;
+		font-size: clamp(1.35rem, 2vw, 1.625rem);
+		font-weight: 650;
+		letter-spacing: 0;
+		line-height: 1.18;
+		color: var(--editorial-ink);
+		margin: 0 0 1.25rem;
+		text-wrap: balance;
+	}
+
+	.news-detail__body :global(.news-prose h3:not(:first-child)) {
+		margin-top: 2.75rem;
+	}
+
+	.news-detail__body :global(.news-prose p),
+	.news-detail__body :global(.news-prose > p:first-of-type),
+	.news-detail__body :global(.news-prose li) {
+		font-size: 1rem;
+		line-height: 1.72;
+		color: var(--editorial-ink);
+		margin-bottom: 1rem;
+	}
+
+	.news-detail__body :global(.news-prose code) {
+		font-size: 0.85em;
+		font-weight: 500;
+		line-height: inherit;
+		color: inherit;
+		padding: 0 0.12em 0.03em;
+		background: color-mix(in oklab, currentColor 4%, transparent);
+		border: 0;
+		border-radius: 2px;
+		overflow-wrap: anywhere;
+		word-break: normal;
+		hyphens: none;
+		box-decoration-break: clone;
+		-webkit-box-decoration-break: clone;
+	}
+
+	.news-detail__body :global(.news-prose :is(h1, h2, h3, h4) code) {
+		font-size: 0.85em;
+		font-weight: inherit;
+		padding: 0;
+		background: transparent;
+		border: 0;
+	}
+
+	.news-detail__body :global(.news-prose pre code) {
+		padding: 0;
+		background: transparent;
+		border: 0;
+		overflow-wrap: normal;
 	}
 
 	.news-detail__tags {
@@ -240,6 +302,10 @@ const categoryTrail = tags[0]?.label;
 	@media (max-width: 720px) {
 		.news-detail__body {
 			padding: 2rem 1.25rem 3rem;
+		}
+
+		.news-detail__body :global(.news-prose h3) {
+			font-size: 1.25rem;
 		}
 	}
 </style>

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -593,7 +593,7 @@ html.dark {
 
 	/* ════════════════════════════════════════════════════════════════
 	   Editorial .prose ramp — Inter Tight body over Instrument Serif
-	   italic display headings, JetBrains Mono code chips. Hairline
+	   italic display headings, sentence-sized JetBrains Mono code. Hairline
 	   blockquote (single 2px ink border-left, no gradient fill).
 	   ════════════════════════════════════════════════════════════════ */
 	.prose {
@@ -797,15 +797,19 @@ html.dark {
 	/* Inline code — mono, but still part of the sentence. */
 	.prose code {
 		font-family: var(--font-jetbrains-mono), monospace;
-		font-size: 16px;
-		font-weight: 600;
-		line-height: 1.3;
-		padding: 0.02em 0.12em 0.04em;
-		background: transparent;
+		font-size: 0.85em;
+		font-weight: 500;
+		line-height: inherit;
+		padding: 0 0.12em 0.03em;
+		background: color-mix(in oklab, currentColor 4%, transparent);
 		border: 0;
 		border-radius: 2px;
-		color: var(--text-primary-content);
-		overflow-wrap: break-word;
+		color: inherit;
+		overflow-wrap: anywhere;
+		word-break: normal;
+		hyphens: none;
+		box-decoration-break: clone;
+		-webkit-box-decoration-break: clone;
 	}
 
 	.prose :is(h1, h2, h3, h4) code {
@@ -813,6 +817,7 @@ html.dark {
 		border: 0;
 		padding: 0;
 		font-size: 0.85em;
+		font-weight: inherit;
 		color: inherit;
 	}
 
@@ -832,6 +837,7 @@ html.dark {
 		padding: 0;
 		font-size: 0.875rem;
 		font-weight: 400;
+		overflow-wrap: normal;
 	}
 
 	.prose .expressive-code,
@@ -1041,15 +1047,28 @@ html.dark {
    wins over UnoCSS reset's unlayered `code { font-size: 1em; }`. */
 .prose code {
 	font-family: var(--font-jetbrains-mono), monospace;
-	font-size: 16px;
-	font-weight: 600;
-	line-height: 1.3;
-	padding: 0.02em 0.12em 0.04em;
-	background: transparent;
+	font-size: 0.85em;
+	font-weight: 500;
+	line-height: inherit;
+	padding: 0 0.12em 0.03em;
+	background: color-mix(in oklab, currentColor 4%, transparent);
 	border: 0;
 	border-radius: 2px;
-	color: var(--text-primary-content);
-	overflow-wrap: break-word;
+	color: inherit;
+	overflow-wrap: anywhere;
+	word-break: normal;
+	hyphens: none;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
+.prose :is(h1, h2, h3, h4) code {
+	font-size: 0.85em;
+	font-weight: inherit;
+	padding: 0;
+	background: transparent;
+	border: 0;
+	color: inherit;
 }
 
 .prose pre code {
@@ -1057,4 +1076,6 @@ html.dark {
 	font-weight: 400;
 	padding: 0;
 	background: transparent;
+	border: 0;
+	overflow-wrap: normal;
 }


### PR DESCRIPTION
## What changed

- Tightened the news article prose column and added a dedicated `news-prose` rhythm for the digest layout.
- Moved inline-code readability into the shared `.prose` styling so read articles, news articles, learning paths, technology guides, courses, people pages, and other `.prose` surfaces inherit the same treatment.
- Aligned `editorial-prose` inline code used by ADR/legal/branding pages with the same sentence-sized treatment.
- Removed video comment inline-code chip classes so comment prose falls back to shared prose styling.
- Reworked the Miasma section copy for clearer, more direct prose.
- Raised the CVE alert foreground contrast with local high-contrast colour tokens.

## Why

The first pass fixed the visible news page, but the root problem was broader: shared prose inline code was forced to a fixed `16px` size, while article pages and other prose surfaces still used inconsistent chip-like code styling. The result was uneven reading rhythm across `/read`, `/news`, ADR/legal pages, and comment prose.

## Validation

- `git diff --check`
- `bun run build`
- Browser verification against the built pages:
  - `/read/introducing-cuenv/`: article body `18px`, inline code `15.3px`, border `0px`, background `currentColor` at 4%
  - `/news/2026-06-01-cloud-native-ai-infra-digest/`: article body `16px`, inline code `13.6px`, border `0px`, background `currentColor` at 4%
  - `/adrs/0001-adopt-adrs/`: editorial prose body `16px`, inline code `13.6px`, border `0px`, background `currentColor` at 4%
