### PR TITLE
fix(api): supergraph refresh for Studio

### DIFF
--- a/projects/rawkode.academy/api/env.cue
+++ b/projects/rawkode.academy/api/env.cue
@@ -58,7 +58,14 @@ tasks: {
 		args: ["x", "wrangler", "deploy"]
 		dependsOn: [_t.compose]
 
+		// Keep API deploy affected when the source schemas that compose the
+		// bundled supergraph change. The generated supergraph is not committed.
 		inputs: [
+			"scripts/collect-schemas.ts",
+			"scripts/compose.ts",
+			"schemas/**",
+			"../platform/*/read-model/schema.gql",
+			"../website/src/subgraph/**",
 			"src/**",
 			"supergraph.graphql",
 			"wrangler.jsonc",

--- a/projects/rawkode.academy/api/package.json
+++ b/projects/rawkode.academy/api/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "wrangler dev",
-		"deploy": "wrangler deploy",
+		"deploy": "bun run build && wrangler deploy",
 		"collect-schemas": "bun run scripts/collect-schemas.ts",
 		"compose": "bun run scripts/compose.ts",
 		"build": "bun run collect-schemas && bun run compose",

--- a/projects/rawkode.academy/website/scripts/publish-subgraph.ts
+++ b/projects/rawkode.academy/website/scripts/publish-subgraph.ts
@@ -28,7 +28,7 @@ const sdl = printSchemaWithDirectives(
 );
 
 mkdirSync(outDir, { recursive: true });
-writeFileSync(outFile, sdl);
+writeFileSync(outFile, `${sdl}\n`);
 console.log(`✅ Subgraph SDL written: ${outFile}`);
 
 console.log("\nNext: publish to Cosmo (example)\n");

--- a/projects/rawkode.academy/website/src/subgraph/publish.ts
+++ b/projects/rawkode.academy/website/src/subgraph/publish.ts
@@ -16,6 +16,6 @@ const schemaAsString = printSchemaWithDirectives(
 );
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-writeFileSync(`${__dirname}/schema.gql`, schemaAsString);
+writeFileSync(`${__dirname}/schema.gql`, `${schemaAsString}\n`);
 
 logger.info("GraphQL schema published to src/subgraph/schema.gql");

--- a/projects/rawkode.academy/website/src/subgraph/schema.gql
+++ b/projects/rawkode.academy/website/src/subgraph/schema.gql
@@ -56,8 +56,8 @@ type Query {
   getAllVideos: [Video!]
   getLatestVideos(limit: Int = 15, offset: Int = 0): [Video!]
   getRandomVideos(limit: Int = 5): [Video!]
-  getUpcomingVideos(limit: Int = 15, offset: Int = 0): [Video!]
   getTechnologies(limit: Int = 15, offset: Int = 0): [Technology!]
+  getUpcomingVideos(limit: Int = 15, offset: Int = 0): [Video!]
   me: Person
   personByGithub(username: String!): Person
   showById(id: String!): Show

--- a/projects/rawkode.studio/src/actions/index.ts
+++ b/projects/rawkode.studio/src/actions/index.ts
@@ -16,6 +16,7 @@ const isoDateTime = z.string().refine((value) => !Number.isNaN(Date.parse(value)
 });
 const optionalText = z.preprocess(
 	(value) => {
+		if (value == null) return undefined;
 		if (typeof value !== "string") return value;
 		const trimmed = value.trim();
 		return trimmed.length > 0 ? trimmed : undefined;
@@ -24,6 +25,7 @@ const optionalText = z.preprocess(
 );
 const optionalIsoDateTime = z.preprocess(
 	(value) => {
+		if (value == null) return undefined;
 		if (typeof value !== "string") return value;
 		const trimmed = value.trim();
 		return trimmed.length > 0 ? trimmed : undefined;
@@ -33,6 +35,7 @@ const optionalIsoDateTime = z.preprocess(
 const optionalPositiveInt = (max: number) =>
 	z.preprocess(
 		(value) => {
+			if (value == null) return undefined;
 			if (typeof value === "string") {
 				const trimmed = value.trim();
 				if (!trimmed) return undefined;

--- a/projects/rawkode.studio/src/server/content.test.ts
+++ b/projects/rawkode.studio/src/server/content.test.ts
@@ -3,6 +3,7 @@ import type { StudioEnv } from "../env";
 import {
 	getStudioContentEvents,
 	getStudioContentPersonByGithub,
+	getStudioUpcomingContentEvents,
 	getStudioContentVideo,
 } from "./content";
 
@@ -136,6 +137,111 @@ describe("Studio content graph", () => {
 		};
 		expect(request.query).not.toContain("githubHandle");
 		expect(request.query).not.toContain("avatarUrl");
+	});
+
+	it("lists upcoming content events through the narrow supergraph field", async () => {
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+			new Response(
+				JSON.stringify({
+					data: {
+						getUpcomingVideos: [
+							{
+								id: "video-2",
+								slug: "later-event",
+								title: "Later event",
+								publishedAt: "2026-08-02T10:00:00.000Z",
+								guests: [],
+								episode: null,
+							},
+							{
+								id: "video-1",
+								slug: "first-event",
+								title: "First event",
+								publishedAt: "2026-08-01T10:00:00.000Z",
+								guests: [],
+								episode: null,
+							},
+						],
+					},
+				}),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			getStudioUpcomingContentEvents({
+				RAWKODE_GRAPHQL_URL: "https://content.example/graphql",
+			} as StudioEnv, 10),
+		).resolves.toMatchObject([
+			{
+				id: "video-1",
+			},
+			{
+				id: "video-2",
+			},
+		]);
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+			variables?: { limit?: number };
+		};
+		expect(request.query).toContain("getUpcomingVideos");
+		expect(request.query).not.toContain("getAllVideos");
+		expect(request.variables?.limit).toBe(10);
+	});
+
+	it("falls back to all videos while an older supergraph is still deployed", async () => {
+		let callCount = 0;
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
+			callCount++;
+			return new Response(
+				JSON.stringify(
+					callCount === 1
+						? {
+								errors: [
+									{
+										message:
+											'Cannot query field "getUpcomingVideos" on type "Query".',
+									},
+								],
+							}
+						: {
+								data: {
+									getAllVideos: [
+										{
+											id: "fallback-video",
+											slug: "fallback-event",
+											title: "Fallback event",
+											publishedAt: "2026-08-01T10:00:00.000Z",
+											guests: [],
+											episode: null,
+										},
+									],
+								},
+							},
+				),
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			getStudioUpcomingContentEvents({
+				RAWKODE_GRAPHQL_URL: "https://content.example/graphql",
+			} as StudioEnv),
+		).resolves.toMatchObject([
+			{
+				id: "fallback-video",
+			},
+		]);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const firstRequest = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		const secondRequest = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		expect(firstRequest.query).toContain("getUpcomingVideos");
+		expect(secondRequest.query).toContain("getAllVideos");
 	});
 
 	it("resolves people by normalized GitHub handle", async () => {

--- a/projects/rawkode.studio/src/server/content.ts
+++ b/projects/rawkode.studio/src/server/content.ts
@@ -80,28 +80,40 @@ const studioContentVideoQuery = `
 	}
 `;
 
-const studioContentEventsQuery = `
-	query StudioContentEvents {
-		getAllVideos {
+const studioContentEventFields = `
+	id
+	slug
+	title
+	publishedAt
+	type
+	guests {
+		id
+		name
+	}
+	episode {
+		show {
 			id
-			slug
-			title
-			publishedAt
-			type
-			guests {
+			name
+			hosts {
 				id
 				name
 			}
-			episode {
-				show {
-					id
-					name
-					hosts {
-						id
-						name
-					}
-				}
-			}
+		}
+	}
+`;
+
+const studioContentEventsQuery = `
+	query StudioContentEvents {
+		getAllVideos {
+			${studioContentEventFields}
+		}
+	}
+`;
+
+const studioUpcomingContentEventsQuery = `
+	query StudioUpcomingContentEvents($limit: Int!) {
+		getUpcomingVideos(limit: $limit) {
+			${studioContentEventFields}
 		}
 	}
 `;
@@ -144,6 +156,57 @@ function sortContentVideos(
 	const leftTime = left.publishedAt ? Date.parse(left.publishedAt) : Number.MAX_SAFE_INTEGER;
 	const rightTime = right.publishedAt ? Date.parse(right.publishedAt) : Number.MAX_SAFE_INTEGER;
 	return leftTime - rightTime || left.title.localeCompare(right.title);
+}
+
+function firstGraphQLError(payload: {
+	errors?: Array<{ message?: string }>;
+}): string | null {
+	return payload.errors?.[0]?.message ?? null;
+}
+
+function isMissingUpcomingVideosField(message: string | null): boolean {
+	return message?.includes('Cannot query field "getUpcomingVideos"') ?? false;
+}
+
+async function fetchStudioContentEvents(
+	env: StudioEnv,
+	input: {
+		query: string;
+		resultKey: "getAllVideos" | "getUpcomingVideos";
+		variables?: Record<string, unknown>;
+	},
+): Promise<StudioContentVideo[]> {
+	const endpoint = env.RAWKODE_GRAPHQL_URL ?? "https://api.rawkode.academy/";
+	const response = await fetch(endpoint, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			query: input.query,
+			variables: input.variables,
+		}),
+	});
+	if (!response.ok) {
+		throw new Error(`Rawkode content graph returned ${response.status}`);
+	}
+
+	const payload = (await response.json()) as {
+		data?: {
+			getAllVideos?: GraphQLVideo[] | null;
+			getUpcomingVideos?: GraphQLVideo[] | null;
+		};
+		errors?: Array<{ message?: string }>;
+	};
+	const graphQLError = firstGraphQLError(payload);
+	if (graphQLError) {
+		throw new Error(graphQLError);
+	}
+
+	return (payload.data?.[input.resultKey] ?? [])
+		.map(normalizeVideo)
+		.filter((video): video is StudioContentVideo => Boolean(video))
+		.sort(sortContentVideos);
 }
 
 export async function getStudioContentVideo(
@@ -189,34 +252,31 @@ export async function getStudioContentVideo(
 export async function getStudioContentEvents(
 	env: StudioEnv,
 ): Promise<StudioContentVideo[]> {
-	const endpoint = env.RAWKODE_GRAPHQL_URL ?? "https://api.rawkode.academy/";
-	const response = await fetch(endpoint, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			query: studioContentEventsQuery,
-		}),
+	return fetchStudioContentEvents(env, {
+		query: studioContentEventsQuery,
+		resultKey: "getAllVideos",
 	});
-	if (!response.ok) {
-		throw new Error(`Rawkode content graph returned ${response.status}`);
-	}
+}
 
-	const payload = (await response.json()) as {
-		data?: {
-			getAllVideos?: GraphQLVideo[] | null;
-		};
-		errors?: Array<{ message?: string }>;
-	};
-	if (payload.errors?.length) {
-		throw new Error(payload.errors[0]?.message ?? "Rawkode content graph failed");
+export async function getStudioUpcomingContentEvents(
+	env: StudioEnv,
+	limit = 25,
+): Promise<StudioContentVideo[]> {
+	try {
+		return await fetchStudioContentEvents(env, {
+			query: studioUpcomingContentEventsQuery,
+			resultKey: "getUpcomingVideos",
+			variables: { limit },
+		});
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			isMissingUpcomingVideosField(error.message)
+		) {
+			return getStudioContentEvents(env);
+		}
+		throw error;
 	}
-
-	return (payload.data?.getAllVideos ?? [])
-		.map(normalizeVideo)
-		.filter((video): video is StudioContentVideo => Boolean(video))
-		.sort(sortContentVideos);
 }
 
 export async function getStudioContentPersonByGithub(

--- a/projects/rawkode.studio/src/server/studio.test.ts
+++ b/projects/rawkode.studio/src/server/studio.test.ts
@@ -864,47 +864,31 @@ describe("Studio operations", () => {
 			status: "live",
 			title: "Future Rawkode Live episode",
 		});
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () =>
-				new Response(
-					JSON.stringify({
-						data: {
-							getAllVideos: [
-								{
-									id: "past-video",
-									slug: "past-event",
-									title: "Past event",
-									publishedAt: "2025-08-01T10:00:00.000Z",
-									guests: [],
-									episode: {
-										show: {
-											id: "rawkode-live",
-											name: "Rawkode Live",
-											hosts: [],
-										},
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+			new Response(
+				JSON.stringify({
+					data: {
+						getUpcomingVideos: [
+							{
+								id: "future-video",
+								slug: "future-event",
+								title: "Future event",
+								publishedAt: "2026-08-01T10:00:00.000Z",
+								guests: [],
+								episode: {
+									show: {
+										id: "rawkode-live",
+										name: "Rawkode Live",
+										hosts: [],
 									},
 								},
-								{
-									id: "future-video",
-									slug: "future-event",
-									title: "Future event",
-									publishedAt: "2026-08-01T10:00:00.000Z",
-									guests: [],
-									episode: {
-										show: {
-											id: "rawkode-live",
-											name: "Rawkode Live",
-											hosts: [],
-										},
-									},
-								},
-							],
-						},
-					}),
-				),
+							},
+						],
+					},
+				}),
 			),
 		);
+		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(
 			loadStudioDashboard(user, {
@@ -927,6 +911,11 @@ describe("Studio operations", () => {
 			],
 			isOperator: true,
 		});
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}")) as {
+			query?: string;
+		};
+		expect(request.query).toContain("getUpcomingVideos");
+		expect(request.query).not.toContain("getAllVideos");
 	});
 
 	it("shows non-operators only assigned events and active sessions for those events", async () => {
@@ -1108,7 +1097,7 @@ describe("Studio operations", () => {
 
 	it("creates Studio sessions from content graph video metadata", async () => {
 		const studioDb = createStudioDbMock();
-		const fetchMock = vi.fn(async () =>
+		const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
 			new Response(
 				JSON.stringify({
 					data: {

--- a/projects/rawkode.studio/src/server/studio.ts
+++ b/projects/rawkode.studio/src/server/studio.ts
@@ -1,6 +1,7 @@
 import type { StudioEnv, StudioUser } from "../env";
 import {
 	getStudioContentEvents,
+	getStudioUpcomingContentEvents,
 	type StudioContentVideo,
 } from "./content";
 import type { RealtimeKitMeeting } from "./realtimekit";
@@ -629,13 +630,19 @@ function contentEventIncludesUser(event: StudioContentVideo, user: StudioUser): 
 	].some((person) => personMatchesUser(person, user));
 }
 
-async function loadContentEvents(env: StudioEnv | undefined): Promise<{
+async function loadContentEvents(
+	env: StudioEnv | undefined,
+	options: { upcomingOnly?: boolean } = {},
+): Promise<{
 	error: string | null;
 	events: StudioContentVideo[];
 }> {
 	if (!env) return { error: null, events: [] };
 	try {
-		return { error: null, events: await getStudioContentEvents(env) };
+		const events = options.upcomingOnly
+			? await getStudioUpcomingContentEvents(env)
+			: await getStudioContentEvents(env);
+		return { error: null, events };
 	} catch (error) {
 		return {
 			error: error instanceof Error ? error.message : "Rawkode content graph failed",
@@ -1325,7 +1332,7 @@ export async function loadStudioDashboard(
 	const isOperator = env ? userIsConfiguredStudioOperator(env, user) : false;
 	const [{ error: contentError, events: contentEvents }, allSessions] =
 		await Promise.all([
-			loadContentEvents(env),
+			loadContentEvents(env, { upcomingOnly: isOperator }),
 			listStudioSessions(env),
 		]);
 	const sessionsByContentVideoId = groupSessionsByContentVideoId(allSessions);


### PR DESCRIPTION
## Summary

Fixes the Studio/API schema drift that left `getUpcomingVideos` present in the website subgraph but absent from the deployed API supergraph.

## What changed

- Make API package deploy run `build` before `wrangler deploy`, so direct API deploys collect schemas and compose `supergraph.graphql` first.
- Mark API deploy affected by the schema collection/composition inputs, including website subgraph sources and platform read-model schemas.
- Keep website subgraph SDL generation newline-stable and sync the tracked schema field order with the generator.
- Move Studio operator dashboards to the narrower `getUpcomingVideos` query, with a temporary fallback to `getAllVideos` while older API supergraphs are still deployed.
- Normalize nullish optional form values in Studio actions so missing optional fields do not surface as invalid non-string values.

## Root cause

The website subgraph exposed `getUpcomingVideos`, but the API gateway supergraph was stale. Studio therefore had to query `getAllVideos`, which made the dashboard wait on a large content query and reproduced the roughly 9s server-side latency seen in production.

## Validation

- `bun run test src/server/content.test.ts src/server/studio.test.ts` from `projects/rawkode.studio`
- `bun run check` from `projects/rawkode.studio`
- `bun run build` from `projects/rawkode.studio`
- `bun run build` from `projects/rawkode.academy/api`
- Verified generated `projects/rawkode.academy/api/supergraph.graphql` contains `getUpcomingVideos`