### PR TITLE
Rawkode Academy News - June 11, 2026

### DIFF
--- a/content/news/2026-06-11-gateway-api-envoy-gke-backstage/index.mdx
+++ b/content/news/2026-06-11-gateway-api-envoy-gke-backstage/index.mdx
@@ -1,0 +1,53 @@
+---
+title: "Gateway API, Envoy, GKE, and Backstage ship routing and platform fixes"
+description: "Gateway API v1.6.0-rc.1 moves TCPRoute and UDPRoute toward v1, Envoy patches HTTP/2 observability and cookie controls, Google details GKE Inference Gateway routing, and Backstage fixes Microsoft Graph user sync."
+publishedAt: 2026-06-11
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - envoy
+  - backstage
+---
+
+Four fresh infrastructure updates landed in the last 24 hours across Kubernetes networking APIs, Envoy HTTP/2 controls, AI inference routing, and Backstage catalog sync.
+
+## Gateway API v1.6.0-rc.1 moves TCPRoute and UDPRoute to GA
+
+Gateway API published v1.6.0-rc.1 on June 10. The release candidate graduates TCPRoute and UDPRoute to the v1 API version, deprecates v1alpha2 for those APIs, and adds UDPRoute conformance profile coverage plus TCPRoute feature support.
+
+Other changes are operator-visible: HTTPRoute retry validation now requires unique `retry.codes` values and `retry.attempts >= 1`, CORS moves into the standard channel, and a ValidatingAdmissionPolicy blocks mixed experimental and standard CRDs, monthly releases, and older releases in unsafe install paths. TLSRoute host and rule limits expand, but the release notes tell operators to validate kube-apiserver, etcd, and Gateway controller behavior before enabling larger manifests in production.
+
+**Source:** [Gateway API v1.6.0-rc.1 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.1) - June 10, 2026
+
+---
+
+## Envoy patches HTTP/2 observability across four supported branches
+
+Envoy released v1.35.12, v1.36.8, v1.37.4, and v1.38.2 on June 10. All four releases carry the same runtime and HTTP/2 changes, so operators can pick up the fix without jumping branches.
+
+Deleting an RTDS runtime guard override now restores the process-wide default runtime guard value. Envoy also adds opt-in HTTP/2 histograms for header-entry count, header-map byte size, reassembled `cookie` header length, and individual `cookie` header count, plus a new `envoy.reloadable_features.http2_max_cookies_size_in_kb` guard to cap reassembled `cookie` header size; the default leaves the limit off.
+
+**Source:** [Envoy v1.38.2 release](https://github.com/envoyproxy/envoy/releases/tag/v1.38.2) - June 10, 2026
+
+---
+
+## Google details prefix-cache-aware routing in GKE Inference Gateway
+
+Google published a June 10 post on GKE Inference Gateway prefix-cache routing for LLM serving. The linked [GKE Inference Gateway documentation](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/about-gke-inference-gateway) describes it as a GKE Gateway extension powered by llm-d that uses model-server signals such as KV cache hits, GPU or TPU utilization, and request queue length to choose a serving pod.
+
+Instead of round-robin placement, the gateway can route requests with shared prompt context to replicas that already hold matching KV cache state. Google attributes benchmark results to Principled Technologies showing 7,169.21 output tokens per second versus 6,042.05, 188.36 ms mean time to first token versus 2624.73 ms, and 30.20 ms mean inter-token latency versus 81.03 ms against a third-party managed Kubernetes service; treat those as vendor-published benchmark claims unless you can reproduce the workload.
+
+**Source:** [Google Cloud Blog](https://cloud.google.com/blog/products/containers-kubernetes/gke-inference-gateway-prefix-caching-accelerates-ai-inference) - June 10, 2026
+
+---
+
+## Backstage v1.51.2 fixes Microsoft Graph user drops
+
+Backstage released v1.51.2 on June 10. The patch fixes an empty `userSelect` value causing all users to be dropped in the Microsoft Graph module.
+
+That is narrow but operationally important for portals whose catalog identity source is Microsoft Graph: the failure mode is missing users, not a cosmetic sync warning. Teams using the msgraph module should compare local config against the patch before assuming catalog data loss is an upstream directory issue.
+
+**Source:** [Backstage v1.51.2 release](https://github.com/backstage/backstage/releases/tag/v1.51.2) - June 10, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest ships four fresh infrastructure items from the strict 24-hour window: Gateway API v1.6.0-rc.1, Envoy's June 10 patch train, Google's GKE Inference Gateway prefix-cache routing write-up, and Backstage v1.51.2. The cut favors operator-visible API, proxy, AI serving, and catalog-sync changes over thin pre-release notes and stale vendor posts.

## Run metadata

- Run time: `2026-06-11 07:03 Europe/London`
- Coverage window: `2026-06-10 07:03 BST` to `2026-06-11 07:03 BST`
- Source URLs inspected: `54`
- Candidates longlisted: `10`
- Candidates shortlisted: `4`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- Gateway API v1.6.0-rc.1 moves TCPRoute and UDPRoute to GA - route APIs move to v1, validation tightens, and conformance coverage expands.
- Envoy patches HTTP/2 observability across four supported branches - supported branches pick up RTDS guard restoration plus opt-in HTTP/2 header and cookie metrics/limits.
- Google details prefix-cache-aware routing in GKE Inference Gateway - GKE documents llm-d-backed Gateway routing using model-server signals for LLM serving.
- Backstage v1.51.2 fixes Microsoft Graph user drops - a narrow msgraph patch prevents empty `userSelect` from dropping all users.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Gateway API v1.6.0-rc.1 was released on June 10 and marks TCPRoute and UDPRoute as GA/v1 while deprecating v1alpha2. | https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.1, release heading and GEP/API Graduation | yes |
| Gateway API v1.6.0-rc.1 tightens HTTPRoute retry validation, moves CORS into the standard channel, adds safe-install ValidatingAdmissionPolicy checks, and adds UDP/TCP conformance coverage. | https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.1, Feature and Test & Conformance sections | yes |
| Envoy v1.35.12, v1.36.8, v1.37.4, and v1.38.2 were released on June 10. | https://github.com/envoyproxy/envoy/releases, release headings | yes |
| Envoy's June 10 patch train fixes RTDS runtime guard override removal and adds opt-in HTTP/2 header histograms plus a cookie-size runtime guard. | https://github.com/envoyproxy/envoy/releases/tag/v1.38.2, Summary of changes | yes |
| Google published the GKE Inference Gateway prefix-caching post on June 10. | https://cloud.google.com/blog/products/containers-kubernetes/gke-inference-gateway-prefix-caching-accelerates-ai-inference, article date | yes |
| GKE Inference Gateway is documented as a GKE Gateway extension powered by llm-d using KV cache hits, accelerator utilization, and queue length signals. | https://docs.cloud.google.com/kubernetes-engine/docs/concepts/about-gke-inference-gateway, Overview and Features and benefits | yes |
| Google attributes the 7,169.21 vs 6,042.05 output-token throughput, 188.36 ms vs 2624.73 ms TTFT, and 30.20 ms vs 81.03 ms ITL benchmark numbers to Principled Technologies. | https://cloud.google.com/blog/products/containers-kubernetes/gke-inference-gateway-prefix-caching-accelerates-ai-inference, benchmark section | yes, vendor-attributed |
| Backstage v1.51.2 was released on June 10 and fixes empty `userSelect` dropping all users in the msgraph module. | https://github.com/backstage/backstage/releases/tag/v1.51.2, release notes | yes |

## Items considered and dropped

- Falco 0.44.1-rc1 - fresh, but a one-line pre-release note about disabling BPF iterators did not clear the substance bar.
- TensorRT-LLM 1.2.0rc18 - published before the run window and too vendor-heavy for a rescue.
- AWS Bitnami image removal from ECR Public - operationally relevant, but the canonical AWS post was published May 18; June 10 was the service-change date, not a fresh source date.
- Google GKE standby buffers - stale June 2 article.
- vLLM v0.22.1 - stale June 5 release.
- Cilium 1.20.0-pre.3 - stale June 2 pre-release.
- OpenTelemetry Collector v0.154.0 - stale June 8 release already considered in the prior run.
- CNCF External Secrets Operator member post - stale June 9 member post without a fresh primary artifact.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `10`
- Segments shipped: `4`
- Any unresolved framing concerns: Google benchmark numbers are vendor-published and explicitly attributed.
- Any vendor-attributed claims: GKE Inference Gateway benchmark results only.
- Local validation: `git diff --check`, banned-word scan, source-count sanity, and heading-count sanity passed.
- Full site build was not run; no dependency install or Bun workspace command was needed for this content-only change.
- Local Git branch/stage was blocked by linked-worktree lock permissions (`HEAD.lock` and `index.lock`), so the branch and commit were created through the GitHub connector.