### PR TITLE
fix(rawkode.studio): use live content graph person fields

### DIFF
--- a/content/people/b5.mdx
+++ b/content/people/b5.mdx
@@ -1,0 +1,5 @@
+---
+id: b5
+name: Brendan O'Brien
+github: b5
+---

--- a/content/people/pmbanugo.mdx
+++ b/content/people/pmbanugo.mdx
@@ -1,0 +1,6 @@
+---
+id: pmbanugo
+name: Peter Mbanugo
+github: pmbanugo
+website: https://www.pmbanugo.me/
+---

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-iroh.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-iroh.md
@@ -1,0 +1,19 @@
+---
+id: 7f1dfedcbf38a19375306862
+slug: hands-on-introduction-to-iroh
+title: Hands-on Introduction to Iroh
+subtitle: A hands-on introduction to Iroh with Brendan O'Brien.
+description: >-
+  Brendan O'Brien joins Rawkode to introduce Iroh, walking through the project,
+  its networking model, and how developers can build peer-to-peer applications
+  with it.
+terms:
+  - Iroh
+publishedAt: 2026-07-09T17:00:00.000Z
+type: live
+category: tutorial
+show: rawkode-live
+duration: 3600
+guests:
+  - b5
+---

--- a/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-odin.md
+++ b/content/videos/shows/rawkode-live/2026/hands-on-introduction-to-odin.md
@@ -1,0 +1,18 @@
+---
+id: 7564ecf9c5c00c7ceea52daf
+slug: hands-on-introduction-to-odin
+title: Hands-on Introduction to Odin
+subtitle: A hands-on introduction to Odin with Peter Mbanugo.
+description: >-
+  Peter Mbanugo joins Rawkode to introduce Odin, walking through the language,
+  its tooling, and how developers can get started building with it.
+terms:
+  - Odin
+publishedAt: 2026-07-16T17:00:00.000Z
+type: live
+category: tutorial
+show: rawkode-live
+duration: 3600
+guests:
+  - pmbanugo
+---

--- a/projects/rawkode.studio/src/server/content.test.ts
+++ b/projects/rawkode.studio/src/server/content.test.ts
@@ -12,23 +12,87 @@ afterEach(() => {
 
 describe("Studio content graph", () => {
 	it("uses GitHub handles as person IDs when resolving content videos", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () =>
-				new Response(
-					JSON.stringify({
-						data: {
-							videoByID: {
-								id: "video-123",
-								slug: "future-episode",
-								title: "Future episode",
-								publishedAt: null,
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+			new Response(
+				JSON.stringify({
+					data: {
+						videoByID: {
+							id: "video-123",
+							slug: "future-episode",
+							title: "Future episode",
+							publishedAt: null,
+							guests: [
+								{
+									id: "SteveKlabnik",
+									name: "Steve Klabnik",
+								},
+							],
+							episode: {
+								show: {
+									id: "rawkode-live",
+									name: "Rawkode Live",
+									hosts: [
+										{
+											id: "Rawkode",
+											name: "Rawkode",
+										},
+									],
+								},
+							},
+						},
+						episodeByVideoId: null,
+					},
+				}),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const video = await getStudioContentVideo(
+			{ RAWKODE_GRAPHQL_URL: "https://content.example/graphql" } as StudioEnv,
+			"video-123",
+		);
+
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		expect(request.query).not.toContain("githubHandle");
+		expect(request.query).not.toContain("avatarUrl");
+		expect(video?.guests[0]).toMatchObject({
+			githubHandle: "steveklabnik",
+			id: "steveklabnik",
+			avatarUrl: null,
+		});
+		expect(video?.slug).toBe("future-episode");
+		expect(video?.show?.hosts[0]).toMatchObject({
+			githubHandle: "rawkode",
+			id: "rawkode",
+			avatarUrl: null,
+		});
+	});
+
+	it("lists content events from all videos with normalized participants", async () => {
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+			new Response(
+				JSON.stringify({
+					data: {
+						getAllVideos: [
+							{
+								id: "video-2",
+								slug: "later-event",
+								title: "Later event",
+								publishedAt: "2026-08-02T10:00:00.000Z",
+								guests: [],
+								episode: null,
+							},
+							{
+								id: "video-1",
+								slug: "first-event",
+								title: "First event",
+								publishedAt: "2026-08-01T10:00:00.000Z",
 								guests: [
 									{
-										id: "steve-klabnik",
-										name: "Steve Klabnik",
-										githubHandle: "SteveKlabnik",
-										avatarUrl: "https://example.com/steve.png",
+										id: "GuestHandle",
+										name: "Guest Person",
 									},
 								],
 								episode: {
@@ -37,88 +101,19 @@ describe("Studio content graph", () => {
 										name: "Rawkode Live",
 										hosts: [
 											{
-												id: "rawkode-person",
+												id: "Rawkode",
 												name: "Rawkode",
-												githubHandle: "Rawkode",
-												avatarUrl: "https://example.com/rawkode.png",
 											},
 										],
 									},
 								},
 							},
-							episodeByVideoId: null,
-						},
-					}),
-				),
+						],
+					},
+				}),
 			),
 		);
-
-		const video = await getStudioContentVideo(
-			{ RAWKODE_GRAPHQL_URL: "https://content.example/graphql" } as StudioEnv,
-			"video-123",
-		);
-
-		expect(video?.guests[0]).toMatchObject({
-			githubHandle: "steveklabnik",
-			id: "steveklabnik",
-		});
-		expect(video?.slug).toBe("future-episode");
-		expect(video?.show?.hosts[0]).toMatchObject({
-			githubHandle: "rawkode",
-			id: "rawkode",
-		});
-	});
-
-	it("lists content events from all videos with normalized participants", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () =>
-				new Response(
-					JSON.stringify({
-						data: {
-							getAllVideos: [
-								{
-									id: "video-2",
-									slug: "later-event",
-									title: "Later event",
-									publishedAt: "2026-08-02T10:00:00.000Z",
-									guests: [],
-									episode: null,
-								},
-								{
-									id: "video-1",
-									slug: "first-event",
-									title: "First event",
-									publishedAt: "2026-08-01T10:00:00.000Z",
-									guests: [
-										{
-											id: "guest-person",
-											name: "Guest Person",
-											githubHandle: "GuestHandle",
-											avatarUrl: null,
-										},
-									],
-									episode: {
-										show: {
-											id: "rawkode-live",
-											name: "Rawkode Live",
-											hosts: [
-												{
-													id: "rawkode-person",
-													name: "Rawkode",
-													githubHandle: "Rawkode",
-													avatarUrl: null,
-												},
-											],
-										},
-									},
-								},
-							],
-						},
-					}),
-				),
-			),
-		);
+		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(
 			getStudioContentEvents({
@@ -136,6 +131,11 @@ describe("Studio content graph", () => {
 				id: "video-2",
 			},
 		]);
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		expect(request.query).not.toContain("githubHandle");
+		expect(request.query).not.toContain("avatarUrl");
 	});
 
 	it("resolves people by normalized GitHub handle", async () => {
@@ -147,10 +147,8 @@ describe("Studio content graph", () => {
 				JSON.stringify({
 					data: {
 						personByGithub: {
-							id: "rawkode-person",
+							id: body.variables?.username,
 							name: "Rawkode Academy",
-							githubHandle: body.variables?.username,
-							avatarUrl: "https://example.com/rawkode.png",
 						},
 					},
 				}),
@@ -169,8 +167,13 @@ describe("Studio content graph", () => {
 				method: "POST",
 			}),
 		);
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		expect(request.query).not.toContain("githubHandle");
+		expect(request.query).not.toContain("avatarUrl");
 		expect(person).toEqual({
-			avatarUrl: "https://example.com/rawkode.png",
+			avatarUrl: null,
 			githubHandle: "rawkode",
 			id: "rawkode",
 			name: "Rawkode Academy",

--- a/projects/rawkode.studio/src/server/content.ts
+++ b/projects/rawkode.studio/src/server/content.ts
@@ -55,8 +55,6 @@ const studioContentVideoQuery = `
 			guests {
 				id
 				name
-				githubHandle
-				avatarUrl
 			}
 			episode {
 				show {
@@ -65,8 +63,6 @@ const studioContentVideoQuery = `
 					hosts {
 						id
 						name
-						githubHandle
-						avatarUrl
 					}
 				}
 			}
@@ -78,8 +74,6 @@ const studioContentVideoQuery = `
 				hosts {
 					id
 					name
-					githubHandle
-					avatarUrl
 				}
 			}
 		}
@@ -97,8 +91,6 @@ const studioContentEventsQuery = `
 			guests {
 				id
 				name
-				githubHandle
-				avatarUrl
 			}
 			episode {
 				show {
@@ -107,8 +99,6 @@ const studioContentEventsQuery = `
 					hosts {
 						id
 						name
-						githubHandle
-						avatarUrl
 					}
 				}
 			}
@@ -121,8 +111,6 @@ const studioPersonByGithubQuery = `
 		personByGithub(username: $username) {
 			id
 			name
-			githubHandle
-			avatarUrl
 		}
 	}
 `;
@@ -273,8 +261,8 @@ function normalizePeople(people: GraphQLPerson[]): StudioContentPerson[] {
 	const seen = new Set<string>();
 	const normalized: StudioContentPerson[] = [];
 	for (const person of people) {
-		const githubHandle = normalizeGithubHandle(person.githubHandle);
-		const id = githubHandle ?? person.id;
+		const githubHandle = normalizeGithubHandle(person.githubHandle ?? person.id);
+		const id = githubHandle ?? person.id?.trim();
 		const name = person.name ?? githubHandle ?? person.id;
 		if (!id || !name || seen.has(id)) {
 			continue;


### PR DESCRIPTION
## Summary
- stop Studio from querying Person.githubHandle/avatarUrl, which are not on the live content graph schema yet
- derive Studio participant GitHub handles from Person.id, matching the GitHub-handle content ID migration
- add upcoming Rawkode Live sessions for Iroh and Odin, including b5 and pmbanugo people entries

## Validation
- bun run test (projects/rawkode.studio)
- bun run check (projects/rawkode.studio)
- bun run build (projects/rawkode.studio)
- bun run deploy:dry-run (projects/rawkode.studio)
- bun run build (projects/rawkode.academy/website)
- verified the live api.rawkode.academy query shape with Person.id/name only