### PR TITLE
Rawkode Academy News - June 5, 2026

### DIFF
--- a/content/news/2026-06-05-envoy-istio-nccl/index.mdx
+++ b/content/news/2026-06-05-envoy-istio-nccl/index.mdx
@@ -1,0 +1,42 @@
+---
+title: "Envoy, Istio, and NCCL ship operator-facing fixes"
+description: "Envoy and Istio published June 4 security and mesh patch releases, while NVIDIA NCCL 2.30.7-1 added zero-SM collectives and symmetric-memory improvements for GPU communication."
+publishedAt: 2026-06-05
+authors:
+  - rawkode
+technologies:
+  - envoy
+  - istio
+---
+
+Envoy, Istio, and NCCL all shipped changes in the last 24 hours that affect production operators: proxy memory-exhaustion fixes, Istio Gateway API and ambient repairs, and lower-overhead GPU collective paths.
+
+## Envoy patches HTTP/2 header accounting and OAuth2 filter bugs
+
+Envoy v1.38.1 was tagged on June 4 with security fixes also backported across the currently supported 1.37 and 1.36 release lines. The headline fix is CVE-2026-47774: HTTP/2 streams now reset when decoded header data exceeds configured limits, and uncompressed cookies count against both request-header byte and header-count limits.
+
+The release also applies the nghttp2 CVE-2026-27135 patch and fixes two OAuth2 filter issues: a timing side channel in HMAC verification and a crash path where AES-CBC token-cookie decryption could appear to succeed with the wrong secret. Operators should also note two behavior changes in v1.38.1: upstream transport failure details are no longer sent in downstream response bodies, and load-balancer rebuild coalescing during EDS batch updates is now opt-in.
+
+**Source:** [Envoy v1.38.1 release notes](https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1) - June 4, 2026
+
+---
+
+## Istio 1.30.1 adds Gateway API checks and ambient fixes
+
+Istio 1.30.1 shipped on June 4 with the Envoy CVE-2026-47774 fix plus several operator-visible repairs in Gateway API, ambient mode, and multicluster handling. The release adds `istioctl analyze` check `IST0176` for stale Gateway API CRDs, because older CRDs can cause istiod to filter resources silently after an Istio 1.30 upgrade.
+
+Gateway API handling gets fixes for `BackendTLSPolicy` conflicts, HTTPS `ListenerSet` certificate delivery with manually deployed gateways, and invalid `HTTPRoute` or `GRPCRoute` header filter reporting. Ambient mode fixes include a multi-network waypoint routing bug, a CNI `concurrent map writes` panic, and a traffic-distribution leak where one not-ready-service setting could affect unrelated services using the same preset.
+
+**Source:** [Istio 1.30.1 release notes](https://istio.io/latest/news/releases/1.30.x/announcing-1.30.1/) - June 4, 2026
+
+---
+
+## NCCL 2.30.7-1 adds zero-SM collectives
+
+NVIDIA published NCCL v2.30.7-1 on June 4 with new hierarchical zero-SM `AllGather` and `All2all` collectives. The release notes describe an inter-node path through an RMA CPU proxy and an intra-node path through copy engines, enabled with the `NCCL_CTA_POLICY_ZERO` flag, so communication can overlap with GPU compute more cleanly.
+
+The release also expands GIN with an experimental GPU Push Interface backend, stronger signal and fence semantics, traffic-class control, and resource-sharing knobs. Symmetric-memory changes include RMA plugin restructuring, asymmetric buffer sizes during window registration, CUDA graph capture support for window registration, and batched copy-engine operations in the RMA put/wait path; experimental MPS plus MLOPart support allows up to two ranks per physical GPU.
+
+**Source:** [NVIDIA NCCL v2.30.7-1 release](https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1) - June 4, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest ships three fresh, operator-facing items from the June 4/5 window: Envoy security backports for HTTP/2 and OAuth2 paths, Istio 1.30.1 Gateway API and ambient repairs, and NVIDIA NCCL 2.30.7-1 GPU communication changes. I cut the technically relevant arXiv items because their canonical timestamps fell outside the actual discovery window.

## Run metadata

- Run time: `2026-06-05 11:58 Europe/London`
- Coverage window: `2026-06-04 11:58 Europe/London` to `2026-06-05 11:58 Europe/London`
- Source URLs inspected: `58`
- Candidates longlisted: `14`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Envoy patches HTTP/2 header accounting and OAuth2 filter bugs - proxy operators need the HTTP/2 memory-exhaustion and OAuth2 fixes across supported Envoy lines.
- Istio 1.30.1 adds Gateway API checks and ambient fixes - Istio operators get the inherited Envoy CVE fix plus upgrade diagnostics and mesh routing repairs.
- NCCL 2.30.7-1 adds zero-SM collectives - GPU infrastructure teams get new collective and symmetric-memory paths that reduce contention with compute.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Envoy v1.38.1 was tagged on June 4, with v1.37.3 and v1.36.7 also tagged June 4. | https://github.com/envoyproxy/envoy/releases | Verified |
| Envoy fixed CVE-2026-47774 by counting decoded HTTP/2 header data and uncompressed cookies against limits. | https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1#bug-fixes | Verified |
| Envoy v1.38.1 applies nghttp2 CVE-2026-27135 and fixes OAuth2 HMAC timing and AES-CBC token-cookie crash paths. | https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1#bug-fixes | Verified |
| Envoy v1.38.1 hides upstream transport failure details from downstream response bodies and makes EDS batch LB rebuild coalescing opt-in. | https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1#minor-behavior-changes | Verified |
| Istio 1.30.1 was published June 4 and includes the Envoy CVE-2026-47774 security update. | https://istio.io/latest/news/releases/1.30.x/announcing-1.30.1/ | Verified |
| Istio 1.30.1 adds IST0176 to flag Gateway API CRDs below the minimum required version. | https://istio.io/latest/news/releases/1.30.x/announcing-1.30.1/#changes | Verified |
| Istio 1.30.1 fixes BackendTLSPolicy conflicts, ListenerSet certificate/status handling, route filter reporting, ambient waypoint routing, CNI concurrent map writes, and traffic-distribution leakage to not-ready endpoints. | https://istio.io/latest/news/releases/1.30.x/announcing-1.30.1/#changes | Verified |
| NCCL v2.30.7-1 was released June 4 at 22:33. | https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1 | Verified |
| NCCL v2.30.7-1 adds hierarchical zero-SM AllGather and All2all collectives enabled with NCCL_CTA_POLICY_ZERO. | https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1 | Verified |
| NCCL v2.30.7-1 adds GIN, symmetric-memory, CUDA graph capture, and MPS plus MLOPart changes. | https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1 | Verified |

## Items considered and dropped

- SlidingServe / arXiv 2606.05933 - relevant LLM serving scheduler paper, but canonical arXiv timestamp was 2026-06-04 09:36 UTC, outside the actual window.
- Demystifying NVSHMEM / arXiv 2606.05951 - relevant GPU communication systems paper, but canonical arXiv timestamp was 2026-06-04 09:50 UTC, outside the actual window.
- SET CUDA Graph pipelines / arXiv 2606.05495 - stale; canonical timestamp was 2026-06-03 22:38 UTC.
- Ekka silent LLM inference errors / arXiv 2606.04594 - stale; canonical timestamp was 2026-06-03 08:32 UTC.
- Triton Inference Server 2.69.0 - stale; released June 2.
- containerd 2.1.8 - stale; released June 2.
- Cilium 1.20.0-pre.3 - stale; released June 2.
- KEDA 2.20.0 - stale; released June 1.
- AWS Load Balancer Controller 3.4.0 - stale; released June 3.
- Prometheus 3.12.0 - stale; released May 28.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 14
- Segments shipped: 3
- Local validation: `git diff --check`, banned-word scan, and source URL HEAD checks passed; `bunx astro check` stopped at Astro's dependency-install prompt before running.
- CI status: `rawkode-academy-website-pullRequest` fails before content validation because workflow setup downloads `Not Found` as `/usr/local/bin/cuenv` from the latest cuenv release asset URL.
- Any unresolved framing concerns: Envoy and Istio both touch CVE-2026-47774, but the Istio item has separate Gateway API and ambient substance.
- Any vendor-attributed claims: NCCL release claims are NVIDIA-authored; performance implications are written as capabilities, not benchmark claims.