### PR TITLE
fix(rawkode.academy): move learnings into watch overview

### DIFF
--- a/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
+++ b/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
@@ -47,28 +47,6 @@
 
  <!-- Tab Content -->
  <div class="p-4 sm:p-6 relative z-10">
- <!-- Description Panel -->
- <div
- v-show="activeTab === 'description'"
- id="video-panel-description"
- role="tabpanel"
- aria-labelledby="video-tab-description"
- >
- <div class="space-y-6">
- <section v-if="whatYouWillLearn.length > 0" aria-labelledby="video-learn-heading">
- <h3 id="video-learn-heading" class="text-sm font-semibold text-muted uppercase tracking-wider mb-3">
- What You'll Learn
- </h3>
- <ol class="video-learn-list">
- <li v-for="item in whatYouWillLearn" :key="item">
- {{ item }}
- </li>
- </ol>
- </section>
- <section v-if="descriptionHtml" class="prose prose-lg dark:prose-invert max-w-none" v-html="descriptionHtml" />
- </div>
- </div>
-
  <!-- Comments Panel -->
  <div
  v-show="activeTab === 'comments'"
@@ -209,20 +187,11 @@ export default {
 			type: Array,
 			default: () => [],
 		},
-		descriptionHtml: {
-			type: String,
-			default: "",
-		},
-		whatYouWillLearn: {
-			type: Array,
-			default: () => [],
-		},
 	},
 	data() {
 		return {
-			activeTab: "description",
+			activeTab: "resources",
 			tabs: [
-				{ id: "description", label: "Description" },
 				{ id: "comments", label: "Comments" },
 				{ id: "transcript", label: "Transcript" },
 				{ id: "resources", label: "Resources" },
@@ -278,46 +247,6 @@ nav {
 /* Additional spacing for prose paragraphs */
 .prose :deep(p) {
  margin-bottom: 1.5rem;
-}
-
-.video-learn-list {
- counter-reset: video-learn-item;
- display: grid;
- gap: 0.875rem;
- margin: 0;
- padding: 0;
- list-style: none;
-}
-
-.video-learn-list li {
- counter-increment: video-learn-item;
- display: grid;
- grid-template-columns: 2rem minmax(0, 1fr);
- gap: 0.875rem;
- align-items: start;
- color: var(--editorial-ink, rgb(17 24 39));
- line-height: 1.6;
-}
-
-.video-learn-list li::before {
- content: counter(video-learn-item);
- display: inline-grid;
- place-items: center;
- width: 2rem;
- height: 2rem;
- border-radius: 999px;
- border: 1px solid color-mix(in srgb, var(--editorial-spruce, rgb(13 148 136)) 35%, transparent);
- background: color-mix(in srgb, var(--editorial-spruce, rgb(13 148 136)) 10%, transparent);
- color: var(--editorial-spruce, rgb(13 148 136));
- font-size: 0.75rem;
- font-weight: 700;
- line-height: 1;
- margin-top: 0.125rem;
- font-variant-numeric: tabular-nums;
-}
-
-.dark .video-learn-list li {
- color: rgb(229 231 235);
 }
 
 /* Clean, professional link styles */

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -423,6 +423,18 @@ const notificationsPublicKey = env.NOTIFICATIONS_VAPID_PUBLIC_KEY ?? "";
 			<section class="watch-detail__overview">
 				<MLabel tone="spruce">§ Overview</MLabel>
 				<h2 class="watch-detail__overview-title">About this video</h2>
+				{video.data.whatYouWillLearn.length > 0 && (
+					<section class="watch-detail__learn" aria-labelledby="watch-detail-learn-heading">
+						<h3 id="watch-detail-learn-heading" class="watch-detail__learn-title">
+							What You'll Learn
+						</h3>
+						<ol class="watch-detail__learn-list">
+							{video.data.whatYouWillLearn.map((item) => (
+								<li>{item}</li>
+							))}
+						</ol>
+					</section>
+				)}
 				<div class="prose" set:html={renderedDescriptionHtml} />
 			</section>
 
@@ -457,8 +469,6 @@ const notificationsPublicKey = env.NOTIFICATIONS_VAPID_PUBLIC_KEY ?? "";
 			<VideoContentTabs
 				client:idle
 				videoId={video.data.id}
-				descriptionHtml={renderedDescriptionHtml}
-				whatYouWillLearn={video.data.whatYouWillLearn}
 				resources={video.data.resources ?? []}
 			/>
 
@@ -624,6 +634,59 @@ const notificationsPublicKey = env.NOTIFICATIONS_VAPID_PUBLIC_KEY ?? "";
 	}
 
 	.watch-detail__overview .prose { max-width: 48rem; }
+
+	.watch-detail__learn {
+		max-width: 48rem;
+		margin: 0;
+	}
+
+	.watch-detail__learn-title {
+		margin: 0 0 0.75rem;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		line-height: 1.2;
+		text-transform: uppercase;
+		color: var(--editorial-ink-mute);
+	}
+
+	.watch-detail__learn-list {
+		counter-reset: watch-learn-item;
+		display: grid;
+		gap: 0.875rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.watch-detail__learn-list li {
+		counter-increment: watch-learn-item;
+		display: grid;
+		grid-template-columns: 2rem minmax(0, 1fr);
+		gap: 0.875rem;
+		align-items: start;
+		color: var(--editorial-ink);
+		line-height: 1.6;
+	}
+
+	.watch-detail__learn-list li::before {
+		content: counter(watch-learn-item);
+		display: inline-grid;
+		place-items: center;
+		width: 2rem;
+		height: 2rem;
+		margin-top: 0.125rem;
+		border-radius: 999px;
+		border: 1px solid color-mix(in oklch, var(--editorial-spruce) 35%, transparent);
+		background: var(--editorial-spruce-dim);
+		color: var(--editorial-spruce);
+		font-family: var(--font-jetbrains-mono), monospace;
+		font-size: 0.75rem;
+		font-weight: 700;
+		line-height: 1;
+		font-variant-numeric: tabular-nums;
+	}
 
 	.watch-detail__tech {
 		display: flex;


### PR DESCRIPTION
Summary: Moves the learning list into the existing watch overview and removes the duplicate Description tab from the hydrated video tabs. Validation: cuenv sync -A; bun run test:performance; bun run build; browser check on /watch/introduction-to-gitpod.