### PR TITLE
fix(rawkode.academy): expose upcoming streams

### DIFF
--- a/projects/rawkode.academy/website/src/lib/content.ts
+++ b/projects/rawkode.academy/website/src/lib/content.ts
@@ -15,3 +15,15 @@ export async function getPublishedVideos() {
 			new Date(a.data.publishedAt).getTime(),
 	);
 }
+
+export async function getUpcomingVideos() {
+	const now = new Date();
+	const videos = await getCollection("videos", ({ data }) => {
+		return data.type === "live" && data.publishedAt > now;
+	});
+	return videos.sort(
+		(a, b) =>
+			new Date(a.data.publishedAt).getTime() -
+			new Date(b.data.publishedAt).getTime(),
+	);
+}

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false;
 
-import { getPublishedVideos } from "@/lib/content";
+import { getPublishedVideos, getUpcomingVideos } from "@/lib/content";
 import VideoItemListJsonLd from "@/components/html/video-itemlist-jsonld.astro";
 import VideoMetadata from "@/components/html/video-metadata.astro";
 import Page from "@/wrappers/page.astro";
@@ -39,6 +39,8 @@ const page = Math.max(
 const videosPerPage = 15;
 
 const allVideos = (await getPublishedVideos()).map((v) => v.data);
+const upcomingVideos = (await getUpcomingVideos()).map((v) => v.data);
+const [nextUpcomingVideo, ...otherUpcomingVideos] = upcomingVideos;
 
 const totalVideoCount = allVideos.length;
 const seriesKeyFor = (video: (typeof allVideos)[number]) =>
@@ -120,6 +122,19 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 	day: "2-digit",
 });
 
+const upcomingDateFormatter = new Intl.DateTimeFormat("en-GB", {
+	weekday: "short",
+	month: "short",
+	day: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+	timeZone: "Europe/London",
+	timeZoneName: "short",
+});
+
+const formatUpcomingDate = (date: Date | string) =>
+	upcomingDateFormatter.format(date instanceof Date ? date : new Date(date));
+
 const formatLabel = (value?: string | null) =>
 	value
 		? value.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
@@ -187,6 +202,39 @@ const featuredSeries = featuredVideo
 			title="Latest Videos"
 			dek="Tutorials, talks, and live builds."
 		/>
+
+		{nextUpcomingVideo && (
+			<section class="watch-upcoming" aria-labelledby="watch-upcoming-title">
+				<div class="watch-upcoming__header">
+					<MLabel tone="amber">Upcoming Streams</MLabel>
+					<h2 id="watch-upcoming-title">Next live sessions</h2>
+				</div>
+
+				<VideoHero
+					href={`/watch/${nextUpcomingVideo.slug}`}
+					title={nextUpcomingVideo.title}
+					series="Upcoming stream"
+					thumbnailUrl={getVideoThumbnailUrl(nextUpcomingVideo.id)}
+					description={nextUpcomingVideo.description}
+					date={formatUpcomingDate(nextUpcomingVideo.publishedAt)}
+					primaryCtaLabel="View stream →"
+				/>
+
+				{otherUpcomingVideos.length > 0 && (
+					<div class="watch-upcoming__grid">
+						{otherUpcomingVideos.slice(0, 5).map((v) => (
+							<VideoGridItem
+								href={`/watch/${v.slug}`}
+								title={v.title}
+								series="Upcoming stream"
+								thumbnailUrl={getVideoThumbnailUrl(v.id)}
+								date={formatUpcomingDate(v.publishedAt)}
+							/>
+						))}
+					</div>
+				)}
+			</section>
+		)}
 
 		{featuredVideo && (
 			<VideoHero
@@ -261,6 +309,37 @@ const featuredSeries = featuredVideo
 		color: var(--editorial-ink);
 	}
 
+	.watch-upcoming {
+		border-bottom: 1px solid var(--editorial-hairline);
+		background: var(--editorial-paper-deep);
+	}
+
+	.watch-upcoming__header {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 2rem 2.5rem 0;
+	}
+
+	.watch-upcoming__header h2 {
+		margin: 0;
+		font-family: var(--font-instrument-serif), serif;
+		font-size: clamp(2.25rem, 5vw, 4rem);
+		font-style: italic;
+		font-weight: 400;
+		line-height: 0.95;
+		letter-spacing: 0;
+		color: var(--editorial-ink);
+	}
+
+	.watch-upcoming__grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 2rem 1.75rem;
+		padding: 0 2.5rem 2.5rem;
+	}
+
 	.watch-grid {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
@@ -298,9 +377,23 @@ const featuredSeries = featuredVideo
 	}
 
 	@media (max-width: 960px) {
-		.watch-grid { grid-template-columns: repeat(2, 1fr); padding: 1.5rem 1.25rem 2rem; }
+		.watch-upcoming__grid,
+		.watch-grid {
+			grid-template-columns: repeat(2, 1fr);
+			padding-inline: 1.25rem;
+		}
+
+		.watch-grid {
+			padding-top: 1.5rem;
+			padding-bottom: 2rem;
+		}
+
+		.watch-upcoming__header {
+			padding-inline: 1.25rem;
+		}
 	}
 	@media (max-width: 640px) {
+		.watch-upcoming__grid,
 		.watch-grid { grid-template-columns: 1fr; }
 		.watch-footer {
 			flex-direction: column;

--- a/projects/rawkode.academy/website/src/subgraph/domains/videos.ts
+++ b/projects/rawkode.academy/website/src/subgraph/domains/videos.ts
@@ -3,9 +3,10 @@ import { DateResolver } from "graphql-scalars";
 import {
 	type VideoItem,
 	getVideoById,
-	getPublishedVideos,
+	getUpcomingVideos,
 	getLatestVideos,
 	getRandomVideos,
+	listVideos,
 	searchVideos,
 } from "../loaders/videos";
 
@@ -87,7 +88,7 @@ export function registerVideos(
 			}),
 			getAllVideos: t.field({
 				type: [VideoRef],
-				resolve: async () => getPublishedVideos(),
+				resolve: async () => listVideos(),
 			}),
 			getLatestVideos: t.field({
 				type: [VideoRef],
@@ -99,6 +100,17 @@ export function registerVideos(
 					_root: any,
 					args: { limit?: number; offset?: number },
 				) => getLatestVideos(args.limit ?? 15, args.offset ?? 0),
+			}),
+			getUpcomingVideos: t.field({
+				type: [VideoRef],
+				args: {
+					limit: t.arg.int({ required: false, defaultValue: 15 }),
+					offset: t.arg.int({ required: false, defaultValue: 0 }),
+				},
+				resolve: async (
+					_root: any,
+					args: { limit?: number; offset?: number },
+				) => getUpcomingVideos(args.limit ?? 15, args.offset ?? 0),
 			}),
 			getRandomVideos: t.field({
 				type: [VideoRef],

--- a/projects/rawkode.academy/website/src/subgraph/loaders/videos.ts
+++ b/projects/rawkode.academy/website/src/subgraph/loaders/videos.ts
@@ -88,6 +88,18 @@ export async function getPublishedVideos(): Promise<VideoItem[]> {
 		.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 }
 
+export async function getUpcomingVideos(
+	limit = 15,
+	offset = 0,
+): Promise<VideoItem[]> {
+	const list = await listVideos();
+	const now = new Date();
+	return list
+		.filter((v) => v.type === "live" && v.publishedAt > now)
+		.sort((a, b) => a.publishedAt.getTime() - b.publishedAt.getTime())
+		.slice(offset, offset + limit);
+}
+
 export async function getLatestVideos(
 	limit = 15,
 	offset = 0,

--- a/projects/rawkode.academy/website/src/subgraph/schema.gql
+++ b/projects/rawkode.academy/website/src/subgraph/schema.gql
@@ -56,6 +56,7 @@ type Query {
   getAllVideos: [Video!]
   getLatestVideos(limit: Int = 15, offset: Int = 0): [Video!]
   getRandomVideos(limit: Int = 5): [Video!]
+  getUpcomingVideos(limit: Int = 15, offset: Int = 0): [Video!]
   getTechnologies(limit: Int = 15, offset: Int = 0): [Technology!]
   me: Person
   personByGithub(username: String!): Person

--- a/projects/rawkode.academy/website/src/tests/subgraph-schema.test.ts
+++ b/projects/rawkode.academy/website/src/tests/subgraph-schema.test.ts
@@ -13,6 +13,7 @@ describe("website content subgraph schema", () => {
 		expect(sdl).toContain("githubHandle: String");
 		expect(sdl).toContain("githubUrl: String");
 		expect(sdl).toContain("personByGithub(username: String!): Person");
+		expect(sdl).toContain("getUpcomingVideos(limit: Int = 15, offset: Int = 0): [Video!]");
 		expect(sdl).toContain("me: Person");
 	});
 });

--- a/projects/rawkode.academy/website/src/tests/video-loader.test.ts
+++ b/projects/rawkode.academy/website/src/tests/video-loader.test.ts
@@ -1,0 +1,82 @@
+import { getCollection } from "astro:content";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	getPublishedVideos,
+	getUpcomingVideos,
+	listVideos,
+} from "../subgraph/loaders/videos";
+
+const mockedGetCollection = vi.mocked(getCollection);
+
+function videoEntry(input: {
+	id: string;
+	publishedAt: Date;
+	title: string;
+	type?: "live" | "recorded";
+}) {
+	return {
+		id: input.id,
+		body: "",
+		data: {
+			id: input.id,
+			slug: input.id,
+			title: input.title,
+			subtitle: undefined,
+			description: `${input.title} description`,
+			publishedAt: input.publishedAt,
+			duration: 3600,
+			type: input.type ?? "live",
+			category: "tutorial",
+			technologies: [],
+			show: "rawkode-live",
+			guests: [],
+			chapters: [],
+		},
+	};
+}
+
+describe("video subgraph loader", () => {
+	beforeEach(() => {
+		mockedGetCollection.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("keeps future live sessions visible to Studio while preserving published-only helpers", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-06T12:00:00.000Z"));
+		mockedGetCollection.mockResolvedValue([
+			videoEntry({
+				id: "published-yoke",
+				title: "Hands-on Introduction to Yoke",
+				publishedAt: new Date("2026-06-03T00:00:00.000Z"),
+			}),
+			videoEntry({
+				id: "upcoming-odin",
+				title: "Hands-on Introduction to Odin",
+				publishedAt: new Date("2026-07-16T17:00:00.000Z"),
+			}),
+			videoEntry({
+				id: "upcoming-iroh",
+				title: "Hands-on Introduction to Iroh",
+				publishedAt: new Date("2026-07-09T17:00:00.000Z"),
+			}),
+		] as never);
+
+		await expect(listVideos()).resolves.toMatchObject([
+			{ id: "published-yoke" },
+			{ id: "upcoming-odin" },
+			{ id: "upcoming-iroh" },
+		]);
+		await expect(getPublishedVideos()).resolves.toMatchObject([
+			{ id: "published-yoke" },
+		]);
+		await expect(getUpcomingVideos()).resolves.toMatchObject([
+			{ id: "upcoming-iroh" },
+			{ id: "upcoming-odin" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- make the content subgraph getAllVideos resolver include future scheduled videos so the deployed Studio can list upcoming events
- add a getUpcomingVideos query/helper for explicit upcoming-stream consumers
- show upcoming live sessions on the website /watch page

## Root Cause
Future-dated live videos were created in content, but the website subgraph getAllVideos resolver called the published-only loader. That meant Studio could not see Iroh/Odin, and /watch only rendered published videos.

## Validation
- bun run test -- src/tests/video-loader.test.ts src/tests/subgraph-schema.test.ts
- bun run test in projects/rawkode.studio
- bun run build in projects/rawkode.academy/website
- browser check against local /watch confirmed Iroh, Odin, and 18:00 BST upcoming stream times