### PR TITLE
fix(rawkode.academy): wait for notification service worker

### DIFF
--- a/projects/rawkode.academy/website/src/components/video/StreamNotifyButton.vue
+++ b/projects/rawkode.academy/website/src/components/video/StreamNotifyButton.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
 import { actions } from "astro:actions";
 import {
 	BellIcon,
 	CheckCircleIcon,
 	ExclamationTriangleIcon,
 } from "@heroicons/vue/24/outline";
+import { computed, onMounted, ref } from "vue";
+import { getNotificationServiceWorkerRegistration } from "@/lib/notification-service-worker";
 
 const props = defineProps<{
 	videoSlug: string;
@@ -84,9 +85,7 @@ function hasWebPushSupport(): boolean {
 }
 
 async function getRegistration(): Promise<ServiceWorkerRegistration> {
-	return navigator.serviceWorker.register("/notification-service-worker.js", {
-		scope: "/",
-	});
+	return getNotificationServiceWorkerRegistration(navigator.serviceWorker);
 }
 
 async function checkExistingSubscription() {

--- a/projects/rawkode.academy/website/src/lib/notification-service-worker.ts
+++ b/projects/rawkode.academy/website/src/lib/notification-service-worker.ts
@@ -1,0 +1,15 @@
+const notificationServiceWorkerUrl = "/notification-service-worker.js";
+const notificationServiceWorkerScope = "/";
+
+export async function getNotificationServiceWorkerRegistration(
+	serviceWorker: Pick<ServiceWorkerContainer, "ready" | "register">,
+): Promise<ServiceWorkerRegistration> {
+	const registration = await serviceWorker.register(
+		notificationServiceWorkerUrl,
+		{
+			scope: notificationServiceWorkerScope,
+		},
+	);
+
+	return registration.active ? registration : serviceWorker.ready;
+}

--- a/projects/rawkode.academy/website/src/tests/stream-notifications.test.ts
+++ b/projects/rawkode.academy/website/src/tests/stream-notifications.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getNotificationServiceWorkerRegistration } from "@/lib/notification-service-worker";
 import {
 	buildStreamNotification,
 	isUpcomingLiveVideo,
@@ -60,5 +61,22 @@ describe("stream notifications", () => {
 		expect(streamNotificationSubjectKey("hands-on-introduction-to-iroh")).toBe(
 			"stream:hands-on-introduction-to-iroh",
 		);
+	});
+
+	it("waits for an active service worker before subscribing", async () => {
+		const activeRegistration = {
+			active: {},
+		} as ServiceWorkerRegistration;
+		const installingRegistration = {
+			active: null,
+		} as ServiceWorkerRegistration;
+		const serviceWorker = {
+			register: async () => installingRegistration,
+			ready: Promise.resolve(activeRegistration),
+		} satisfies Pick<ServiceWorkerContainer, "ready" | "register">;
+
+		await expect(
+			getNotificationServiceWorkerRegistration(serviceWorker),
+		).resolves.toBe(activeRegistration);
 	});
 });


### PR DESCRIPTION
## What changed

- Added a small notification service worker registration helper for the Rawkode Academy website.
- Updated the stream notification button to wait for an active service worker registration before reading or creating push subscriptions.
- Added a regression test for the service worker readiness path.

## Why

Browsers can resolve `navigator.serviceWorker.register()` before the registered worker is active. Calling `registration.pushManager.subscribe()` during that installing/waiting window can fail with `Subscription failed - no active Service Worker`.

## Validation

- `bun run test -- src/tests/stream-notifications.test.ts`
- `bun run build`
- `bunx biome check src/lib/notification-service-worker.ts src/tests/stream-notifications.test.ts`

Note: `biome check` directly on `StreamNotifyButton.vue` still reports existing script-setup/template false positives for template-used bindings.