### PR TITLE
fix(rawkode.academy): cache video collection for GraphQL

### DIFF
--- a/projects/rawkode.academy/website/src/subgraph/loaders/videos.ts
+++ b/projects/rawkode.academy/website/src/subgraph/loaders/videos.ts
@@ -30,54 +30,98 @@ export interface VideoItem {
 	chapters: Array<{ startTime: number; title: string }>;
 }
 
-export async function listVideos(): Promise<VideoItem[]> {
+interface VideoStore {
+	videos: VideoItem[];
+	byId: Map<string, VideoItem>;
+	bySlug: Map<string, VideoItem>;
+	byShow: Map<string, VideoItem[]>;
+}
+
+let videoStorePromise: Promise<VideoStore> | undefined;
+
+function toVideoItem(e: VideoEntry): VideoItem {
+	const data = e.data;
+	return {
+		id: data.id, // video asset ID
+		slug: data.slug, // human-readable URL identifier
+		title: data.title,
+		subtitle: data.subtitle,
+		description: data.description,
+		terms: data.terms,
+		publishedAt: data.publishedAt,
+		duration: data.duration,
+		type: data.type,
+		category: data.category,
+		streamUrl: `https://content.rawkode.academy/videos/${data.id}/stream.m3u8`,
+		thumbnailUrl: getVideoThumbnailUrl(data.id),
+		technologies: (data.technologies ?? []).map((t: any) =>
+			typeof t === "string" ? t : t.id,
+		),
+		show: data.show
+			? typeof data.show === "string"
+				? data.show
+				: data.show.id
+			: undefined,
+		guests: (data.guests ?? []).map((g: any) =>
+			typeof g === "string" ? g : g.id,
+		),
+		chapters: data.chapters ?? [],
+	} satisfies VideoItem;
+}
+
+async function loadVideoStore(): Promise<VideoStore> {
 	const { getCollection } = await import("astro:content");
 
 	const items = await getCollection("videos");
-	return items.map((e: VideoEntry) => {
-		const data = e.data;
-		return {
-			id: data.id, // video asset ID
-			slug: data.slug, // human-readable URL identifier
-			title: data.title,
-			subtitle: data.subtitle,
-			description: data.description,
-			terms: data.terms,
-			publishedAt: data.publishedAt,
-			duration: data.duration,
-			type: data.type,
-			category: data.category,
-			streamUrl: `https://content.rawkode.academy/videos/${data.id}/stream.m3u8`,
-			thumbnailUrl: getVideoThumbnailUrl(data.id),
-			technologies: (data.technologies ?? []).map((t: any) =>
-				typeof t === "string" ? t : t.id,
-			),
-			show: data.show
-				? typeof data.show === "string"
-					? data.show
-					: data.show.id
-				: undefined,
-			guests: (data.guests ?? []).map((g: any) =>
-				typeof g === "string" ? g : g.id,
-			),
-			chapters: data.chapters ?? [],
-		} satisfies VideoItem;
+	const videos = items.map((e: VideoEntry) => toVideoItem(e));
+	const byId = new Map<string, VideoItem>();
+	const bySlug = new Map<string, VideoItem>();
+	const byShow = new Map<string, VideoItem[]>();
+
+	for (const video of videos) {
+		byId.set(video.id, video);
+		bySlug.set(video.slug, video);
+
+		if (video.show) {
+			const showVideos = byShow.get(video.show) ?? [];
+			showVideos.push(video);
+			byShow.set(video.show, showVideos);
+		}
+	}
+
+	return { videos, byId, bySlug, byShow };
+}
+
+async function getVideoStore(): Promise<VideoStore> {
+	videoStorePromise ??= loadVideoStore().catch((error) => {
+		videoStorePromise = undefined;
+		throw error;
 	});
+	return videoStorePromise;
+}
+
+export function resetVideoLoaderCacheForTests(): void {
+	videoStorePromise = undefined;
+}
+
+export async function listVideos(): Promise<VideoItem[]> {
+	const store = await getVideoStore();
+	return [...store.videos];
 }
 
 export async function getVideoById(id: string): Promise<VideoItem | null> {
-	const list = await listVideos();
-	return list.find((v) => v.id === id) ?? null;
+	const store = await getVideoStore();
+	return store.byId.get(id) ?? null;
 }
 
 export async function getVideoBySlug(slug: string): Promise<VideoItem | null> {
-	const list = await listVideos();
-	return list.find((v) => v.slug === slug) ?? null;
+	const store = await getVideoStore();
+	return store.bySlug.get(slug) ?? null;
 }
 
 export async function getVideosByShow(showId: string): Promise<VideoItem[]> {
-	const list = await listVideos();
-	return list.filter((v) => v.show === showId);
+	const store = await getVideoStore();
+	return [...(store.byShow.get(showId) ?? [])];
 }
 
 export async function getPublishedVideos(): Promise<VideoItem[]> {

--- a/projects/rawkode.academy/website/src/tests/video-loader.test.ts
+++ b/projects/rawkode.academy/website/src/tests/video-loader.test.ts
@@ -2,9 +2,12 @@ import { getCollection } from "astro:content";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+	getVideoById,
+	getVideoBySlug,
 	getPublishedVideos,
 	getUpcomingVideos,
 	listVideos,
+	resetVideoLoaderCacheForTests,
 } from "../subgraph/loaders/videos";
 
 const mockedGetCollection = vi.mocked(getCollection);
@@ -13,14 +16,16 @@ function videoEntry(input: {
 	id: string;
 	publishedAt: Date;
 	title: string;
+	slug?: string;
 	type?: "live" | "recorded";
+	show?: string;
 }) {
 	return {
 		id: input.id,
 		body: "",
 		data: {
 			id: input.id,
-			slug: input.id,
+			slug: input.slug ?? input.id,
 			title: input.title,
 			subtitle: undefined,
 			description: `${input.title} description`,
@@ -29,7 +34,7 @@ function videoEntry(input: {
 			type: input.type ?? "live",
 			category: "tutorial",
 			technologies: [],
-			show: "rawkode-live",
+			show: input.show ?? "rawkode-live",
 			guests: [],
 			chapters: [],
 		},
@@ -39,9 +44,11 @@ function videoEntry(input: {
 describe("video subgraph loader", () => {
 	beforeEach(() => {
 		mockedGetCollection.mockReset();
+		resetVideoLoaderCacheForTests();
 	});
 
 	afterEach(() => {
+		resetVideoLoaderCacheForTests();
 		vi.useRealTimers();
 	});
 
@@ -78,5 +85,34 @@ describe("video subgraph loader", () => {
 			{ id: "upcoming-iroh" },
 			{ id: "upcoming-odin" },
 		]);
+	});
+
+	it("caches the mapped video collection across loader helpers", async () => {
+		const videos = [
+			videoEntry({
+				id: "cached-video",
+				slug: "cached-video-slug",
+				title: "Cached Video",
+				publishedAt: new Date("2026-06-03T00:00:00.000Z"),
+			}),
+			videoEntry({
+				id: "other-video",
+				title: "Other Video",
+				publishedAt: new Date("2026-06-04T00:00:00.000Z"),
+				show: "other-show",
+			}),
+		];
+		mockedGetCollection.mockResolvedValue(videos as never);
+
+		await expect(listVideos()).resolves.toHaveLength(2);
+		await expect(getVideoById("cached-video")).resolves.toMatchObject({
+			id: "cached-video",
+		});
+		await expect(getVideoBySlug("cached-video-slug")).resolves.toMatchObject({
+			id: "cached-video",
+		});
+		await expect(getPublishedVideos()).resolves.toHaveLength(2);
+
+		expect(mockedGetCollection).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

- Cache the mapped Astro `videos` collection behind a per-worker promise.
- Build `id`, `slug`, and `show` indexes so GraphQL loader helpers stop reloading and rescanning all videos.
- Add focused loader coverage proving multiple helpers share one `getCollection("videos")` call.

## Why

`getAllVideos` resolves through `listVideos()`, which previously imported and mapped the full Astro content collection on every resolver call. Other video lookups also called `listVideos()` and rescanned the same collection. This change moves that work to one cached load per worker isolate while preserving copied array returns for callers that sort/filter.

## Validation

- `git diff --check` passes.
- `bun run test src/tests/video-loader.test.ts` is blocked: `vitest` is not installed in this checkout.
- `bun install --frozen-lockfile` is blocked by unresolved workspace dependencies: `email-preferences`, `ski-achievements`, `ski-leaderboard`, `ski-player-learned-phrases`, `ski-player-stats`, and `ski-share-cards`.
- `nix run nixpkgs#biome -- check --config-path=projects/rawkode.academy/website/biome.json ...` is blocked before file checks by Biome's nested root configuration error.