### PR TITLE
fix(deps): pin kysely to 0.28.17 for better-auth compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -595,6 +595,7 @@
     "workerd",
   ],
   "overrides": {
+    "kysely": "0.28.17",
     "picomatch": "^3.0.2",
   },
   "packages": {
@@ -2936,7 +2937,7 @@
 
     "kubernetes-course": ["kubernetes-course@workspace:projects/workshop-automation"],
 
-    "kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
+    "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "knip": "knip"
   },
   "overrides": {
-    "picomatch": "^3.0.2"
+    "picomatch": "^3.0.2",
+    "kysely": "0.28.17"
   }
 }


### PR DESCRIPTION
The identity Astro 6 build failed in CI: the lockfile regen pulled kysely 0.29.2, which removed exports that `@better-auth/kysely-adapter` imports. Pinned kysely to 0.28.17 (the pre-regen version) via root overrides. identity `astro build` passes locally.

This PR was created with the assistance of a LLM.