### PR TITLE
fix(rawkode.academy): avoid missing upcoming stream thumbnails

### DIFF
--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -11,6 +11,7 @@ import {
 	resolveTechnologyHorizontalLogoUrl,
 	resolveTechnologyIconUrl,
 } from "@/utils/resolve-technology-icon";
+import { normalizeTechnologyReferences } from "@/utils/normalize-technology-refs";
 
 import VideoMasthead from "@/components/video/VideoMasthead.astro";
 import VideoHero from "@/components/video/VideoHero.astro";
@@ -49,7 +50,10 @@ const upcomingVideos = (await getUpcomingVideos()).map((v) => v.data);
 const visibleUpcomingVideos = upcomingVideos.slice(0, 6);
 const technologyEntries = await getCollection("technologies");
 const technologyById = new Map(
-	technologyEntries.map((technology) => [technology.id, technology]),
+	technologyEntries.map((technology) => [
+		technology.id.replace(/\/index$/, ""),
+		technology,
+	]),
 );
 
 const totalVideoCount = allVideos.length;
@@ -159,9 +163,9 @@ const featuredSeries = featuredVideo
 	: undefined;
 
 const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
-	(video.technologies ?? [])
-		.map((technologyRef) => {
-			const technology = technologyById.get(String(technologyRef));
+	normalizeTechnologyReferences(video.technologies)
+		.map((technologyId) => {
+			const technology = technologyById.get(technologyId);
 			if (!technology) return undefined;
 
 			const horizontalSrc = resolveTechnologyHorizontalLogoUrl(
@@ -265,7 +269,6 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 								<VideoStill
 									title={v.title}
 									series="Upcoming stream"
-									thumbnailUrl={getVideoThumbnailUrl(v.id)}
 									technologyLogos={technologyLogosFor(v)}
 									accent="amber"
 								/>


### PR DESCRIPTION
## What
- Stop upcoming stream cards on `/watch` from requesting missing generated video thumbnails.
- Normalize technology references before resolving upcoming stream logos, so entries like `iroh/index` and `odin/index` map to the repo's technology SVG assets.

## Why
Upcoming streams sometimes do not have video thumbnails yet. Passing the generated thumbnail URL forced the `VideoStill` fallback into a broken remote image path, which surfaced as placeholder question marks instead of the available technology logos.

## Impact
- Upcoming streams without thumbnails now render their technology logo fallback.
- Existing latest-video thumbnail behavior is unchanged.

## Validation
- `git diff --check --cached`
- `bun run build`
- Browser `/watch` verification: Iroh and Odin logo images rendered, and upcoming cards emitted zero remote video thumbnail URLs.