### PR TITLE
fix(rawkode.academy): hide player for upcoming streams

### DIFF
--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -193,6 +193,8 @@ const guestEntries = Array.isArray(video.data.guests)
 const thumbnailUrl = getVideoThumbnailUrl(video.data.id);
 const streamUrl = `https://content.rawkode.academy/videos/${video.data.id}/stream.m3u8`;
 const captionUrl = `https://content.rawkode.academy/videos/${video.data.id}/captions/en.vtt`;
+const now = new Date();
+const isUpcomingLive = video.data.type === "live" && video.data.publishedAt > now;
 
 const META_DESCRIPTION_LIMIT = 160;
 const metaDescription = (() => {
@@ -237,7 +239,7 @@ const user = Astro.locals.user;
 const isAuthenticated = !!user;
 
 let initialPosition = 0;
-if (isAuthenticated && user?.id) {
+if (!isUpcomingLive && isAuthenticated && user?.id) {
 	try {
 		const response = await fetch("https://api.rawkode.academy/graphql", {
 			method: "POST",
@@ -269,6 +271,15 @@ const categoryLabel =
 const isLive = video.data.type === "live";
 const runtimeLabel = formatRuntime(durationSec);
 const publishedLabel = formatDate(video.data.publishedAt);
+const scheduledLabel = new Intl.DateTimeFormat("en-US", {
+	weekday: "long",
+	year: "numeric",
+	month: "long",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
+	timeZoneName: "short",
+}).format(video.data.publishedAt);
 ---
 
 <Page
@@ -337,13 +348,33 @@ const publishedLabel = formatDate(video.data.publishedAt);
 		</header>
 
 		<div class="watch-detail__player-frame">
-			<VideoPlayer
-				client:only="vue"
-				video={video.data.id}
-				thumbnailUrl={thumbnailUrl}
-				initialPosition={initialPosition}
-				isAuthenticated={isAuthenticated}
-			/>
+			{isUpcomingLive ? (
+				<section class="watch-detail__upcoming-player" aria-label="Upcoming stream details">
+					<img
+						class="watch-detail__upcoming-thumbnail"
+						src={thumbnailUrl}
+						alt=""
+						loading="eager"
+					/>
+					<div class="watch-detail__upcoming-scrim"></div>
+					<div class="watch-detail__upcoming-card">
+						<MLabel tone="amber">Upcoming Stream</MLabel>
+						<h2>This session has not started yet.</h2>
+						<p>
+							The video player will appear when the live stream is available.
+							Join us on <time datetime={video.data.publishedAt.toISOString()}>{scheduledLabel}</time>.
+						</p>
+					</div>
+				</section>
+			) : (
+				<VideoPlayer
+					client:only="vue"
+					video={video.data.id}
+					thumbnailUrl={thumbnailUrl}
+					initialPosition={initialPosition}
+					isAuthenticated={isAuthenticated}
+				/>
+			)}
 		</div>
 
 		<div class="watch-detail__body">
@@ -489,6 +520,65 @@ const publishedLabel = formatDate(video.data.publishedAt);
 	.watch-detail__player-frame :global(> *) {
 		position: absolute;
 		inset: 0;
+	}
+
+	.watch-detail__upcoming-player {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		padding: clamp(1.25rem, 4vw, 3rem);
+		overflow: hidden;
+	}
+
+	.watch-detail__upcoming-thumbnail {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		filter: saturate(0.85) brightness(0.55);
+		transform: scale(1.02);
+	}
+
+	.watch-detail__upcoming-scrim {
+		position: absolute;
+		inset: 0;
+		background:
+			linear-gradient(135deg, oklch(0.16 0.04 82 / 0.88), oklch(0.09 0.02 240 / 0.78)),
+			radial-gradient(circle at 50% 50%, transparent 0, oklch(0.08 0.02 240 / 0.78) 70%);
+	}
+
+	.watch-detail__upcoming-card {
+		position: relative;
+		z-index: 1;
+		max-width: 42rem;
+		padding: clamp(1rem, 3vw, 2rem);
+		border: 1px solid oklch(0.88 0.08 82 / 0.32);
+		background: oklch(0.13 0.03 82 / 0.78);
+		backdrop-filter: blur(18px);
+		color: oklch(0.96 0.03 82);
+		text-align: center;
+		box-shadow: 0 1.5rem 4rem oklch(0 0 0 / 0.35);
+	}
+
+	.watch-detail__upcoming-card h2 {
+		margin: 0.75rem 0 0;
+		font-family: var(--font-instrument-serif), serif;
+		font-size: clamp(2rem, 4vw, 3rem);
+		font-style: italic;
+		font-weight: 400;
+		line-height: 1;
+		letter-spacing: -0.02em;
+	}
+
+	.watch-detail__upcoming-card p {
+		margin: 1rem auto 0;
+		max-width: 34rem;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: clamp(0.95rem, 2vw, 1.125rem);
+		line-height: 1.5;
+		color: oklch(0.92 0.03 82 / 0.86);
 	}
 
 	.watch-detail__body {


### PR DESCRIPTION
### Motivation
- Upcoming live sessions mounted the regular video player during server render which can fail when no playable stream exists, producing a broken player experience for scheduled streams.

### Description
- Detect future-dated live videos (`isUpcomingLive`) and render a non-interactive scheduled-stream placeholder instead of mounting the `VideoPlayer` when the session is not yet live.
- Skip the watch-position lookup for upcoming live streams to avoid unnecessary API calls when no playable media exists (`if (!isUpcomingLive && isAuthenticated ...)`).
- Add a human-friendly scheduled time label (`scheduledLabel`) and a centered placeholder card that uses the video thumbnail, scrim, and label treatment for the upcoming state.
- Add CSS for the upcoming placeholder and integrate the behavior into the watch detail page (`projects/rawkode.academy/website/src/pages/watch/[...slug].astro`).

### Testing
- Ran `bunx biome check 'src/pages/watch/[...slug].astro'` which succeeded and reported the file as formatted/valid.
- Attempted `bun run build` but `astro` was unavailable because workspace dependencies are not installed in this checkout, so the build could not be completed in this environment (blocked by missing workspace packages).
- `bun install` failed to resolve several workspace packages present in the monorepo, so dependency installation did not complete.
- `bunx astro check` could not complete under the default Node (v20.20.2); running under Node 22.12.0 reached Astro's interactive dependency prompt which is not usable in this non-interactive CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a240efdf3c08331a83beb9f80c45a7c)