### PR TITLE
Rawkode Academy News - June 9, 2026

### DIFF
--- a/content/news/2026-06-09-nccl-opentelemetry-cert-manager/index.mdx
+++ b/content/news/2026-06-09-nccl-opentelemetry-cert-manager/index.mdx
@@ -1,0 +1,48 @@
+---
+title: "NCCL EP, OpenTelemetry Collector, and cert-manager ship runtime changes"
+description: "NVIDIA published NCCL EP v0.1.0 for MoE expert-parallel communication, OpenTelemetry Collector v0.154.0 tightened builder behavior and queue config handling, and cert-manager v1.21.0-alpha.1 added Gateway API and issuer fixes."
+publishedAt: 2026-06-09
+authors:
+  - rawkode
+technologies:
+  - opentelemetry
+  - cert-manager
+---
+
+Three fresh releases landed in the last 24 hours across AI/HPC communication, telemetry collection, and certificate automation.
+
+## NCCL EP v0.1.0 targets MoE expert-parallel communication
+
+NVIDIA published NCCL EP v0.1.0 on June 8 as an NCCL API extension for Mixture-of-Experts communication. It adds dispatch and combine primitives for Expert Parallelism across distributed GPU systems on top of NCCL Device API LSA and GIN operations.
+
+The release changes EP tensor memory ownership to caller-managed allocations, separates handle initialization from routing updates for CUDA Graph-compatible data paths, lets users set NCCL EP SM usage, associates EP tensors with NCCL Windows for zero-copy paths, and adds active-rank masks so failed ranks can be excluded without aborting. It also moves HT mode to JIT compilation, adds Multi-node NVLINK support, removes rank-count limits in LSA teams, and removes CUDA IPC dependencies by migrating to NCCL infrastructure.
+
+For teams serving MoE models, the concrete change is a communication path built around dispatch and combine rather than treating expert routing as generic collectives.
+
+**Source:** [NVIDIA NCCL EP v0.1.0 release](https://github.com/NVIDIA/nccl/releases/tag/nccl-ep-v0.1.0) - June 8, 2026
+
+---
+
+## OpenTelemetry Collector v0.154.0 makes builder skip behavior real
+
+OpenTelemetry Collector released v1.60.0/v0.154.0 on June 8. The user-visible breaking change fixes `ocb --skip-get-modules` so it no longer regenerates `go.mod`, matching the builder flag contract.
+
+The release adds an `include_insecure_cipher_suites` config option in `configtls`, with insecure suites disabled by default, and adds `ExposedHeaders` to HTTP CORS config. It also fixes a collector startup panic when `sending_queue::sizer` is configured while batching is disabled.
+
+For collector distribution maintainers, the builder change matters because the flag now leaves existing module files untouched.
+
+**Source:** [OpenTelemetry Collector v1.60.0/v0.154.0 release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0) - June 8, 2026
+
+---
+
+## cert-manager v1.21.0-alpha.1 adds Gateway API and issuer plumbing
+
+cert-manager published v1.21.0-alpha.1 on June 8 as a testing-only pre-release. It adds Venafi OAuth token request observability plus an `AuthFailed` Issuer condition reason, a controller flag to propagate Helm `global.commonLabels` to ACME HTTP-01 solver Pods, Services, Ingresses, and Gateway API HTTPRoutes, and Gateway API options for ignored TLS listeners and additional listener protocols.
+
+Bug fixes include DNS issuer secret validation before readiness, missing issuer-finalizer RBAC for order controller owner references, namespace-scoped metrics collector startup behavior, a Venafi TPP signing regression, 30-second negative caching for CRD-missing discovery in the `certificateRequestApproval` webhook, and an infinite re-issuance loop when an issuer returns an already expired certificate.
+
+This is not an upgrade target, but it is a useful preview of where the 1.21 line is tightening issuer diagnostics and Gateway API automation.
+
+**Source:** [cert-manager v1.21.0-alpha.1 release](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0-alpha.1) - June 8, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest ships three fresh, primary-sourced items from the last 24 hours: NCCL EP v0.1.0 for MoE expert-parallel communication, OpenTelemetry Collector v0.154.0 for collector builder/config fixes, and cert-manager v1.21.0-alpha.1 for issuer diagnostics and Gateway API plumbing. Older releases, vendor roundups, and stale artifacts were cut rather than padded into the issue.

## Run metadata

- Run time: `2026-06-09 07:01 Europe/London`
- Coverage window: `2026-06-08 07:01 BST` to `2026-06-09 07:01 BST`
- Source URLs inspected: `34`
- Candidates longlisted: `10`
- Candidates shortlisted: `3`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- NCCL EP v0.1.0 targets MoE expert-parallel communication - matters because MoE serving gets dispatch/combine primitives instead of only generic collective paths.
- OpenTelemetry Collector v0.154.0 makes builder skip behavior real - matters because custom collector distributions can rely on `ocb --skip-get-modules` leaving module files untouched.
- cert-manager v1.21.0-alpha.1 adds Gateway API and issuer plumbing - matters because the 1.21 alpha tightens issuer failure diagnostics and Gateway API automation paths.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| NCCL EP v0.1.0 was published on June 8 and is an NCCL API extension for Expert Parallelism. | https://github.com/NVIDIA/nccl/releases/tag/nccl-ep-v0.1.0, release heading and description | ✅ |
| NCCL EP adds dispatch/combine primitives, caller-managed tensor memory, CUDA Graph-compatible routing updates, SM usage controls, NCCL Window association, active-rank masks, HT JIT compilation, Multi-node NVLINK, larger LSA teams, and no CUDA IPC dependency. | https://github.com/NVIDIA/nccl/releases/tag/nccl-ep-v0.1.0, What's Changed | ✅ |
| OpenTelemetry Collector v1.60.0/v0.154.0 was published on June 8. | https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0, release heading | ✅ |
| OpenTelemetry Collector v0.154.0 fixes `ocb --skip-get-modules`, adds `include_insecure_cipher_suites`, adds CORS `ExposedHeaders`, and fixes a queue-sizer startup panic. | https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0, Breaking changes / Configuration / Bug fixes | ✅ |
| cert-manager v1.21.0-alpha.1 was published on June 8 as a testing-only pre-release. | https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0-alpha.1, release heading and pre-release notice | ✅ |
| cert-manager v1.21.0-alpha.1 adds Venafi OAuth observability, `AuthFailed`, common-label propagation for ACME HTTP-01 solver resources, Gateway API listener options, and the listed issuer/webhook bug fixes. | https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0-alpha.1, Changes since v1.20.0 | ✅ |

## Items considered and dropped

- CNCF / Portworx VirtBench post - fresh article, but the benchmark repository artifact was older and the source framing was vendor-shaped.
- AWS Weekly Roundup / EKS 1.36 - roundup was fresh, but the canonical EKS announcement was outside the 24-hour window.
- OpenTelemetry Collector Contrib and OpenTelemetry Operator - latest releases inspected were stale for this window.
- vLLM, SGLang, Helm, containerd, CRI-O, etcd, Gateway API, Kueue, Cluster API, Backstage, Kyverno, Falco, SPIRE, and cosign - no fresh primary release or material update found inside the window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 10
- Segments shipped: 3
- Any unresolved framing concerns: none
- Any vendor-attributed claims: NVIDIA NCCL EP is a vendor-hosted technical release; claims are limited to the release notes.

## Validation

- `git diff --check`
- Banned-word scan over the new digest file
- Frontmatter/source-count sanity check over the new digest file

Full site build was not run; the prior Rawkode News Team workflow treats lightweight content checks as the honest path when workspace/build availability is uncertain.