### PR TITLE
fix(rawkode.academy/identity): make sign-out button work

### DIFF
--- a/projects/rawkode.academy/identity/src/pages/index.astro
+++ b/projects/rawkode.academy/identity/src/pages/index.astro
@@ -112,11 +112,15 @@ const session = await auth.api.getSession({
 			const logoutBtn = document.getElementById('logout-btn');
 			if (logoutBtn) {
 				logoutBtn.addEventListener('click', async () => {
+					// Better Auth parses the JSON body of sign-out POSTs; sending
+					// the Content-Type header with no body throws and 500s, so the
+					// session is never cleared. Always send a body.
 					await fetch('/auth/sign-out', {
 						method: 'POST',
 						headers: {
 							'Content-Type': 'application/json'
-						}
+						},
+						body: '{}'
 					});
 					window.location.reload();
 				});


### PR DESCRIPTION
The sign-out button did nothing: its fetch sent `Content-Type: application/json` with no body, so Better Auth's sign-out handler JSON-parsed an empty string and returned 500 (verified against prod — empty body 500s, `{}` body 200s). The session was never cleared. Send a `{}` body.

Pre-existing bug in the inline script, surfaced during the Astro 6 work.

This PR was created with the assistance of a LLM.