### PR TITLE
[codex] fix(rawkode.studio): accept form submissions for studio actions

### DIFF
--- a/projects/rawkode.studio/src/actions/index.ts
+++ b/projects/rawkode.studio/src/actions/index.ts
@@ -65,6 +65,7 @@ function toActionError(error: unknown): never {
 
 export const server = {
 	createSession: defineAction({
+		accept: "form",
 		input: z
 			.object({
 				showId: optionalText,
@@ -95,6 +96,7 @@ export const server = {
 	}),
 
 	endSession: defineAction({
+		accept: "form",
 		input: z.object({
 			sessionId: z.string().min(1),
 		}),
@@ -148,6 +150,7 @@ export const server = {
 	}),
 
 	createInvite: defineAction({
+		accept: "form",
 		input: z.object({
 			expiresInHours: optionalPositiveInt(24 * 30),
 			maxUses: optionalPositiveInt(25),


### PR DESCRIPTION
## What changed

- Configured the Studio dashboard form-backed actions to accept form submissions: createSession, createInvite, and endSession.

## Why

Operators could not create an RTK session from the Studio dashboard. The dashboard submits a normal HTML form to actions.createSession, but Astro actions accept JSON by default unless accept: form is set.

## Impact

The dashboard POST forms now reach the action handlers instead of failing early with: This action only accepts JSON. Programmatic JSON paths, including participant token issuance and recording readiness, are left unchanged.

## Validation

- git diff --check
- Source scan confirmed the three dashboard POST forms now map to form-accepting actions.

Could not run bun run test or bun run check in this sparse worktree. The project had no installed dependencies, and bun install --frozen-lockfile --filter @rawkode/studio is blocked by unrelated missing workspace packages referenced elsewhere in the monorepo: email-preferences, ski-achievements, ski-leaderboard, ski-player-learned-phrases, ski-player-stats, and ski-share-cards.