### PR TITLE
feat(rawkode.academy/website): rework partnerships sales page for conversion

### DIFF
--- a/.impeccable/critique/2026-06-12T17-36-31Z__e-src-pages-organizations-partnerships-index-astro.md
+++ b/.impeccable/critique/2026-06-12T17-36-31Z__e-src-pages-organizations-partnerships-index-astro.md
@@ -1,0 +1,61 @@
+---
+target: partnerships sales page (/organizations/partnerships)
+total_score: 22
+p0_count: 1
+p1_count: 3
+timestamp: 2026-06-12T17-36-31Z
+slug: e-src-pages-organizations-partnerships-index-astro
+---
+# Critique: /organizations/partnerships (primary sales page)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | CTA silently hands off to mail client, no on-page confirmation of next step |
+| 2 | Match System / Real World | 1 | "Signal read", "sharper friction", "launch motions": buyer must translate the whole page |
+| 3 | User Control and Freedom | 2 | mailto: is the only contact path; no form, calendar, or visible plain-text address |
+| 4 | Consistency and Standards | 2 | Sells "Council"; the pages funneling here sell "Launch". Re-implements existing primitives |
+| 5 | Error Prevention | 2 | 8-field pre-encoded mailto body breaks in corporate webmail; no recovery path |
+| 6 | Recognition Rather Than Recall | 2 | "Everything in Signal/Adoption" forces cross-card recall; jargon never defined |
+| 7 | Flexibility and Efficiency | 2 | No fast path for high-intent buyers (no call booking) |
+| 8 | Aesthetic and Minimalist Design | 3 | Hairline/paper discipline is handsome; 8 identical section rhythms, 14 always-open bullets |
+| 9 | Error Recovery | 2 | "Not a good fit" path handled well in copy; failed mailto is a dead end |
+| 10 | Help and Documentation | 3 | 7-question FAQ with JSON-LD, explicit scope boundaries; strongest heuristic |
+| **Total** | | **22/40** | **Acceptable: significant improvements needed** |
+
+## Anti-Patterns Verdict
+
+LLM assessment: reads AI-assembled. Eyebrow kicker on all 8 sections; three different numbered/labeled list devices; "Each month..." opens six sentences; abstract-noun counts: adoption ×35, proof ×20, signal ×19, narrative ×7, friction ×6; loop steps are the canonical AI triplet ("Read the signal. / Choose the friction. / Turn it into motion.").
+
+Deterministic scan: 0 findings on the target file (exit 0). One warning on sibling organizations/index.astro:202 (side-tab: border-left 3px var(--editorial-red)), judged a plausible false positive (editorial list rule, not a card stripe). The detector's rules don't cover kicker-scaffolding or copy cadence, which is where this page actually fails.
+
+Browser visualization: skipped, no browser automation available.
+
+## Priority Issues
+
+- [P0] Package naming contradicts the funnel: organizations/index.astro and lets-chat.astro sell "Launch" (£3k); this page sells "Council". Fix all three + organization-jsonld.astro.
+- [P1] Zero social proof on a £12k–£36k/yr decision: no testimonial, logo, audience number, or named partner. Only vendor named is Teleport, by accident, in a course URL.
+- [P1] mailto:-only conversion path, hostile at the moment of highest intent; lets-chat.astro (built to explain the email) is never linked from this page.
+- [P1] Copy doesn't survive translation into buyer language; deliverables invisible ("a clearer signal read, sharper friction, and a practical next move").
+- [P2] Page forks the design system: opts out of Instrument Serif italic ramp, uses unloaded font weights (730–780 vs loaded 300–700), re-implements EditorialButton/MLabel, wrong token fallbacks (hue 260 vs 60; opaque hairline), 118rem width vs 72rem siblings.
+
+## Persona Red Flags
+
+- Jordan (first-time marketing leader): page never establishes who Rawkode/David is; "Rawkode Live"/"Klustered" meaningless without reach numbers.
+- Casey (mobile): five identical "Get in Touch" CTAs; package card puts CTA above the description in DOM order; 8-field email draft on a phone.
+- Skeptical DevRel lead: "signal brief", "adoption map", "pattern notes" pattern-match to consultant-speak; cohort/expert claims unverifiable.
+
+## Minor Observations
+
+- "The Work Behind the Signal" is the only Title Case h2.
+- Featured Adoption mailto is the only one missing the "Preferred partnership path" prefill.
+- Two !important declarations; three near-duplicate inline mailto strings, already drifted.
+- No link back to /organizations; page is a cul-de-sac.
+- Clearest selling copy (how to choose a tier) is buried in a collapsed FAQ.
+
+## Questions to Consider
+
+1. If every sentence containing "signal", "friction", or "narrative" were deleted, would the buyer understand the offer better?
+2. The page uses "proof" 20 times and offers none about itself. Would David email a vendor whose £2k/month pitch page had zero named customers and a mailto CTA?
+3. Why is the strongest evidence (the Teleport course) hidden as a hyperlink instead of leading the proof section?

--- a/projects/rawkode.academy/website/src/actions/index.ts
+++ b/projects/rawkode.academy/website/src/actions/index.ts
@@ -1,6 +1,7 @@
 import { auth } from "./auth";
 import { signupForCourseUpdates } from "./courses";
 import { newsletter } from "./newsletter";
+import { partnership } from "./partnership";
 import { addReaction, removeReaction } from "./reaction";
 import { trackShareEvent } from "./share";
 import { streamNotifications } from "./stream-notifications";
@@ -12,6 +13,7 @@ export const server = {
 	trackVideoEvent,
 	signupForCourseUpdates,
 	newsletter,
+	partnership,
 	trackShareEvent,
 	streamNotifications,
 	addReaction,

--- a/projects/rawkode.academy/website/src/actions/partnership.ts
+++ b/projects/rawkode.academy/website/src/actions/partnership.ts
@@ -1,0 +1,110 @@
+import { defineAction } from "astro:actions";
+import { z } from "astro/zod";
+import { EmailMessage } from "cloudflare:email";
+import { env } from "cloudflare:workers";
+import { applicationPaths } from "@/lib/partnerships";
+
+const FROM_ADDRESS = "partnerships@rawkode.academy";
+const TO_ADDRESS = "david@rawkode.academy";
+
+/** Strip CR/LF so user input can never inject extra MIME headers. */
+const sanitizeHeader = (value: string): string =>
+	value.replace(/[\r\n]+/g, " ").trim();
+
+/** RFC 2047 encode a header value when it contains non-ASCII characters. */
+const encodeHeader = (value: string): string => {
+	const clean = sanitizeHeader(value);
+	if (/^[\x20-\x7e]*$/.test(clean)) {
+		return clean;
+	}
+	const bytes = new TextEncoder().encode(clean);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return `=?utf-8?B?${btoa(binary)}?=`;
+};
+
+export const partnership = {
+	apply: defineAction({
+		input: z.object({
+			name: z.string().trim().min(1, "Please tell us your name").max(200),
+			email: z.email("Please enter a valid work email"),
+			company: z
+				.string()
+				.trim()
+				.min(1, "Please tell us about your company and product")
+				.max(1000),
+			path: z.enum(applicationPaths),
+			targetDevelopers: z
+				.string()
+				.trim()
+				.min(1, "Please tell us which developers you need to reach")
+				.max(2000),
+			challenge: z
+				.string()
+				.trim()
+				.min(1, "Please describe your current adoption challenge")
+				.max(5000),
+			links: z.string().trim().max(2000).optional(),
+			// Honeypot: real users never fill this in.
+			website: z.string().optional(),
+		}),
+		handler: async (input) => {
+			if (input.website) {
+				return { success: true };
+			}
+
+			const subject = encodeHeader(
+				`Partnership application: ${input.path} - ${input.company}`.slice(
+					0,
+					180,
+				),
+			);
+
+			const body = [
+				`Name: ${input.name}`,
+				`Email: ${input.email}`,
+				`Preferred path: ${input.path}`,
+				"",
+				"Company and product:",
+				input.company,
+				"",
+				"Target developers or platform teams:",
+				input.targetDevelopers,
+				"",
+				"Current adoption challenge:",
+				input.challenge,
+				...(input.links ? ["", "Links worth a look:", input.links] : []),
+				"",
+			].join("\r\n");
+
+			const raw = [
+				`From: Rawkode Academy Partnerships <${FROM_ADDRESS}>`,
+				`To: <${TO_ADDRESS}>`,
+				`Reply-To: <${sanitizeHeader(input.email)}>`,
+				`Subject: ${subject}`,
+				`Message-ID: <${crypto.randomUUID()}@rawkode.academy>`,
+				`Date: ${new Date().toUTCString()}`,
+				"MIME-Version: 1.0",
+				'Content-Type: text/plain; charset="utf-8"',
+				"Content-Transfer-Encoding: 8bit",
+				"",
+				body,
+			].join("\r\n");
+
+			try {
+				await env.PARTNERSHIP_APPLICATIONS.send(
+					new EmailMessage(FROM_ADDRESS, TO_ADDRESS, raw),
+				);
+			} catch (error) {
+				console.error("Failed to send partnership application:", error);
+				throw new Error(
+					"We could not send your application. Please email david@rawkode.academy directly.",
+				);
+			}
+
+			return { success: true };
+		},
+	}),
+};

--- a/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
@@ -66,7 +66,7 @@ const organizationSchema = {
 				"@type": "Service",
 				name: "Signal",
 				description:
-					"Lightweight monthly partnership for outside practitioner signal before more budget moves",
+					"Async advisory partnership: a practitioner advisor in your Slack with a written monthly brief on developer adoption",
 			},
 		},
 		{
@@ -77,7 +77,7 @@ const organizationSchema = {
 				"@type": "Service",
 				name: "Adoption",
 				description:
-					"Monthly developer adoption partnership for positioning, launches, docs, demos, DevRel, technical proof, and sales enablement",
+					"Advisory partnership with Slack access, monthly video working sessions, experiment plans, and a monthly summary for leadership",
 			},
 		},
 		{

--- a/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
@@ -77,7 +77,7 @@ const organizationSchema = {
 				"@type": "Service",
 				name: "Adoption",
 				description:
-					"Advisory partnership with Slack access, monthly video working sessions, and experiment support",
+					"Advisory partnership with Slack access, monthly video working sessions, and tactical reviews of docs, demos, onboarding, and launches",
 			},
 		},
 		{

--- a/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
@@ -82,13 +82,13 @@ const organizationSchema = {
 		},
 		{
 			"@type": "Offer",
-			name: "Launch",
+			name: "Council",
 			url: "https://rawkode.academy/organizations/partnerships",
 			itemOffered: {
 				"@type": "Service",
-				name: "Launch",
+				name: "Council",
 				description:
-					"High-focus monthly partnership for launch, repositioning, category, DevRel, or sales motions",
+					"Monthly cohort partnership with peer case reviews and industry expert sessions for developer adoption teams",
 			},
 		},
 		{

--- a/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
@@ -82,13 +82,13 @@ const organizationSchema = {
 		},
 		{
 			"@type": "Offer",
-			name: "Council",
+			name: "Community",
 			url: "https://rawkode.academy/organizations/partnerships",
 			itemOffered: {
 				"@type": "Service",
-				name: "Council",
+				name: "Community",
 				description:
-					"Monthly cohort partnership with peer case reviews and industry expert sessions for developer adoption teams",
+					"Monthly cohort partnership with peer case reviews and expert sessions for developer adoption teams, limited to ten member companies",
 			},
 		},
 		{

--- a/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
+++ b/projects/rawkode.academy/website/src/components/html/organization-jsonld.astro
@@ -66,7 +66,7 @@ const organizationSchema = {
 				"@type": "Service",
 				name: "Signal",
 				description:
-					"Async advisory partnership: a practitioner advisor in your Slack with a written monthly brief on developer adoption",
+					"Advisory partnership over Slack Connect with a monthly review of plans and objectives",
 			},
 		},
 		{
@@ -77,7 +77,7 @@ const organizationSchema = {
 				"@type": "Service",
 				name: "Adoption",
 				description:
-					"Advisory partnership with Slack access, monthly video working sessions, experiment plans, and a monthly summary for leadership",
+					"Advisory partnership with Slack access, monthly video working sessions, and experiment support",
 			},
 		},
 		{

--- a/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
+++ b/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
@@ -1,0 +1,299 @@
+<template>
+	<div v-if="submitted" class="application-success" role="status">
+		<h3>Application received</h3>
+		<p>David reads every application and replies either way.</p>
+	</div>
+	<form v-else class="application-form" novalidate @submit.prevent="submit">
+		<p v-if="error" class="application-form__error" role="alert">{{ error }}</p>
+
+		<div class="application-form__row application-form__row--split">
+			<label class="application-form__field">
+				<span>Name</span>
+				<input
+					v-model="name"
+					type="text"
+					name="name"
+					autocomplete="name"
+					required
+					:disabled="loading"
+				/>
+			</label>
+			<label class="application-form__field">
+				<span>Work email</span>
+				<input
+					v-model="email"
+					type="email"
+					name="email"
+					autocomplete="email"
+					required
+					:disabled="loading"
+				/>
+			</label>
+		</div>
+
+		<div class="application-form__row application-form__row--split">
+			<label class="application-form__field">
+				<span>Company and product</span>
+				<input
+					v-model="company"
+					type="text"
+					name="company"
+					autocomplete="organization"
+					required
+					:disabled="loading"
+				/>
+			</label>
+			<label class="application-form__field">
+				<span>Preferred plan</span>
+				<select v-model="path" name="path" :disabled="loading">
+					<option v-for="option in applicationPaths" :key="option" :value="option">
+						{{ option }}
+					</option>
+				</select>
+			</label>
+		</div>
+
+		<label class="application-form__field">
+			<span>The developers or platform teams you need to reach</span>
+			<input
+				v-model="targetDevelopers"
+				type="text"
+				name="targetDevelopers"
+				required
+				:disabled="loading"
+			/>
+		</label>
+
+		<label class="application-form__field">
+			<span>Your current adoption challenge</span>
+			<textarea
+				v-model="challenge"
+				name="challenge"
+				rows="4"
+				required
+				:disabled="loading"
+			></textarea>
+		</label>
+
+		<label class="application-form__field">
+			<span>Links worth a look <em>(optional)</em></span>
+			<input v-model="links" type="text" name="links" :disabled="loading" />
+		</label>
+
+		<div class="application-form__trap" aria-hidden="true">
+			<label>
+				Website
+				<input
+					v-model="website"
+					type="text"
+					name="website"
+					tabindex="-1"
+					autocomplete="off"
+				/>
+			</label>
+		</div>
+
+		<button type="submit" class="editorial-button" :disabled="loading">
+			{{ loading ? "Sending application..." : "Submit application" }}
+		</button>
+	</form>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { actions } from "astro:actions";
+import { applicationPaths, type ApplicationPath } from "@/lib/partnerships";
+
+const name = ref("");
+const email = ref("");
+const company = ref("");
+const path = ref<ApplicationPath>("Not sure yet");
+const targetDevelopers = ref("");
+const challenge = ref("");
+const links = ref("");
+const website = ref("");
+
+const loading = ref(false);
+const submitted = ref(false);
+const error = ref("");
+
+const isApplicationPath = (value: string): value is ApplicationPath =>
+	(applicationPaths as readonly string[]).includes(value);
+
+// Package CTAs are plain anchors carrying data-apply-path; clicking one
+// scrolls to this form and preselects the plan.
+const onDocumentClick = (event: MouseEvent) => {
+	const target = event.target as HTMLElement | null;
+	const trigger = target?.closest<HTMLElement>("[data-apply-path]");
+	const value = trigger?.dataset.applyPath;
+	if (value && isApplicationPath(value)) {
+		path.value = value;
+	}
+};
+
+onMounted(() => {
+	document.addEventListener("click", onDocumentClick);
+});
+
+onBeforeUnmount(() => {
+	document.removeEventListener("click", onDocumentClick);
+});
+
+async function submit() {
+	error.value = "";
+	loading.value = true;
+
+	try {
+		const result = await actions.partnership.apply({
+			name: name.value,
+			email: email.value,
+			company: company.value,
+			path: path.value,
+			targetDevelopers: targetDevelopers.value,
+			challenge: challenge.value,
+			...(links.value.trim() ? { links: links.value } : {}),
+			...(website.value ? { website: website.value } : {}),
+		});
+
+		if (result.error) {
+			error.value =
+				result.error.message ||
+				"We could not send your application. Please email david@rawkode.academy directly.";
+		} else {
+			submitted.value = true;
+		}
+	} catch {
+		error.value =
+			"We could not send your application. Please email david@rawkode.academy directly.";
+	} finally {
+		loading.value = false;
+	}
+}
+</script>
+
+<style scoped>
+.application-form {
+	display: grid;
+	gap: 1rem;
+	justify-items: start;
+}
+
+.application-form__row {
+	display: grid;
+	gap: 1rem;
+	width: 100%;
+}
+
+.application-form__field {
+	display: grid;
+	gap: 0.4rem;
+	width: 100%;
+}
+
+.application-form__field span {
+	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+	font-size: 0.7rem;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--editorial-ink-soft);
+}
+
+.application-form__field em {
+	font-style: normal;
+	font-weight: 500;
+	color: var(--editorial-ink-mute);
+	text-transform: none;
+	letter-spacing: 0.04em;
+}
+
+.application-form__field input,
+.application-form__field select,
+.application-form__field textarea {
+	width: 100%;
+	border: 1px solid var(--editorial-hairline-strong);
+	border-radius: 4px;
+	background: var(--editorial-paper);
+	color: var(--editorial-ink);
+	font-family: var(--font-inter-tight), system-ui, sans-serif;
+	font-size: 0.95rem;
+	line-height: 1.4;
+	padding: 0.65rem 0.75rem;
+}
+
+.application-form__field textarea {
+	resize: vertical;
+	min-height: 6rem;
+}
+
+.application-form__field input:focus-visible,
+.application-form__field select:focus-visible,
+.application-form__field textarea:focus-visible {
+	outline: 2px solid var(--editorial-spruce);
+	outline-offset: 1px;
+}
+
+.application-form__field input:disabled,
+.application-form__field select:disabled,
+.application-form__field textarea:disabled {
+	opacity: 0.6;
+}
+
+.application-form__error {
+	width: 100%;
+	margin: 0;
+	border: 1px solid var(--editorial-rust);
+	border-radius: 4px;
+	background: var(--editorial-paper-deep);
+	color: var(--editorial-ink);
+	font-family: var(--font-inter-tight), system-ui, sans-serif;
+	font-size: 0.92rem;
+	line-height: 1.5;
+	padding: 0.75rem 1rem;
+}
+
+.application-form__trap {
+	position: absolute;
+	left: -9999px;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+.application-form button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.application-success {
+	border: 1px solid var(--editorial-hairline);
+	border-radius: 6px;
+	background: var(--editorial-paper-deep);
+	padding: 1.5rem;
+	display: grid;
+	gap: 0.5rem;
+}
+
+.application-success h3 {
+	font-family: var(--font-inter-tight), system-ui, sans-serif;
+	font-size: 1.25rem;
+	font-weight: 700;
+	line-height: 1.1;
+	margin: 0;
+	color: var(--editorial-ink);
+}
+
+.application-success p {
+	margin: 0;
+	color: var(--editorial-ink-soft);
+	font-family: var(--font-inter-tight), system-ui, sans-serif;
+	font-size: 0.95rem;
+	line-height: 1.55;
+}
+
+@media (min-width: 720px) {
+	.application-form__row--split {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+</style>

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -103,6 +103,15 @@ export const partnershipTiers: PartnershipTier[] = [
 /** "Signal, Adoption, or Community" for prose. */
 export const partnershipTierNames = partnershipTiers.map((tier) => tier.name);
 
+/** Options for the application form's preferred-path field. */
+export const applicationPaths = [
+	"Signal",
+	"Adoption",
+	"Community",
+	"Not sure yet",
+] as const;
+export type ApplicationPath = (typeof applicationPaths)[number];
+
 /** Boundaries: what the partnership intentionally does not include. */
 export const partnershipBoundaries = [
 	"Outsourced DevRel execution, or someone to run the function for you.",

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -66,12 +66,13 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£2,000 / month",
 		priceShort: "£2k/mo",
 		bestFor:
-			"Teams that want the advisor on video with the people doing the work, not just in threads.",
+			"Teams that want the advisor reviewing the work itself, not just the plan.",
 		outcome:
 			"Adoption blockers worked through together, with evidence instead of opinion.",
 		included: [
 			"Everything in Signal",
 			"A monthly video working session with your team on whatever matters most right now",
+			"Tactical reviews of the work itself: docs, demos, onboarding, launch posts, and pricing pages",
 			"Experiment plans when a blocker needs evidence: the audience, the hypothesis, and what success looks like",
 		],
 		featured: true,

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -16,7 +16,7 @@ const buildMailto = (subject: string, body: string): string =>
 export interface PartnershipTier {
 	id: string;
 	name: string;
-	/** Short mono label shown above the tier name (Entry / Default / Cohort). */
+	/** Short mono label shown above the tier name (Slack / Slack + video / Cohort). */
 	label: string;
 	/** Full price string, e.g. "£1,000 / month". */
 	price: string;
@@ -45,18 +45,18 @@ export const partnershipTiers: PartnershipTier[] = [
 	{
 		id: "signal",
 		name: "Signal",
-		label: "Entry",
+		label: "Slack",
 		price: "£1,000 / month",
 		priceShort: "£1k/mo",
 		bestFor:
-			"Teams that want a recurring outside read without another meeting. Fully async: the brief is the meeting.",
+			"Teams that want an advisor in their Slack and a recurring outside read, without another meeting on the calendar.",
 		outcome:
 			"Know what developers hit in their first fifteen minutes, every month, before your funnel data tells you.",
 		included: [
+			"David in your Slack: async advice on positioning, docs, demos, launches, and objections as they come up",
 			"Your getting-started path, run cold every month like a first-time evaluator, with time-to-first-success tracked",
 			"A written monthly brief: what developers see in your docs, demos, and positioning, and what they say in public",
 			"A running log of adoption blockers, opened and closed month over month",
-			"One clear recommendation: what to keep, change, prove, pause, or escalate",
 			"An optional public field note, only with your approval, when the learning belongs in the community",
 		],
 		featured: false,
@@ -65,17 +65,17 @@ export const partnershipTiers: PartnershipTier[] = [
 	{
 		id: "adoption",
 		name: "Adoption",
-		label: "Default",
+		label: "Slack + video",
 		price: "£2,000 / month",
 		priceShort: "£2k/mo",
 		bestFor:
-			"Teams ready to turn that recurring read into one focused experiment each month, working directly with David.",
+			"Teams that want the advisor on video with the people doing the work, not just in threads.",
 		outcome:
-			"One adoption blocker killed per month, with evidence your whole team can reuse.",
+			"Adoption blockers moved from opinion to evidence, with artifacts your whole team can reuse.",
 		included: [
 			"Everything in Signal",
-			"A monthly working session with your team on one adoption blocker",
-			"A written experiment plan: the audience, the blocker, the hypothesis, and what success looks like",
+			"A monthly video working session with your team on whatever is blocking adoption right now",
+			"Experiment plans when a blocker needs evidence: the audience, the hypothesis, and what success looks like",
 			"A growing experiment record: what was tested, what the evidence said, what changed",
 			"A one-page monthly summary written for the people you report to",
 		],
@@ -85,7 +85,7 @@ export const partnershipTiers: PartnershipTier[] = [
 	{
 		id: "community",
 		name: "Community",
-		label: "10 seats",
+		label: "Cohort",
 		price: "£3,000 / month",
 		priceShort: "£3k/mo",
 		bestFor:

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -30,15 +30,13 @@ export interface PartnershipTier {
 	mailto: string;
 }
 
-const tierBriefBody = (path: string, extra?: string): string =>
+const tierBriefBody = (path: string): string =>
 	[
-		"Company/category:",
-		`Preferred partnership path: ${path}`,
+		"Company and product:",
+		`Preferred path: ${path}`,
 		"Target developers or platform teams:",
-		"Team stakeholders:",
 		"Current adoption challenge:",
-		...(extra ? [extra] : ["Current GTM, DevRel, or product rhythm:"]),
-		"Useful links:",
+		"Links worth a look:",
 	].join("\n");
 
 export const partnershipTiers: PartnershipTier[] = [
@@ -49,17 +47,17 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£1,000 / month",
 		priceShort: "£1k/mo",
 		bestFor:
-			"Teams that need a recurring outside read on what developers understand, question, trust, or ignore.",
+			"Teams that want a recurring outside read on what developers understand, question, trust, or ignore.",
 		outcome:
-			"Each month gives your team a clearer read on adoption friction, proof gaps, and the next story or surface worth improving.",
+			"A clearer picture, every month, of where adoption is getting stuck and what is worth improving next.",
 		included: [
-			"Monthly signal brief drawn from public technical work, product surfaces, category movement, and field notes",
-			"Adoption friction tracked over time across positioning, docs, demos, onboarding, and narrative",
-			"One clear recommendation for what to keep, change, prove, pause, or escalate",
-			"Optional public field note when the learning belongs in the community",
+			"A written monthly brief covering your docs, demos, positioning, and what developers are saying in public",
+			"A running log of adoption blockers, tracked month over month",
+			"One clear recommendation: what to keep, change, prove, pause, or escalate",
+			"An optional public field note when the learning belongs in the community",
 		],
 		featured: false,
-		mailto: buildMailto("Signal path", tierBriefBody("Signal")),
+		mailto: buildMailto("Signal partnership", tierBriefBody("Signal")),
 	},
 	{
 		id: "adoption",
@@ -68,18 +66,18 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£2,000 / month",
 		priceShort: "£2k/mo",
 		bestFor:
-			"Teams ready to turn recurring signal into a focused monthly adoption experiment.",
+			"Teams ready to turn that recurring read into one focused adoption experiment each month.",
 		outcome:
-			"Each month moves one adoption blocker from vague concern to clearer experiment, evidence, and next step.",
+			"One adoption blocker per month moved from vague concern to a tested answer your team can act on.",
 		included: [
 			"Everything in Signal",
-			"Monthly working session around one adoption blocker",
-			"Experiment shape: audience, friction, hypothesis, proof, and success signal",
-			"Shared learning artifact your team can use in docs, demos, onboarding, narrative, or sales handoff",
-			"Adoption map updated with what changed, what remains unclear, and what to test next",
+			"A monthly working session with your team on one adoption blocker",
+			"A written experiment plan: the audience, the blocker, the hypothesis, and what success looks like",
+			"A shared artifact your team can reuse in docs, demos, onboarding, or sales conversations",
+			"An adoption map updated each month: what changed, what is still unclear, what to test next",
 		],
 		featured: true,
-		mailto: buildMailto("Adoption path", tierBriefBody("Adoption")),
+		mailto: buildMailto("Adoption partnership", tierBriefBody("Adoption")),
 	},
 	{
 		id: "council",
@@ -90,19 +88,16 @@ export const partnershipTiers: PartnershipTier[] = [
 		bestFor:
 			"Teams that want peer comparison, expert perspective, and a shared room for serious developer adoption problems.",
 		outcome:
-			"Each month gives your team practitioner patterns from other members, expert perspective, and reusable language for the decisions ahead.",
+			"Patterns from other member teams and outside experts, applied to your own adoption decisions.",
 		included: [
 			"Everything in Adoption",
-			"Shared monthly cohort room where Council members compare adoption problems",
-			"Member case reviews around live docs, demos, narratives, onboarding, or launch motions",
-			"Monthly industry expert presentation with working Q&A",
-			"Council pattern notes with risks, experiments, expert takeaways, and useful decision language",
+			"A monthly cohort session with the other Council member teams",
+			"Case reviews of live docs, demos, onboarding, and launches: yours and theirs",
+			"A monthly industry expert presentation with working Q&A",
+			"Written pattern notes: risks, experiments, and expert takeaways you can bring to your roadmap",
 		],
 		featured: false,
-		mailto: buildMailto(
-			"Council path",
-			tierBriefBody("Council", "Cohort or expert themes that would help:"),
-		),
+		mailto: buildMailto("Council partnership", tierBriefBody("Council")),
 	},
 ];
 
@@ -121,14 +116,10 @@ export const partnershipBoundaries = [
 /** General partnership-fit brief: subject, plain-text template, mailto. */
 export const partnershipFitSubject = "Partnership fit";
 export const partnershipFitTemplate = [
-	"Company/category:",
-	"Product or platform:",
+	"Company and product:",
 	"Target developers or platform teams:",
-	"Team stakeholders:",
 	"Current adoption challenge:",
-	"Current GTM, DevRel, or product rhythm:",
-	"What your team wants to learn or improve next:",
-	"Useful links:",
+	"Links worth a look:",
 ].join("\n");
 export const partnershipFitMailto = buildMailto(
 	partnershipFitSubject,

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -26,6 +26,8 @@ export interface PartnershipTier {
 	outcome: string;
 	included: string[];
 	featured: boolean;
+	/** Scarcity or availability note, e.g. seat limits and cohort dates. */
+	note?: string;
 	/** Prefilled mailto for this tier. */
 	mailto: string;
 }
@@ -47,14 +49,15 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£1,000 / month",
 		priceShort: "£1k/mo",
 		bestFor:
-			"Teams that want a recurring outside read on what developers understand, question, trust, or ignore.",
+			"Teams that want a recurring outside read without another meeting. Fully async: the brief is the meeting.",
 		outcome:
-			"A clearer picture, every month, of where adoption is getting stuck and what is worth improving next.",
+			"Know what developers hit in their first fifteen minutes, every month, before your funnel data tells you.",
 		included: [
-			"A written monthly brief covering your docs, demos, positioning, and what developers are saying in public",
-			"A running log of adoption blockers, tracked month over month",
+			"Your getting-started path, run cold every month like a first-time evaluator, with time-to-first-success tracked",
+			"A written monthly brief: what developers see in your docs, demos, and positioning, and what they say in public",
+			"A running log of adoption blockers, opened and closed month over month",
 			"One clear recommendation: what to keep, change, prove, pause, or escalate",
-			"An optional public field note when the learning belongs in the community",
+			"An optional public field note, only with your approval, when the learning belongs in the community",
 		],
 		featured: false,
 		mailto: buildMailto("Signal partnership", tierBriefBody("Signal")),
@@ -66,42 +69,43 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£2,000 / month",
 		priceShort: "£2k/mo",
 		bestFor:
-			"Teams ready to turn that recurring read into one focused adoption experiment each month.",
+			"Teams ready to turn that recurring read into one focused experiment each month, working directly with David.",
 		outcome:
-			"One adoption blocker per month moved from vague concern to a tested answer your team can act on.",
+			"One adoption blocker killed per month, with evidence your whole team can reuse.",
 		included: [
 			"Everything in Signal",
 			"A monthly working session with your team on one adoption blocker",
 			"A written experiment plan: the audience, the blocker, the hypothesis, and what success looks like",
-			"A shared artifact your team can reuse in docs, demos, onboarding, or sales conversations",
-			"An adoption map updated each month: what changed, what is still unclear, what to test next",
+			"A growing experiment record: what was tested, what the evidence said, what changed",
+			"A one-page monthly summary written for the people you report to",
 		],
 		featured: true,
 		mailto: buildMailto("Adoption partnership", tierBriefBody("Adoption")),
 	},
 	{
-		id: "council",
-		name: "Council",
-		label: "Cohort",
+		id: "community",
+		name: "Community",
+		label: "10 seats",
 		price: "£3,000 / month",
 		priceShort: "£3k/mo",
 		bestFor:
-			"Teams that want peer comparison, expert perspective, and a shared room for serious developer adoption problems.",
+			"Teams that want peer comparison and expert perspective on serious developer adoption problems, in a room that stays small.",
 		outcome:
-			"Patterns from other member teams and outside experts, applied to your own adoption decisions.",
+			"Patterns from the other member teams and invited experts, applied to your own adoption decisions.",
 		included: [
 			"Everything in Adoption",
-			"A monthly cohort session with the other Council member teams",
+			"A monthly cohort session with the other member teams, capped at ten companies",
 			"Case reviews of live docs, demos, onboarding, and launches: yours and theirs",
-			"A monthly industry expert presentation with working Q&A",
-			"Written pattern notes: risks, experiments, and expert takeaways you can bring to your roadmap",
+			"A monthly expert session drawn from the Rawkode network: maintainers, platform leads, and CNCF voices, with the calendar published a quarter ahead",
+			"Written pattern notes: risks, experiments, and takeaways you can bring to your roadmap",
 		],
 		featured: false,
-		mailto: buildMailto("Council partnership", tierBriefBody("Council")),
+		note: "Limited to 10 teams. First cohort kicks off August 2026.",
+		mailto: buildMailto("Community partnership", tierBriefBody("Community")),
 	},
 ];
 
-/** "Signal, Adoption, or Council" for prose. */
+/** "Signal, Adoption, or Community" for prose. */
 export const partnershipTierNames = partnershipTiers.map((tier) => tier.name);
 
 /** Boundaries: what the partnership intentionally does not include. */

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -49,15 +49,12 @@ export const partnershipTiers: PartnershipTier[] = [
 		price: "£1,000 / month",
 		priceShort: "£1k/mo",
 		bestFor:
-			"Teams that want an advisor in their Slack and a recurring outside read, without another meeting on the calendar.",
+			"Teams that want an advisor in their Slack without adding another meeting to the calendar.",
 		outcome:
-			"Know what developers hit in their first fifteen minutes, every month, before your funnel data tells you.",
+			"Your plans and objectives, checked monthly against how developers actually evaluate tools.",
 		included: [
-			"David in your Slack: async advice on positioning, docs, demos, launches, and objections as they come up",
-			"Your getting-started path, run cold every month like a first-time evaluator, with time-to-first-success tracked",
-			"A written monthly brief: what developers see in your docs, demos, and positioning, and what they say in public",
-			"A running log of adoption blockers, opened and closed month over month",
-			"An optional public field note, only with your approval, when the learning belongs in the community",
+			"Slack Connect with Rawkode Academy: advice on positioning, docs, demos, launches, and objections as they come up",
+			"A monthly review of your high-level plans and objectives",
 		],
 		featured: false,
 		mailto: buildMailto("Signal partnership", tierBriefBody("Signal")),
@@ -71,13 +68,11 @@ export const partnershipTiers: PartnershipTier[] = [
 		bestFor:
 			"Teams that want the advisor on video with the people doing the work, not just in threads.",
 		outcome:
-			"Adoption blockers moved from opinion to evidence, with artifacts your whole team can reuse.",
+			"Adoption blockers worked through together, with evidence instead of opinion.",
 		included: [
 			"Everything in Signal",
-			"A monthly video working session with your team on whatever is blocking adoption right now",
+			"A monthly video working session with your team on whatever matters most right now",
 			"Experiment plans when a blocker needs evidence: the audience, the hypothesis, and what success looks like",
-			"A growing experiment record: what was tested, what the evidence said, what changed",
-			"A one-page monthly summary written for the people you report to",
 		],
 		featured: true,
 		mailto: buildMailto("Adoption partnership", tierBriefBody("Adoption")),
@@ -97,7 +92,6 @@ export const partnershipTiers: PartnershipTier[] = [
 			"A monthly cohort session with the other member teams, capped at ten companies",
 			"Case reviews of live docs, demos, onboarding, and launches: yours and theirs",
 			"A monthly expert session drawn from the Rawkode network: maintainers, platform leads, and CNCF voices, with the calendar published a quarter ahead",
-			"Written pattern notes: risks, experiments, and takeaways you can bring to your roadmap",
 		],
 		featured: false,
 		note: "Limited to 10 teams. First cohort kicks off August 2026.",

--- a/projects/rawkode.academy/website/src/lib/partnerships.ts
+++ b/projects/rawkode.academy/website/src/lib/partnerships.ts
@@ -57,7 +57,7 @@ export const partnershipTiers: PartnershipTier[] = [
 			"A monthly review of your high-level plans and objectives",
 		],
 		featured: false,
-		mailto: buildMailto("Signal partnership", tierBriefBody("Signal")),
+		mailto: buildMailto("Signal application", tierBriefBody("Signal")),
 	},
 	{
 		id: "adoption",
@@ -76,7 +76,7 @@ export const partnershipTiers: PartnershipTier[] = [
 			"Experiment plans when a blocker needs evidence: the audience, the hypothesis, and what success looks like",
 		],
 		featured: true,
-		mailto: buildMailto("Adoption partnership", tierBriefBody("Adoption")),
+		mailto: buildMailto("Adoption application", tierBriefBody("Adoption")),
 	},
 	{
 		id: "community",
@@ -96,7 +96,7 @@ export const partnershipTiers: PartnershipTier[] = [
 		],
 		featured: false,
 		note: "Limited to 10 teams. First cohort kicks off August 2026.",
-		mailto: buildMailto("Community partnership", tierBriefBody("Community")),
+		mailto: buildMailto("Community application", tierBriefBody("Community")),
 	},
 ];
 
@@ -112,8 +112,8 @@ export const partnershipBoundaries = [
 	"Audience rental or open-ended access.",
 ];
 
-/** General partnership-fit brief: subject, plain-text template, mailto. */
-export const partnershipFitSubject = "Partnership fit";
+/** General partnership application: subject, plain-text template, mailto. */
+export const partnershipFitSubject = "Partnership application";
 export const partnershipFitTemplate = [
 	"Company and product:",
 	"Target developers or platform teams:",

--- a/projects/rawkode.academy/website/src/pages/organizations/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/index.astro
@@ -146,7 +146,7 @@ const badFits = partnershipBoundaries;
 			</div>
 			<div class="editorial-card editorial-card--paper">
 				<p class="editorial-card__body">
-					Bring the product, the evaluator, the current adoption risk, the docs, demos, architecture notes, enablement material, and any useful infrastructure artifacts: Helm charts, CRDs, RBAC/IAM notes, Terraform, telemetry, tenancy, runbooks, or demo environments. We will tell you whether it fits Signal, Adoption, Council, or is not a fit.
+					Bring the product, the evaluator, the current adoption risk, the docs, demos, architecture notes, enablement material, and any useful infrastructure artifacts: Helm charts, CRDs, RBAC/IAM notes, Terraform, telemetry, tenancy, runbooks, or demo environments. We will tell you whether it fits Signal, Adoption, Community, or is not a fit.
 				</p>
 			</div>
 			<ContactFallback

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -3,7 +3,6 @@ import FAQJsonLD from "@/components/html/faq-jsonld.astro";
 import ContactFallback from "@/components/organizations/ContactFallback.astro";
 import EditorialShell from "@/components/ui/EditorialShell.astro";
 import {
-	PARTNERSHIP_EMAIL,
 	partnershipFitMailto,
 	partnershipFitSubject,
 	partnershipFitTemplate,
@@ -13,7 +12,6 @@ import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
 
-const contactEmail = PARTNERSHIP_EMAIL;
 const contactHref = partnershipFitMailto;
 
 const faqs = [
@@ -25,22 +23,22 @@ const faqs = [
 	{
 		question: "What happens in the first month?",
 		answer:
-			"We open a shared Slack channel and run a full baseline audit: your getting-started path run cold like a first-time evaluator, your docs and demos read the way developers read them, and a written brief on where adoption stands today and what to fix first.",
+			"We open Slack Connect between our workspaces and start with your current plans and objectives: what is in motion, where adoption stands, and what to focus on first.",
 	},
 	{
 		question: "How does Slack access work?",
 		answer:
-			"David joins a shared channel with your team. It is advisory access, practitioner to practitioner: questions get considered answers, not instant ones, and anything bigger than a thread becomes part of the monthly brief, or a video session on Adoption and Community. It is not on-call support.",
+			"Slack Connect links your workspace with Rawkode Academy's. It is advisory access, practitioner to practitioner: questions get considered answers, not instant ones, and anything bigger than a thread becomes the focus of the monthly review, or a video session on Adoption and Community. It is not on-call support.",
 	},
 	{
 		question: "What changes month to month?",
 		answer:
-			"Your product, your competitors, and developer reactions keep moving. Each brief builds on the last, so over time your team owns a running record of what was tried, what the evidence said, and what to do next. Every third brief steps back into a quarterly review of how adoption is trending.",
+			"Your product, your competitors, and developer reactions keep moving, and the advice keeps pace. Each monthly review starts from what changed: what developers are saying, what your team shipped, and what you are deciding next.",
 	},
 	{
 		question: "What does Community add beyond Adoption?",
 		answer:
-			"A monthly cohort session with the other member teams, case reviews of live docs, demos, and launches, a monthly expert session with working Q&A, and written pattern notes your team can bring to its own roadmap.",
+			"A monthly cohort session with the other member teams, case reviews of live docs, demos, and launches, and a monthly expert session with working Q&A.",
 	},
 	{
 		question: "Why is Community limited to ten teams?",
@@ -79,7 +77,7 @@ const anchors = [
 	{
 		term: "Instead of an analyst report",
 		detail:
-			"Written by your target audience: the platform engineers and maintainers who evaluate, adopt, and veto tools.",
+			"Advice from your target audience: the platform engineers and maintainers who evaluate, adopt, and veto tools.",
 	},
 ];
 
@@ -108,12 +106,12 @@ const loopSteps = [
 		body: "Positioning questions, launch reviews, demo feedback, a tough technical objection: raise it in Slack and get a practitioner's answer.",
 	},
 	{
-		title: "Get the evaluator's view monthly.",
-		body: "Your getting-started path run cold, your docs and demos read like a first-time evaluator, and a written brief on what changed.",
+		title: "Review the plan monthly.",
+		body: "Once a month, we look at your high-level plans and objectives: what developers are telling you, what changed, and where to focus next.",
 	},
 	{
-		title: "Keep the record.",
-		body: "The blocker log and experiment record compound month over month into your team's institutional memory for adoption decisions.",
+		title: "Decide what's next.",
+		body: "Each review ends with clear calls: what to keep, change, prove, pause, or stop.",
 	},
 ];
 
@@ -144,14 +142,9 @@ const heroProofPoints = [
 		title="We help your team turn technical depth into developer adoption."
 		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. The kind of guidance agencies and analyst firms charge five figures for, from your actual target audience."
 	>
-		<div class="partnerships-cta" slot="actions">
-			<div class="editorial-actions">
-				<a class="editorial-button" href={contactHref}>Email David</a>
-				<a class="editorial-button editorial-button--secondary" href="#packages">View plans and pricing</a>
-			</div>
-			<p class="partnerships-contact-note">
-				Prefer to write your own email? <a href={`mailto:${contactEmail}`}>{contactEmail}</a> works too. <a href="/organizations/lets-chat">See what a useful first email includes</a>.
-			</p>
+		<div class="editorial-actions" slot="actions">
+			<a class="editorial-button" href={contactHref}>Email David</a>
+			<a class="editorial-button editorial-button--secondary" href="#packages">View plans and pricing</a>
 		</div>
 
 		<section class="editorial-section" aria-label="How the partnership works">
@@ -186,7 +179,7 @@ const heroProofPoints = [
 			<div class="editorial-section__header">
 				<h2 id="loop-title" class="editorial-section__title">An advisor on tap, not a monthly report</h2>
 				<p class="editorial-section__lede">
-					Questions do not wait for a scheduled call. Ask in Slack as they come up; every month, the written brief captures what developers see, what changed, and what to do next.
+					Questions do not wait for a scheduled call. Ask in Slack as they come up; once a month, we step back and look at the bigger picture together.
 				</p>
 			</div>
 			<div class="partnerships-rows">
@@ -279,7 +272,7 @@ const heroProofPoints = [
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">03</span>
 					<h3 class="editorial-card__title">Work with your team</h3>
-					<p class="editorial-card__body">A shared Slack channel opens and the monthly cadence starts. Every month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes.</p>
+					<p class="editorial-card__body">Slack Connect opens and the monthly rhythm starts: advice as questions come up, and a review of your plans and objectives each month.</p>
 				</article>
 			</div>
 		</section>
@@ -320,12 +313,6 @@ const heroProofPoints = [
 </Page>
 
 <style>
-	.partnerships-cta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.85rem;
-	}
-
 	.partnerships-contact-note {
 		color: var(--editorial-ink-soft);
 		font-size: 0.88rem;

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -1,5 +1,6 @@
 ---
 import FAQJsonLD from "@/components/html/faq-jsonld.astro";
+import EditorialShell from "@/components/ui/EditorialShell.astro";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
@@ -148,16 +149,16 @@ const loopSteps = [
 
 const heroProofPoints = [
 	{
-		label: "You own",
-		body: "Execution. Content, community, and shipping stay with your team.",
+		value: "You own",
+		label: "Execution, content, and community",
 	},
 	{
-		label: "We bring",
-		body: "A practitioner's read on your product, docs, demos, and story.",
+		value: "We bring",
+		label: "A practitioner's read on product, docs, and demos",
 	},
 	{
-		label: "You decide",
-		body: "What to prove, change, or stop before the next investment.",
+		value: "You decide",
+		label: "What to prove, change, or stop next",
 	},
 ];
 ---
@@ -168,156 +169,147 @@ const heroProofPoints = [
 >
 	<FAQJsonLD questions={faqs} slot="extra-head" />
 
-	<main class="partnerships-page">
-		<section class="partnerships-hero" aria-labelledby="partnerships-title">
-			<div class="partnerships-hero__header">
-				<p class="partnerships-kicker">Partnerships for DevTools and infrastructure teams</p>
-				<h1 id="partnerships-title">We help your team turn technical depth into developer adoption.</h1>
+	<EditorialShell
+		eyebrow="Partnerships for DevTools and infrastructure teams"
+		title="We help your team turn technical depth into developer adoption."
+		lede="Rawkode works with the people shaping your product story: product, marketing, DevRel, sales engineering, and engineering. Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next."
+	>
+		<div class="partnerships-cta" slot="actions">
+			<div class="editorial-actions">
+				<a class="editorial-button" href={contactHref}>Email David</a>
+				<a class="editorial-button editorial-button--secondary" href="#packages">View plans and pricing</a>
 			</div>
-			<div class="partnerships-hero__grid">
-				<div class="partnerships-hero__copy">
-					<p class="partnerships-hero__lead">
-						Rawkode works with the people shaping your product story: product, marketing, DevRel, sales engineering, and engineering. Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next.
-					</p>
-					<div class="partnerships-actions">
-						<a class="partnerships-button" href={contactHref}>Email David</a>
-						<a class="partnerships-link" href="#packages">View plans and pricing</a>
+			<p class="partnerships-contact-note">
+				Prefer to write your own email? <a href={`mailto:${contactEmail}`}>{contactEmail}</a> works too. <a href="/organizations/lets-chat">See what a useful first email includes</a>.
+			</p>
+		</div>
+
+		<section class="editorial-section" aria-label="How the partnership works">
+			<div class="editorial-stat-grid">
+				{heroProofPoints.map((point) => (
+					<div class="editorial-stat">
+						<span class="editorial-stat__value">{point.value}</span>
+						<span class="editorial-stat__label">{point.label}</span>
 					</div>
-					<p class="partnerships-contact-note">
-						Prefer to write your own email? <a href={`mailto:${contactEmail}`}>{contactEmail}</a> works too. <a href="/organizations/lets-chat">See what a useful first email includes</a>.
-					</p>
-				</div>
-				<aside class="partnerships-hero__rail" aria-label="How the partnership works">
-					<p class="partnerships-hero__rail-label">Developer growth grounded in technical reality</p>
-					<ul>
-						{heroProofPoints.map((point) => (
-							<li>
-								<span>{point.label}</span>
-								<p>{point.body}</p>
-							</li>
-						))}
-					</ul>
-				</aside>
+				))}
 			</div>
 		</section>
 
-		<section id="inspect" class="partnerships-section partnerships-section--inspect" aria-labelledby="inspect-title">
-			<div class="partnerships-section__header">
-				<h2 id="inspect-title">Where adoption gets unclear.</h2>
-				<p>
+		<section class="editorial-section editorial-section--split" aria-labelledby="inspect-title">
+			<div class="editorial-section__header">
+				<h2 id="inspect-title" class="editorial-section__title">Where adoption gets unclear</h2>
+				<p class="editorial-section__lede">
 					The problem is rarely that the team is not doing enough. It is that product, marketing, DevRel, and engineering each see a different part of the adoption story. Developers feel that gap before your dashboard does.
 				</p>
 			</div>
-			<div class="partnerships-inspection-list">
+			<div class="partnerships-rows">
 				{inspectAreas.map((area) => (
-					<article class="partnerships-inspection-item">
-						<h3>{area.title}</h3>
-						<p>{area.body}</p>
+					<article class="partnerships-row">
+						<h3 class="editorial-card__title">{area.title}</h3>
+						<p class="editorial-card__body">{area.body}</p>
 					</article>
 				))}
 			</div>
 		</section>
 
-		<section class="partnerships-section partnerships-section--split partnerships-section--loop" aria-labelledby="loop-title">
-			<div class="partnerships-section__header">
-				<h2 id="loop-title">A monthly loop, not a one-off audit.</h2>
-				<p>
+		<section class="editorial-section editorial-section--split" aria-labelledby="loop-title">
+			<div class="editorial-section__header">
+				<h2 id="loop-title" class="editorial-section__title">A monthly loop, not a one-off audit</h2>
+				<p class="editorial-section__lede">
 					Adoption keeps moving, so the work repeats. Every month ends with a written read on what developers believe about your product, where confidence breaks down, and what to do about it next.
 				</p>
 			</div>
-			<div class="partnerships-work-grid partnerships-work-grid--three">
+			<div class="partnerships-rows">
 				{loopSteps.map((step) => (
-					<article class="partnerships-work">
-						<h3>{step.title}</h3>
-						<p>{step.body}</p>
+					<article class="partnerships-row">
+						<h3 class="editorial-card__title">{step.title}</h3>
+						<p class="editorial-card__body">{step.body}</p>
 					</article>
 				))}
 			</div>
 		</section>
 
-		<section class="partnerships-section partnerships-section--split partnerships-section--proof" aria-labelledby="proof-title">
-			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Why Rawkode</p>
-				<h2 id="proof-title">The work is public. Judge it before you email.</h2>
-				<p>
+		<section class="editorial-section editorial-section--split" aria-labelledby="proof-title">
+			<div class="editorial-section__header">
+				<p class="editorial-kicker">Why Rawkode</p>
+				<h2 id="proof-title" class="editorial-section__title">The work is public. Judge it before you email.</h2>
+				<p class="editorial-section__lede">
 					Rawkode's shows and courses reach the people your product has to convince: platform engineers, maintainers, and the practitioners who veto tools. That same audience is where the partnership's read on your product comes from.
 				</p>
 			</div>
-			<div class="partnerships-work-grid">
-				<article class="partnerships-work">
-					<h3>Courses built with partners</h3>
-					<p>Teleport worked with Rawkode Academy on <a href="/courses/teleport-for-kubernetes">Teleport for Kubernetes</a>: a runnable course that meets developers where they evaluate, hands on, in a real cluster.</p>
+			<div class="partnerships-rows">
+				<article class="partnerships-row">
+					<h3 class="editorial-card__title">Courses built with partners</h3>
+					<p class="editorial-card__body">Teleport worked with Rawkode Academy on <a href="/courses/teleport-for-kubernetes">Teleport for Kubernetes</a>: a runnable course that meets developers where they evaluate, hands on, in a real cluster.</p>
 				</article>
-				<article class="partnerships-work">
-					<h3>Klustered</h3>
-					<p>Engineers from Adobe, Red Hat, Pulumi, Kong, Chainguard, DigitalOcean, Zapier, Skyscanner, and Civo have <a href="/shows/klustered">debugged broken Kubernetes clusters live on Klustered</a>. It is a public record of what practitioners trust under pressure.</p>
+				<article class="partnerships-row">
+					<h3 class="editorial-card__title">Klustered</h3>
+					<p class="editorial-card__body">Engineers from Adobe, Red Hat, Pulumi, Kong, Chainguard, DigitalOcean, Zapier, Skyscanner, and Civo have <a href="/shows/klustered">debugged broken Kubernetes clusters live on Klustered</a>. It is a public record of what practitioners trust under pressure.</p>
 				</article>
-				<article class="partnerships-work">
-					<h3>Rawkode Live</h3>
-					<p><a href="/shows/rawkode-live">Maintainer-led live builds and product walkthroughs</a> show how technical people explain tradeoffs, evaluate tools, ask questions, and decide whether something is worth trying.</p>
+				<article class="partnerships-row">
+					<h3 class="editorial-card__title">Rawkode Live</h3>
+					<p class="editorial-card__body"><a href="/shows/rawkode-live">Maintainer-led live builds and product walkthroughs</a> show how technical people explain tradeoffs, evaluate tools, ask questions, and decide whether something is worth trying.</p>
 				</article>
 			</div>
 		</section>
 
-		<section id="packages" class="partnerships-section partnerships-section--tight" aria-labelledby="packages-title">
-			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Partnership paths</p>
-				<h2 id="packages-title">Start where your adoption work needs support.</h2>
-				<p>
+		<section id="packages" class="editorial-section partnerships-packages" aria-labelledby="packages-title">
+			<div class="editorial-section__header partnerships-packages__header">
+				<p class="editorial-kicker">Partnership paths</p>
+				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
+				<p class="editorial-section__lede">
 					Each path is month-to-month, no annual lock-in. Start with Signal if you want a recurring outside read. Choose Adoption to turn that read into one focused experiment each month. Choose Council when peer comparison and expert perspective would make the work stronger.
 				</p>
 			</div>
 			<div class="partnerships-package-grid">
 				{packages.map((pkg) => (
-					<article class:list={["partnerships-package", { "partnerships-package--featured": pkg.featured }]}>
+					<article class:list={["editorial-card", "partnerships-package", { "partnerships-package--featured": pkg.featured }]}>
 						<div class="partnerships-package__top">
-							<p class="partnerships-package__label">{pkg.label}</p>
-							<h3>{pkg.name}</h3>
+							<p class="editorial-kicker">{pkg.label}</p>
+							<h3 class="partnerships-package__name">{pkg.name}</h3>
 							<p class="partnerships-package__price">{pkg.price}</p>
-							<a class="partnerships-button" href={pkg.href}>{pkg.cta}</a>
+							<a class="editorial-button" href={pkg.href}>{pkg.cta}</a>
 						</div>
 						<div class="partnerships-package__summary">
-							<p>{pkg.bestFor}</p>
+							<p class="editorial-card__body">{pkg.bestFor}</p>
 							<p class="partnerships-package__outcome">{pkg.outcome}</p>
 						</div>
-						<div>
-							<ul class="partnerships-package__included">
-								{pkg.included.map((item) => <li>{item}</li>)}
-							</ul>
-						</div>
+						<ul class="editorial-list">
+							{pkg.included.map((item) => <li>{item}</li>)}
+						</ul>
 					</article>
 				))}
 			</div>
 		</section>
 
-		<section class="partnerships-section partnerships-section--split" aria-labelledby="process-title">
-			<div class="partnerships-section__header">
-				<h2 id="process-title">Send context first. Call only when there is a fit.</h2>
+		<section class="editorial-section editorial-section--split" aria-labelledby="process-title">
+			<div class="editorial-section__header">
+				<h2 id="process-title" class="editorial-section__title">Send context first. Call only when there is a fit.</h2>
 			</div>
-			<div class="partnerships-process">
-				<article>
-					<span>01</span>
-					<h3>Send context</h3>
-					<p>Your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.</p>
+			<div class="partnerships-rows">
+				<article class="partnerships-row partnerships-row--numbered">
+					<span class="partnerships-step">01</span>
+					<h3 class="editorial-card__title">Send context</h3>
+					<p class="editorial-card__body">Your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.</p>
 				</article>
-				<article>
-					<span>02</span>
-					<h3>Get a fit reply</h3>
-					<p>David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Council, or say plainly that it is not a good fit.</p>
+				<article class="partnerships-row partnerships-row--numbered">
+					<span class="partnerships-step">02</span>
+					<h3 class="editorial-card__title">Get a fit reply</h3>
+					<p class="editorial-card__body">David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Council, or say plainly that it is not a good fit.</p>
 				</article>
-				<article>
-					<span>03</span>
-					<h3>Work with your team</h3>
-					<p>Each month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes that feed your strategy, docs, demos, and sales conversations.</p>
+				<article class="partnerships-row partnerships-row--numbered">
+					<span class="partnerships-step">03</span>
+					<h3 class="editorial-card__title">Work with your team</h3>
+					<p class="editorial-card__body">Each month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes that feed your strategy, docs, demos, and sales conversations.</p>
 				</article>
 			</div>
 		</section>
 
-		<section class="partnerships-section partnerships-section--split" aria-labelledby="faq-title">
-			<div class="partnerships-section__header">
-				<h2 id="faq-title">Questions before you start.</h2>
+		<section class="editorial-section editorial-section--split" aria-labelledby="faq-title">
+			<div class="editorial-section__header">
+				<h2 id="faq-title" class="editorial-section__title">Questions before you start</h2>
 			</div>
-			<div class="partnerships-faq-list">
+			<div class="editorial-faq">
 				{faqs.map((faq) => (
 					<details>
 						<summary>{faq.question}</summary>
@@ -327,312 +319,146 @@ const heroProofPoints = [
 			</div>
 		</section>
 
-		<section class="partnerships-final" aria-labelledby="final-title">
-			<h2 id="final-title">Start with the next adoption problem.</h2>
-			<p>
-				Rough context is enough: your product, the developers you need to reach, and the adoption problem in front of you.
-			</p>
-			<div class="partnerships-actions">
-				<a class="partnerships-button" href={contactHref}>Email David</a>
+		<section class="editorial-section" aria-labelledby="final-title">
+			<div class="editorial-callout">
+				<div>
+					<h2 id="final-title" class="editorial-section__title">Start with the next adoption problem</h2>
+					<p class="editorial-card__body">
+						Rough context is enough: your product, the developers you need to reach, and the adoption problem in front of you.
+					</p>
+				</div>
+				<a class="editorial-button" href={contactHref}>Email David</a>
 			</div>
-			<p class="partnerships-contact-note">
+			<p class="partnerships-contact-note partnerships-contact-note--footer">
 				Or write your own email to <a href={`mailto:${contactEmail}`}>{contactEmail}</a>. <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.
 			</p>
 		</section>
-	</main>
+	</EditorialShell>
 </Page>
 
 <style>
-	.partnerships-page {
-		--partnerships-ink: var(--editorial-ink);
-		--partnerships-muted: var(--editorial-ink-soft);
-		--partnerships-paper: var(--editorial-paper);
-		--partnerships-paper-deep: var(--editorial-paper-deep);
-		--partnerships-line: var(--editorial-hairline);
-		--partnerships-accent: var(--editorial-spruce);
-		background: var(--partnerships-paper);
-		color: var(--partnerships-ink);
-		font-family: var(--font-inter-tight), system-ui, sans-serif;
-	}
-
-	.partnerships-hero,
-	.partnerships-section,
-	.partnerships-final {
-		max-width: 118rem;
-		margin: 0 auto;
-		padding-left: clamp(1rem, 3vw, 3rem);
-		padding-right: clamp(1rem, 3vw, 3rem);
-	}
-
-	.partnerships-hero {
-		padding-top: clamp(1.5rem, 3vw, 3rem);
-		padding-bottom: clamp(1.75rem, 3vw, 2.75rem);
-		border-bottom: 1px solid var(--partnerships-line);
-	}
-
-	.partnerships-hero__header {
-		display: grid;
-		gap: clamp(0.85rem, 1.8vw, 1.25rem);
-	}
-
-	.partnerships-kicker,
-	.partnerships-package__label {
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.7rem;
-		font-weight: 700;
-		letter-spacing: 0.12em;
-		line-height: 1.35;
-		margin: 0;
-		text-transform: uppercase;
-		color: var(--partnerships-accent);
-	}
-
-	.partnerships-hero__grid {
-		display: grid;
-		gap: clamp(1.75rem, 4vw, 4rem);
-		margin-top: clamp(1.4rem, 3vw, 2.35rem);
-	}
-
-	.partnerships-hero h1 {
-		font-family: var(--font-inter-tight), system-ui, sans-serif;
-		font-size: clamp(2.2rem, 4.4vw, 4.55rem);
-		font-style: normal;
-		font-weight: 700;
-		letter-spacing: 0;
-		line-height: 1;
-		margin: 0;
-		max-width: 30ch;
-		text-wrap: balance;
-	}
-
-	.partnerships-hero__lead,
-	.partnerships-section__header p,
-	.partnerships-package p,
-	.partnerships-inspection-item p,
-	.partnerships-work p,
-	.partnerships-process p,
-	.partnerships-faq-list p,
-	.partnerships-final p {
-		color: var(--partnerships-muted);
-		font-size: 1rem;
-		line-height: 1.55;
-		margin: 0;
-	}
-
-	.partnerships-hero__lead {
-		font-size: clamp(1rem, 2.2vw, 1.18rem);
-		line-height: 1.6;
-		max-width: 44rem;
-	}
-
-	.partnerships-hero__rail {
-		border-top: 1px solid var(--partnerships-line);
-		display: grid;
-		gap: 0.9rem;
-		padding-top: 1rem;
-	}
-
-	.partnerships-hero__rail-label {
-		color: var(--partnerships-ink);
-		font-size: 0.95rem;
-		font-weight: 700;
-		line-height: 1.25;
-		margin: 0;
-	}
-
-	.partnerships-hero__rail ul {
-		display: grid;
-		gap: 0;
-		list-style: none;
-		margin: 0;
-		padding: 0;
-	}
-
-	.partnerships-hero__rail li {
-		border-top: 1px solid var(--partnerships-line);
-		display: grid;
-		gap: 0.5rem;
-		grid-template-columns: 5rem minmax(0, 1fr);
-		padding: 0.85rem 0;
-	}
-
-	.partnerships-hero__rail li:first-child {
-		border-top: 0;
-		padding-top: 0;
-	}
-
-	.partnerships-hero__rail span {
-		color: var(--partnerships-accent);
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.7rem;
-		font-weight: 700;
-		letter-spacing: 0.08em;
-		line-height: 1.25;
-		text-transform: uppercase;
-	}
-
-	.partnerships-hero__rail p {
-		color: var(--partnerships-ink);
-		font-size: 1rem;
-		font-weight: 600;
-		line-height: 1.35;
-		margin: 0;
-	}
-
-	.partnerships-actions {
+	.partnerships-cta {
 		display: flex;
 		flex-direction: column;
-		gap: 0.75rem;
-		margin-top: 1.5rem;
-		width: fit-content;
+		gap: 0.85rem;
 	}
 
 	.partnerships-contact-note {
-		color: var(--partnerships-muted);
+		color: var(--editorial-ink-soft);
 		font-size: 0.88rem;
 		line-height: 1.5;
-		margin: 0.85rem 0 0;
+		margin: 0;
 		max-width: 38rem;
 	}
 
+	.partnerships-contact-note--footer {
+		margin-top: 1rem;
+	}
+
 	.partnerships-contact-note a {
-		color: var(--partnerships-ink);
+		color: var(--editorial-ink);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 0.18em;
 	}
 
 	.partnerships-contact-note a:hover {
-		color: var(--partnerships-accent);
+		color: var(--editorial-spruce);
 	}
 
-	.partnerships-button {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		min-height: 2.85rem;
-		border: 1px solid var(--partnerships-ink);
-		border-radius: 4px;
-		padding: 0.85rem 1rem;
-		background: var(--partnerships-ink);
-		color: var(--partnerships-paper);
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.72rem;
-		font-weight: 700;
-		letter-spacing: 0.08em;
-		line-height: 1.1;
-		text-align: center;
-		text-decoration: none;
-		text-transform: uppercase;
+	.partnerships-rows {
+		display: grid;
+		gap: 0;
+		border-top: 1px solid var(--editorial-hairline);
+		border-bottom: 1px solid var(--editorial-hairline);
 	}
 
-	.partnerships-button:hover {
-		background: var(--partnerships-accent);
-		border-color: var(--partnerships-accent);
+	.partnerships-row {
+		border-top: 1px solid var(--editorial-hairline);
+		display: grid;
+		gap: 0.4rem;
+		padding: 1rem 0;
 	}
 
-	.partnerships-link {
-		align-self: flex-start;
-		display: inline-flex;
-		align-items: center;
-		color: var(--partnerships-ink);
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.72rem;
-		font-weight: 700;
-		letter-spacing: 0.08em;
-		line-height: 1.2;
-		min-height: 2.85rem;
+	.partnerships-row:first-child {
+		border-top: 0;
+	}
+
+	.partnerships-row :global(.editorial-card__title) {
+		margin: 0;
+	}
+
+	.partnerships-row :global(a) {
+		color: var(--editorial-ink);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
-		text-underline-offset: 0.22em;
-		text-transform: uppercase;
+		text-underline-offset: 0.18em;
 	}
 
-	.partnerships-link:hover {
-		color: var(--partnerships-accent);
+	.partnerships-row :global(a:hover) {
+		color: var(--editorial-spruce);
 	}
 
-	.partnerships-work,
-	.partnerships-process article,
-	.partnerships-package,
-	.partnerships-faq-list details {
-		border: 1px solid var(--partnerships-line);
-		border-radius: 6px;
-		background: var(--partnerships-paper-deep);
+	.partnerships-row--numbered {
+		grid-template-columns: 2.4rem minmax(0, 1fr);
+		column-gap: 0.85rem;
 	}
 
-	.partnerships-section {
-		padding-top: 2.5rem;
-		padding-bottom: 2.5rem;
-		border-bottom: 1px solid var(--partnerships-line);
+	.partnerships-row--numbered :global(.editorial-card__body) {
+		grid-column: 2;
+	}
+
+	.partnerships-step {
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.72rem;
+		font-weight: 700;
+		color: var(--editorial-spruce);
+		padding-top: 0.2rem;
+	}
+
+	.partnerships-packages {
 		scroll-margin-top: 5rem;
 	}
 
-	.partnerships-section--tight {
-		padding-top: 2rem;
-	}
-
-	.partnerships-section__header {
-		display: flex;
-		flex-direction: column;
-		gap: 0.65rem;
-		margin-bottom: 1.25rem;
-		max-width: none;
-	}
-
-	.partnerships-section h2,
-	.partnerships-final h2 {
-		font-family: var(--font-inter-tight), system-ui, sans-serif;
-		font-size: clamp(1.65rem, 6vw, 4rem);
-		font-style: normal;
-		font-weight: 700;
-		letter-spacing: 0;
-		line-height: 0.98;
-		margin: 0;
-		max-width: 20ch;
-	}
-
-	.partnerships-section__header p {
+	.partnerships-packages__header {
 		max-width: 58rem;
+		margin-bottom: 1.5rem;
 	}
 
-	.partnerships-package-grid,
-	.partnerships-work-grid,
-	.partnerships-process {
+	.partnerships-package-grid {
 		display: grid;
 		gap: 1rem;
 	}
 
 	.partnerships-package {
-		padding: 0.9rem;
 		display: flex;
 		flex-direction: column;
-		gap: 0.75rem;
+		gap: 0.85rem;
 	}
 
 	.partnerships-package--featured {
-		border-color: var(--partnerships-accent);
-		box-shadow: inset 0 0 0 1px var(--partnerships-accent);
+		border-color: var(--editorial-spruce);
+		box-shadow: inset 0 0 0 1px var(--editorial-spruce);
 	}
 
 	.partnerships-package__top {
 		display: flex;
 		flex-direction: column;
-		gap: 0.3rem;
+		gap: 0.35rem;
+		align-items: flex-start;
 	}
 
-	.partnerships-package__top .partnerships-button {
-		margin-top: 0.35rem;
+	.partnerships-package__top :global(.editorial-button) {
+		margin-top: 0.5rem;
 	}
 
-	.partnerships-package h3,
-	.partnerships-inspection-item h3,
-	.partnerships-work h3,
-	.partnerships-process h3 {
-		font-size: 1.25rem;
-		font-weight: 600;
+	.partnerships-package__name {
+		font-family: var(--font-inter-tight), system-ui, sans-serif;
+		font-size: 1.35rem;
+		font-weight: 700;
 		line-height: 1.1;
 		letter-spacing: 0;
+		color: var(--editorial-ink);
 		margin: 0;
 	}
 
@@ -640,7 +466,8 @@ const heroProofPoints = [
 		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
 		font-size: 0.95rem;
 		font-weight: 700;
-		color: var(--partnerships-ink) !important;
+		color: var(--editorial-ink);
+		margin: 0;
 	}
 
 	.partnerships-package__summary {
@@ -649,230 +476,19 @@ const heroProofPoints = [
 	}
 
 	.partnerships-package__outcome {
-		color: var(--partnerships-ink) !important;
-	}
-
-	.partnerships-package__included {
-		list-style: none;
-		padding: 0;
+		font-family: var(--font-inter-tight), system-ui, sans-serif;
+		font-size: 0.94rem;
+		line-height: 1.55;
+		color: var(--editorial-ink);
 		margin: 0;
-		display: grid;
-		gap: 0.45rem;
-	}
-
-	.partnerships-package__included li {
-		position: relative;
-		padding-left: 1rem;
-		color: var(--partnerships-muted);
-		font-size: 0.92rem;
-		line-height: 1.4;
-	}
-
-	.partnerships-package__included li::before {
-		content: "";
-		position: absolute;
-		left: 0;
-		top: 0.62em;
-		width: 0.35rem;
-		height: 0.35rem;
-		border-radius: 999px;
-		background: var(--partnerships-accent);
-	}
-
-	.partnerships-work,
-	.partnerships-process article {
-		padding: clamp(1.15rem, 2vw, 1.4rem);
-		display: flex;
-		flex-direction: column;
-		gap: 0.7rem;
-	}
-
-	.partnerships-work a {
-		color: var(--partnerships-ink);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 0.18em;
-	}
-
-	.partnerships-section--proof .partnerships-work-grid {
-		gap: 0;
-		grid-template-columns: 1fr;
-	}
-
-	.partnerships-section--proof .partnerships-work {
-		border-left: 0;
-		border-right: 0;
-		border-radius: 0;
-	}
-
-	.partnerships-section--proof .partnerships-work + .partnerships-work {
-		border-top: 0;
-	}
-
-	.partnerships-section--inspect .partnerships-section__header {
-		margin-bottom: 1.35rem;
-	}
-
-	.partnerships-section--inspect .partnerships-section__header h2 {
-		max-width: 20ch;
-	}
-
-	.partnerships-inspection-list {
-		border-bottom: 1px solid var(--partnerships-line);
-		border-top: 1px solid var(--partnerships-line);
-		display: grid;
-		gap: 0;
-	}
-
-	.partnerships-inspection-item {
-		border-top: 1px solid var(--partnerships-line);
-		display: grid;
-		gap: 0.35rem;
-		padding: 0.95rem 0;
-	}
-
-	.partnerships-inspection-item:first-child {
-		border-top: 0;
-	}
-
-	.partnerships-process span {
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.72rem;
-		font-weight: 700;
-		color: var(--partnerships-accent);
-	}
-
-	.partnerships-process {
-		grid-template-columns: 1fr;
-	}
-
-	.partnerships-faq-list {
-		display: grid;
-		gap: 0.75rem;
-	}
-
-	.partnerships-faq-list details {
-		padding: 1rem;
-	}
-
-	.partnerships-faq-list summary {
-		cursor: pointer;
-		font-size: 1rem;
-		font-weight: 600;
-		line-height: 1.3;
-	}
-
-	.partnerships-faq-list p {
-		margin-top: 0.75rem;
-	}
-
-	.partnerships-final {
-		padding-top: 2.5rem;
-		padding-bottom: 3rem;
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.partnerships-final h2 {
-		max-width: 16ch;
-	}
-
-	.partnerships-final p {
-		max-width: 38rem;
-	}
-
-	.partnerships-final .partnerships-actions {
-		margin-top: 0;
-	}
-
-	.partnerships-final .partnerships-contact-note {
-		margin-top: 0;
-	}
-
-	@media (min-width: 640px) {
-		.partnerships-actions {
-			flex-direction: row;
-			align-items: center;
-		}
-
-		.partnerships-button {
-			width: auto;
-		}
-
-		.partnerships-work-grid {
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-		}
 	}
 
 	@media (min-width: 1100px) {
-		.partnerships-inspection-list {
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-			column-gap: 1.5rem;
-		}
-
-		.partnerships-inspection-item:nth-child(2) {
-			border-top: 0;
-		}
-	}
-
-	@media (min-width: 1180px) {
-		.partnerships-hero__grid {
-			align-items: start;
-			grid-template-columns: minmax(0, 0.62fr) minmax(20rem, 0.38fr);
-		}
-
-		.partnerships-hero__rail {
-			border-left: 1px solid var(--partnerships-line);
-			border-top: 0;
-			margin-top: 0.25rem;
-			padding-left: clamp(1.25rem, 2vw, 2rem);
-			padding-top: 0;
-		}
-
-		.partnerships-section__header {
-			max-width: 72rem;
-			margin-bottom: 1.75rem;
-		}
-
-		.partnerships-section__header p {
-			max-width: 58rem;
-		}
-
-		.partnerships-work-grid--three {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-		}
-
 		.partnerships-package {
 			display: grid;
 			grid-template-columns: minmax(13rem, 0.45fr) minmax(0, 0.8fr) minmax(0, 1fr);
 			gap: 1.25rem;
 			align-items: start;
-			padding: 1.15rem;
-		}
-
-		.partnerships-process {
-			grid-template-columns: 1fr;
-		}
-
-		.partnerships-process article {
-			display: grid;
-			grid-template-columns: 3rem minmax(12rem, 0.35fr) minmax(0, 1fr);
-			gap: 1rem;
-			align-items: start;
-		}
-
-		.partnerships-section--proof .partnerships-work-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.partnerships-section--proof .partnerships-work {
-			display: grid;
-			grid-template-columns: minmax(12rem, 0.28fr) minmax(0, 1fr);
-			column-gap: clamp(1.75rem, 3vw, 2.75rem);
-			row-gap: 0.6rem;
-			align-items: start;
-			padding: clamp(1.25rem, 2vw, 1.6rem) clamp(1.4rem, 2.5vw, 2rem);
 		}
 	}
 </style>

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -25,17 +25,22 @@ const faqs = [
 	{
 		question: "What happens in the first month?",
 		answer:
-			"We start with your current adoption challenge, the developers your product needs to reach, and the surfaces they already see. The first month ends with your first written brief: what developers see today, where they get stuck, and the next thing worth fixing.",
+			"The first month is a full baseline audit: your getting-started path run cold like a first-time evaluator, your docs and demos read the way developers read them, and a written brief on where adoption stands today and what to fix first.",
 	},
 	{
 		question: "What changes month to month?",
 		answer:
-			"Your product, your competitors, and developer reactions keep moving. Each brief builds on the last, so over time your team has a running record of what was tried, what the evidence said, and what to do next.",
+			"Your product, your competitors, and developer reactions keep moving. Each brief builds on the last, so over time your team owns a running record of what was tried, what the evidence said, and what to do next. Every third brief steps back into a quarterly review of how adoption is trending.",
 	},
 	{
-		question: "What does Council add beyond Adoption?",
+		question: "What does Community add beyond Adoption?",
 		answer:
-			"A monthly cohort session with the other Council member teams, case reviews of live docs, demos, and launches, an industry expert presentation with working Q&A, and written pattern notes your team can bring to its own roadmap.",
+			"A monthly cohort session with the other member teams, case reviews of live docs, demos, and launches, a monthly expert session with working Q&A, and written pattern notes your team can bring to its own roadmap.",
+	},
+	{
+		question: "Why is Community limited to ten teams?",
+		answer:
+			"The room only works if every team gets reviewed and every voice knows the others. Ten teams keeps the case reviews honest and the patterns specific. The first cohort kicks off in August 2026.",
 	},
 	{
 		question: "What do you need from our team?",
@@ -51,9 +56,27 @@ const faqs = [
 
 const packages = partnershipTiers.map((tier) => ({
 	...tier,
-	cta: `Ask about ${tier.name}`,
+	cta: tier.id === "community" ? "Apply for a seat" : `Ask about ${tier.name}`,
 	href: tier.mailto,
 }));
+
+const anchors = [
+	{
+		term: "Instead of a conference",
+		detail:
+			"A booth at one event costs more than a year of Signal, and the feedback ends when the hall closes.",
+	},
+	{
+		term: "Instead of an agency",
+		detail:
+			"A fraction of a retainer, no onboarding ramp, and no account manager between you and the practitioner.",
+	},
+	{
+		term: "Instead of an analyst report",
+		detail:
+			"Written by your target audience: the platform engineers and maintainers who evaluate, adopt, and veto tools.",
+	},
+];
 
 const inspectAreas = [
 	{
@@ -114,7 +137,7 @@ const heroProofPoints = [
 	<EditorialShell
 		eyebrow="Partnerships for DevTools and infrastructure teams"
 		title="We help your team turn technical depth into developer adoption."
-		lede="Rawkode works with the people shaping your product story: product, marketing, DevRel, sales engineering, and engineering. Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next."
+		lede="Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next. The kind of read agencies and analyst firms charge five figures for, from your actual target audience."
 	>
 		<div class="partnerships-cta" slot="actions">
 			<div class="editorial-actions">
@@ -200,9 +223,17 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Each path is month-to-month, no annual lock-in. Start with Signal if you want a recurring outside read. Choose Adoption to turn that read into one focused experiment each month. Choose Council when peer comparison and expert perspective would make the work stronger.
+					Each path is month-to-month: start, pause, or cancel any month. Start with Signal for the recurring outside read. Choose Adoption to kill one blocker per month with your team. Apply for Community when peer comparison would sharpen the work: ten seats, first cohort in August.
 				</p>
 			</div>
+			<dl class="partnerships-anchors">
+				{anchors.map((anchor) => (
+					<div class="partnerships-anchors__item">
+						<dt>{anchor.term}</dt>
+						<dd>{anchor.detail}</dd>
+					</div>
+				))}
+			</dl>
 			<div class="partnerships-package-grid">
 				{packages.map((pkg) => (
 					<article class:list={["editorial-card", "partnerships-package", { "partnerships-package--featured": pkg.featured }]}>
@@ -210,6 +241,7 @@ const heroProofPoints = [
 							<p class="editorial-kicker">{pkg.label}</p>
 							<h3 class="partnerships-package__name">{pkg.name}</h3>
 							<p class="partnerships-package__price">{pkg.price}</p>
+							{pkg.note && <p class="partnerships-package__note">{pkg.note}</p>}
 							<a class="editorial-button" href={pkg.href}>{pkg.cta}</a>
 						</div>
 						<div class="partnerships-package__summary">
@@ -237,7 +269,7 @@ const heroProofPoints = [
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">02</span>
 					<h3 class="editorial-card__title">Get a fit reply</h3>
-					<p class="editorial-card__body">David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Council, or say plainly that it is not a good fit.</p>
+					<p class="editorial-card__body">David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Community, or say plainly that it is not a good fit.</p>
 				</article>
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">03</span>
@@ -364,6 +396,52 @@ const heroProofPoints = [
 
 	.partnerships-packages {
 		scroll-margin-top: 5rem;
+	}
+
+	.partnerships-anchors {
+		display: grid;
+		gap: 1rem;
+		margin: 0 0 1.5rem;
+	}
+
+	.partnerships-anchors__item {
+		border-top: 1px solid var(--editorial-hairline-strong);
+		padding-top: 0.85rem;
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	.partnerships-anchors dt {
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--editorial-spruce);
+	}
+
+	.partnerships-anchors dd {
+		font-family: var(--font-inter-tight), system-ui, sans-serif;
+		font-size: 0.94rem;
+		line-height: 1.55;
+		color: var(--editorial-ink-soft);
+		margin: 0;
+	}
+
+	.partnerships-package__note {
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--editorial-rust);
+		margin: 0;
+	}
+
+	@media (min-width: 720px) {
+		.partnerships-anchors {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
 	}
 
 	.partnerships-packages__header {

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -221,7 +221,7 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Each path is month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video working sessions with your team, and is the recommended path. Community adds the room: ten seats, first cohort in August.
+					Each path is month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room: ten seats, first cohort in August.
 				</p>
 			</div>
 			<dl class="partnerships-anchors">

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -1,27 +1,20 @@
 ---
 import FAQJsonLD from "@/components/html/faq-jsonld.astro";
+import ContactFallback from "@/components/organizations/ContactFallback.astro";
 import EditorialShell from "@/components/ui/EditorialShell.astro";
+import {
+	PARTNERSHIP_EMAIL,
+	partnershipFitMailto,
+	partnershipFitSubject,
+	partnershipFitTemplate,
+	partnershipTiers,
+} from "@/lib/partnerships";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
 
-const contactEmail = "david@rawkode.academy";
-
-const mailtoBody = (path?: string) =>
-	encodeURIComponent(
-		[
-			"Company and product:",
-			...(path ? [`Preferred path: ${path}`] : []),
-			"Target developers or platform teams:",
-			"Current adoption challenge:",
-			"Links worth a look:",
-		].join("\r\n"),
-	);
-
-const mailto = (subject: string, path?: string) =>
-	`mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${mailtoBody(path)}`;
-
-const contactHref = mailto("Partnership fit");
+const contactEmail = PARTNERSHIP_EMAIL;
+const contactHref = partnershipFitMailto;
 
 const faqs = [
 	{
@@ -56,62 +49,11 @@ const faqs = [
 	},
 ];
 
-const packages = [
-	{
-		name: "Signal",
-		price: "£1,000 / month",
-		label: "Entry",
-		bestFor:
-			"Teams that want a recurring outside read on what developers understand, question, trust, or ignore.",
-		outcome:
-			"A clearer picture, every month, of where adoption is getting stuck and what is worth improving next.",
-		included: [
-			"A written monthly brief covering your docs, demos, positioning, and what developers are saying in public",
-			"A running log of adoption blockers, tracked month over month",
-			"One clear recommendation: what to keep, change, prove, pause, or escalate",
-			"An optional public field note when the learning belongs in the community",
-		],
-		cta: "Ask about Signal",
-		href: mailto("Signal partnership", "Signal"),
-	},
-	{
-		name: "Adoption",
-		price: "£2,000 / month",
-		label: "Default",
-		bestFor:
-			"Teams ready to turn that recurring read into one focused adoption experiment each month.",
-		outcome:
-			"One adoption blocker per month moved from vague concern to a tested answer your team can act on.",
-		included: [
-			"Everything in Signal",
-			"A monthly working session with your team on one adoption blocker",
-			"A written experiment plan: the audience, the blocker, the hypothesis, and what success looks like",
-			"A shared artifact your team can reuse in docs, demos, onboarding, or sales conversations",
-			"An adoption map updated each month: what changed, what is still unclear, what to test next",
-		],
-		cta: "Ask about Adoption",
-		href: mailto("Adoption partnership", "Adoption"),
-		featured: true,
-	},
-	{
-		name: "Council",
-		price: "£3,000 / month",
-		label: "Cohort",
-		bestFor:
-			"Teams that want peer comparison, expert perspective, and a shared room for serious developer adoption problems.",
-		outcome:
-			"Patterns from other member teams and outside experts, applied to your own adoption decisions.",
-		included: [
-			"Everything in Adoption",
-			"A monthly cohort session with the other Council member teams",
-			"Case reviews of live docs, demos, onboarding, and launches: yours and theirs",
-			"A monthly industry expert presentation with working Q&A",
-			"Written pattern notes: risks, experiments, and expert takeaways you can bring to your roadmap",
-		],
-		cta: "Ask about Council",
-		href: mailto("Council partnership", "Council"),
-	},
-];
+const packages = partnershipTiers.map((tier) => ({
+	...tier,
+	cta: `Ask about ${tier.name}`,
+	href: tier.mailto,
+}));
 
 const inspectAreas = [
 	{
@@ -330,8 +272,12 @@ const heroProofPoints = [
 				<a class="editorial-button" href={contactHref}>Email David</a>
 			</div>
 			<p class="partnerships-contact-note partnerships-contact-note--footer">
-				Or write your own email to <a href={`mailto:${contactEmail}`}>{contactEmail}</a>. <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.
+				Not sure what to send? <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.
 			</p>
+			<ContactFallback
+				subject={partnershipFitSubject}
+				template={partnershipFitTemplate}
+			/>
 		</section>
 	</EditorialShell>
 </Page>

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -21,7 +21,22 @@ const faqs = [
 	{
 		question: "How does Slack access work?",
 		answer:
-			"Slack Connect links your workspace with Rawkode Academy's. It is advisory access, practitioner to practitioner: questions get considered answers, not instant ones, and anything bigger than a thread becomes the focus of the monthly review, or a video session on Adoption and Community. It is not on-call support.",
+			"Slack Connect links your workspace with Rawkode Academy's. It is advisory access, practitioner to practitioner: questions get considered answers within a couple of working days, and anything bigger than a thread becomes the focus of the monthly review, or a video session on Adoption and Community. It is not on-call support.",
+	},
+	{
+		question: "Why pay for Signal instead of just DMing David?",
+		answer:
+			"You can, and people do: when there is time, about whatever happens to be in front of him. Signal means your context is held month over month, your questions take priority over the inbox, and the review of your plans happens every month whether or not you remembered to ask.",
+	},
+	{
+		question: "Do you work with competing companies?",
+		answer:
+			"No. One company per problem space at a time, across every plan. If a direct competitor applies while we work together, they wait. Community cohorts are screened the same way: no two member teams compete directly.",
+	},
+	{
+		question: "Does a partnership affect Rawkode Live coverage?",
+		answer:
+			"No. Advisory clients get no coverage, and coverage decisions never consider who pays. The audience's trust is the product; it is not for sale.",
 	},
 	{
 		question: "What changes month to month?",
@@ -51,7 +66,7 @@ const faqs = [
 	{
 		question: "What is intentionally out of scope?",
 		answer:
-			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings a practitioner's read, strategic critique, and adoption patterns that have worked elsewhere.",
+			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings a practitioner's read, strategic critique, and adoption patterns that have worked elsewhere. And if you have your own DevRel team, the advice goes through them, not around them.",
 	},
 ];
 
@@ -72,9 +87,9 @@ const anchors = [
 			"A fraction of a retainer, no onboarding ramp, and no account manager between you and the practitioner.",
 	},
 	{
-		term: "Instead of an analyst report",
+		term: "Instead of a fractional hire",
 		detail:
-			"Advice from your target audience: the platform engineers and maintainers who evaluate, adopt, and veto tools.",
+			"A senior practitioner's judgement without a day rate, a ramp-up, or a seat on your payroll.",
 	},
 ];
 
@@ -137,7 +152,7 @@ const heroProofPoints = [
 	<EditorialShell
 		eyebrow="Partnerships for DevTools and infrastructure teams"
 		title="We help your team turn technical depth into developer adoption."
-		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. The kind of guidance agencies and analyst firms charge five figures for, from your actual target audience."
+		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. One advisor, direct access, no agency in between."
 	>
 		<div class="editorial-actions" slot="actions">
 			<a class="editorial-button" href="#apply">Apply for a partnership</a>
@@ -199,6 +214,10 @@ const heroProofPoints = [
 			</div>
 			<div class="partnerships-rows">
 				<article class="partnerships-row">
+					<h3 class="editorial-card__title">A new programme, an old practice</h3>
+					<p class="editorial-card__body">This programme is new, and the first teams in it are exactly that: first. The practice behind it is not. Hundreds of projects evaluated on air, dozens of teams worked with directly, and over two decades of trust in this field that does not get spent on bad advice.</p>
+				</article>
+				<article class="partnerships-row">
 					<h3 class="editorial-card__title">Courses built with partners</h3>
 					<p class="editorial-card__body">Teleport worked with Rawkode Academy on <a href="/courses/teleport-for-kubernetes">Teleport for Kubernetes</a>: a runnable course that meets developers where they evaluate, hands on, in a real cluster.</p>
 				</article>
@@ -209,6 +228,10 @@ const heroProofPoints = [
 				<article class="partnerships-row">
 					<h3 class="editorial-card__title">Rawkode Live</h3>
 					<p class="editorial-card__body"><a href="/shows/rawkode-live">Maintainer-led live builds and product walkthroughs</a> show how technical people explain tradeoffs, evaluate tools, ask questions, and decide whether something is worth trying.</p>
+				</article>
+				<article class="partnerships-row">
+					<h3 class="editorial-card__title">No agency behind this page</h3>
+					<p class="editorial-card__body">The person who answers your Slack is the person on every episode: no account managers, no juniors, no handoffs.</p>
 				</article>
 			</div>
 		</section>

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -1,9 +1,9 @@
 ---
 import FAQJsonLD from "@/components/html/faq-jsonld.astro";
 import ContactFallback from "@/components/organizations/ContactFallback.astro";
+import PartnershipApplicationForm from "@/components/organizations/PartnershipApplicationForm.vue";
 import EditorialShell from "@/components/ui/EditorialShell.astro";
 import {
-	partnershipFitMailto,
 	partnershipFitSubject,
 	partnershipFitTemplate,
 	partnershipTiers,
@@ -11,8 +11,6 @@ import {
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
-
-const contactHref = partnershipFitMailto;
 
 const faqs = [
 	{
@@ -34,6 +32,11 @@ const faqs = [
 		question: "What changes month to month?",
 		answer:
 			"Your product, your competitors, and developer reactions keep moving, and the advice keeps pace. Each monthly review starts from what changed: what developers are saying, what your team shipped, and what you are deciding next.",
+	},
+	{
+		question: "Is there an annual option?",
+		answer:
+			"Yes. Pay for twelve months up front and get two free, on any plan. Otherwise every plan is month-to-month: start, pause, or cancel any month.",
 	},
 	{
 		question: "What does Community add beyond Adoption?",
@@ -60,7 +63,6 @@ const faqs = [
 const packages = partnershipTiers.map((tier) => ({
 	...tier,
 	cta: `Apply for ${tier.name}`,
-	href: tier.mailto,
 }));
 
 const anchors = [
@@ -143,7 +145,7 @@ const heroProofPoints = [
 		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. The kind of guidance agencies and analyst firms charge five figures for, from your actual target audience."
 	>
 		<div class="editorial-actions" slot="actions">
-			<a class="editorial-button" href={contactHref}>Apply for a partnership</a>
+			<a class="editorial-button" href="#apply">Apply for a partnership</a>
 			<a class="editorial-button editorial-button--secondary" href="#packages">View plans and pricing</a>
 		</div>
 
@@ -221,7 +223,7 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Every plan starts with an application, and not every application is a fit. All plans are month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room, capped at ten teams.
+					Every plan starts with an application, and not every application is a fit. All plans are month-to-month: start, pause, or cancel any month, or pay for twelve months up front and get two free. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room, capped at ten teams.
 				</p>
 			</div>
 			<dl class="partnerships-anchors">
@@ -240,7 +242,7 @@ const heroProofPoints = [
 							<h3 class="partnerships-package__name">{pkg.name}</h3>
 							<p class="partnerships-package__price">{pkg.price}</p>
 							{pkg.note && <p class="partnerships-package__note">{pkg.note}</p>}
-							<a class="editorial-button" href={pkg.href}>{pkg.cta}</a>
+							<a class="editorial-button" href="#apply" data-apply-path={pkg.name}>{pkg.cta}</a>
 						</div>
 						<div class="partnerships-package__summary">
 							<p class="editorial-card__body">{pkg.bestFor}</p>
@@ -291,23 +293,23 @@ const heroProofPoints = [
 			</div>
 		</section>
 
-		<section class="editorial-section" aria-labelledby="final-title">
-			<div class="editorial-callout">
-				<div>
-					<h2 id="final-title" class="editorial-section__title">Apply with your next adoption problem</h2>
-					<p class="editorial-card__body">
-						Your product, the developers you need to reach, and the adoption problem in front of you. That is enough to apply.
-					</p>
-				</div>
-				<a class="editorial-button" href={contactHref}>Apply for a partnership</a>
+		<section id="apply" class="editorial-section editorial-section--split partnerships-apply" aria-labelledby="apply-title">
+			<div class="editorial-section__header">
+				<h2 id="apply-title" class="editorial-section__title">Apply with your next adoption problem</h2>
+				<p class="editorial-section__lede">
+					Your product, the developers you need to reach, and the adoption problem in front of you. That is enough to apply.
+				</p>
 			</div>
-			<p class="partnerships-contact-note partnerships-contact-note--footer">
-				Not sure what to send? <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.
-			</p>
-			<ContactFallback
-				subject={partnershipFitSubject}
-				template={partnershipFitTemplate}
-			/>
+			<div class="partnerships-apply__body">
+				<PartnershipApplicationForm client:visible />
+				<p class="partnerships-contact-note">
+					Prefer email? The same application works as an email to David.
+				</p>
+				<ContactFallback
+					subject={partnershipFitSubject}
+					template={partnershipFitTemplate}
+				/>
+			</div>
 		</section>
 	</EditorialShell>
 </Page>
@@ -319,10 +321,6 @@ const heroProofPoints = [
 		line-height: 1.5;
 		margin: 0;
 		max-width: 38rem;
-	}
-
-	.partnerships-contact-note--footer {
-		margin-top: 1rem;
 	}
 
 	.partnerships-contact-note a {
@@ -388,6 +386,16 @@ const heroProofPoints = [
 
 	.partnerships-packages {
 		scroll-margin-top: 5rem;
+	}
+
+	.partnerships-apply {
+		scroll-margin-top: 5rem;
+	}
+
+	.partnerships-apply__body {
+		display: grid;
+		gap: 1.25rem;
+		justify-items: start;
 	}
 
 	.partnerships-anchors {

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -25,7 +25,12 @@ const faqs = [
 	{
 		question: "What happens in the first month?",
 		answer:
-			"The first month is a full baseline audit: your getting-started path run cold like a first-time evaluator, your docs and demos read the way developers read them, and a written brief on where adoption stands today and what to fix first.",
+			"We open a shared Slack channel and run a full baseline audit: your getting-started path run cold like a first-time evaluator, your docs and demos read the way developers read them, and a written brief on where adoption stands today and what to fix first.",
+	},
+	{
+		question: "How does Slack access work?",
+		answer:
+			"David joins a shared channel with your team. It is advisory access, practitioner to practitioner: questions get considered answers, not instant ones, and anything bigger than a thread becomes part of the monthly brief, or a video session on Adoption and Community. It is not on-call support.",
 	},
 	{
 		question: "What changes month to month?",
@@ -99,16 +104,16 @@ const inspectAreas = [
 
 const loopSteps = [
 	{
-		title: "Look at what developers actually see.",
-		body: "Your docs, demos, positioning, public discussion, and the questions your team keeps hearing from evaluators.",
+		title: "Ask as things come up.",
+		body: "Positioning questions, launch reviews, demo feedback, a tough technical objection: raise it in Slack and get a practitioner's answer.",
 	},
 	{
-		title: "Pick the blocker that matters.",
-		body: "One adoption blocker per month: unclear positioning, missing proof, a weak evaluation path, or an unresolved technical objection.",
+		title: "Get the evaluator's view monthly.",
+		body: "Your getting-started path run cold, your docs and demos read like a first-time evaluator, and a written brief on what changed.",
 	},
 	{
-		title: "Ship something your team can use.",
-		body: "A written brief, an experiment plan, or sharper language for your docs, demos, and sales conversations.",
+		title: "Keep the record.",
+		body: "The blocker log and experiment record compound month over month into your team's institutional memory for adoption decisions.",
 	},
 ];
 
@@ -119,7 +124,7 @@ const heroProofPoints = [
 	},
 	{
 		value: "We bring",
-		label: "A practitioner's read on product, docs, and demos",
+		label: "An advisor who lives where developers evaluate tools",
 	},
 	{
 		value: "You decide",
@@ -130,14 +135,14 @@ const heroProofPoints = [
 
 <Page
 	title="Partnerships"
-	description="Cloud-native and DevTool partnerships for teams improving developer adoption across product, marketing, DevRel, sales engineering, and engineering."
+	description="Developer adoption partnerships for DevTools and cloud-native teams: a practitioner advisor in your Slack, monthly video working sessions, and a ten-seat community."
 >
 	<FAQJsonLD questions={faqs} slot="extra-head" />
 
 	<EditorialShell
 		eyebrow="Partnerships for DevTools and infrastructure teams"
 		title="We help your team turn technical depth into developer adoption."
-		lede="Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next. The kind of read agencies and analyst firms charge five figures for, from your actual target audience."
+		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. The kind of guidance agencies and analyst firms charge five figures for, from your actual target audience."
 	>
 		<div class="partnerships-cta" slot="actions">
 			<div class="editorial-actions">
@@ -179,9 +184,9 @@ const heroProofPoints = [
 
 		<section class="editorial-section editorial-section--split" aria-labelledby="loop-title">
 			<div class="editorial-section__header">
-				<h2 id="loop-title" class="editorial-section__title">A monthly loop, not a one-off audit</h2>
+				<h2 id="loop-title" class="editorial-section__title">An advisor on tap, not a monthly report</h2>
 				<p class="editorial-section__lede">
-					Adoption keeps moving, so the work repeats. Every month ends with a written read on what developers believe about your product, where confidence breaks down, and what to do about it next.
+					Questions do not wait for a scheduled call. Ask in Slack as they come up; every month, the written brief captures what developers see, what changed, and what to do next.
 				</p>
 			</div>
 			<div class="partnerships-rows">
@@ -223,7 +228,7 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Each path is month-to-month: start, pause, or cancel any month. Start with Signal for the recurring outside read. Choose Adoption to kill one blocker per month with your team. Apply for Community when peer comparison would sharpen the work: ten seats, first cohort in August.
+					Each path is month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video working sessions with your team, and is the recommended path. Community adds the room: ten seats, first cohort in August.
 				</p>
 			</div>
 			<dl class="partnerships-anchors">
@@ -274,7 +279,7 @@ const heroProofPoints = [
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">03</span>
 					<h3 class="editorial-card__title">Work with your team</h3>
-					<p class="editorial-card__body">Each month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes that feed your strategy, docs, demos, and sales conversations.</p>
+					<p class="editorial-card__body">A shared Slack channel opens and the monthly cadence starts. Every month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes.</p>
 				</article>
 			</div>
 		</section>

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -59,7 +59,7 @@ const faqs = [
 
 const packages = partnershipTiers.map((tier) => ({
 	...tier,
-	cta: tier.id === "community" ? "Apply for a seat" : `Ask about ${tier.name}`,
+	cta: `Apply for ${tier.name}`,
 	href: tier.mailto,
 }));
 
@@ -143,7 +143,7 @@ const heroProofPoints = [
 		lede="Get a practitioner advisor in your team's Slack: someone who watches developers evaluate tools every week, and tells you what to fix, prove, or test next. The kind of guidance agencies and analyst firms charge five figures for, from your actual target audience."
 	>
 		<div class="editorial-actions" slot="actions">
-			<a class="editorial-button" href={contactHref}>Email David</a>
+			<a class="editorial-button" href={contactHref}>Apply for a partnership</a>
 			<a class="editorial-button editorial-button--secondary" href="#packages">View plans and pricing</a>
 		</div>
 
@@ -221,7 +221,7 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Each path is month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room: ten seats, first cohort in August.
+					Every plan starts with an application, and not every application is a fit. All plans are month-to-month: start, pause, or cancel any month. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room, capped at ten teams.
 				</p>
 			</div>
 			<dl class="partnerships-anchors">
@@ -256,22 +256,22 @@ const heroProofPoints = [
 
 		<section class="editorial-section editorial-section--split" aria-labelledby="process-title">
 			<div class="editorial-section__header">
-				<h2 id="process-title" class="editorial-section__title">Send context first. Call only when there is a fit.</h2>
+				<h2 id="process-title" class="editorial-section__title">Every plan starts with an application</h2>
 			</div>
 			<div class="partnerships-rows">
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">01</span>
-					<h3 class="editorial-card__title">Send context</h3>
-					<p class="editorial-card__body">Your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.</p>
+					<h3 class="editorial-card__title">Apply</h3>
+					<p class="editorial-card__body">Rough context is enough: your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.</p>
 				</article>
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">02</span>
-					<h3 class="editorial-card__title">Get a fit reply</h3>
-					<p class="editorial-card__body">David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Community, or say plainly that it is not a good fit.</p>
+					<h3 class="editorial-card__title">Get an answer</h3>
+					<p class="editorial-card__body">David Flanagan, Rawkode Academy's founder, reviews every application and replies with a straight answer: which plan fits, or that it is not a good fit.</p>
 				</article>
 				<article class="partnerships-row partnerships-row--numbered">
 					<span class="partnerships-step">03</span>
-					<h3 class="editorial-card__title">Work with your team</h3>
+					<h3 class="editorial-card__title">Start</h3>
 					<p class="editorial-card__body">Slack Connect opens and the monthly rhythm starts: advice as questions come up, and a review of your plans and objectives each month.</p>
 				</article>
 			</div>
@@ -294,12 +294,12 @@ const heroProofPoints = [
 		<section class="editorial-section" aria-labelledby="final-title">
 			<div class="editorial-callout">
 				<div>
-					<h2 id="final-title" class="editorial-section__title">Start with the next adoption problem</h2>
+					<h2 id="final-title" class="editorial-section__title">Apply with your next adoption problem</h2>
 					<p class="editorial-card__body">
-						Rough context is enough: your product, the developers you need to reach, and the adoption problem in front of you.
+						Your product, the developers you need to reach, and the adoption problem in front of you. That is enough to apply.
 					</p>
 				</div>
-				<a class="editorial-button" href={contactHref}>Email David</a>
+				<a class="editorial-button" href={contactHref}>Apply for a partnership</a>
 			</div>
 			<p class="partnerships-contact-note partnerships-contact-note--footer">
 				Not sure what to send? <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -1,13 +1,8 @@
 ---
 import FAQJsonLD from "@/components/html/faq-jsonld.astro";
-import ContactFallback from "@/components/organizations/ContactFallback.astro";
 import PartnershipApplicationForm from "@/components/organizations/PartnershipApplicationForm.vue";
 import EditorialShell from "@/components/ui/EditorialShell.astro";
-import {
-	partnershipFitSubject,
-	partnershipFitTemplate,
-	partnershipTiers,
-} from "@/lib/partnerships";
+import { partnershipTiers } from "@/lib/partnerships";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
@@ -302,38 +297,12 @@ const heroProofPoints = [
 			</div>
 			<div class="partnerships-apply__body">
 				<PartnershipApplicationForm client:visible />
-				<p class="partnerships-contact-note">
-					Prefer email? The same application works as an email to David.
-				</p>
-				<ContactFallback
-					subject={partnershipFitSubject}
-					template={partnershipFitTemplate}
-				/>
 			</div>
 		</section>
 	</EditorialShell>
 </Page>
 
 <style>
-	.partnerships-contact-note {
-		color: var(--editorial-ink-soft);
-		font-size: 0.88rem;
-		line-height: 1.5;
-		margin: 0;
-		max-width: 38rem;
-	}
-
-	.partnerships-contact-note a {
-		color: var(--editorial-ink);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 0.18em;
-	}
-
-	.partnerships-contact-note a:hover {
-		color: var(--editorial-spruce);
-	}
-
 	.partnerships-rows {
 		display: grid;
 		gap: 0;

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -1,61 +1,116 @@
 ---
 import FAQJsonLD from "@/components/html/faq-jsonld.astro";
-import ContactFallback from "@/components/organizations/ContactFallback.astro";
-import {
-	partnershipFitMailto,
-	partnershipFitSubject,
-	partnershipFitTemplate,
-	partnershipTiers,
-} from "@/lib/partnerships";
 import Page from "@/wrappers/page.astro";
 
 export const prerender = true;
 
-const contactHref = partnershipFitMailto;
+const contactEmail = "david@rawkode.academy";
+
+const mailtoBody = (path?: string) =>
+	encodeURIComponent(
+		[
+			"Company and product:",
+			...(path ? [`Preferred path: ${path}`] : []),
+			"Target developers or platform teams:",
+			"Current adoption challenge:",
+			"Links worth a look:",
+		].join("\r\n"),
+	);
+
+const mailto = (subject: string, path?: string) =>
+	`mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${mailtoBody(path)}`;
+
+const contactHref = mailto("Partnership fit");
 
 const faqs = [
 	{
 		question: "When is this useful?",
 		answer:
-			"When your product has real technical depth, but adoption is getting stuck between positioning, docs, demos, DevRel activity, sales conversations, and the proof developers need before they trust it.",
+			"When your product has real technical depth, but adoption is getting stuck somewhere between positioning, docs, demos, DevRel activity, and the proof developers need before they trust it.",
 	},
 	{
 		question: "What happens in the first month?",
 		answer:
-			"We start with your current adoption challenge, the people your product needs to reach, and the surfaces developers already see. The first month should leave your team with a clearer signal read, sharper friction, and a practical next move.",
+			"We start with your current adoption challenge, the developers your product needs to reach, and the surfaces they already see. The first month ends with your first written brief: what developers see today, where they get stuck, and the next thing worth fixing.",
 	},
 	{
 		question: "What changes month to month?",
 		answer:
-			"The product, category, competitors, launch moments, buyer questions, and developer reactions keep moving. Each month updates the signal history, friction backlog, experiment record, and decisions your team can act on next.",
-	},
-	{
-		question: "How do we choose between Signal, Adoption, and Council?",
-		answer:
-			"Start with Signal if you need recurring outside perspective. Choose Adoption when you want to turn that signal into a focused monthly experiment. Choose Council when peer comparison, expert perspective, and a shared room would make the work stronger.",
+			"Your product, your competitors, and developer reactions keep moving. Each brief builds on the last, so over time your team has a running record of what was tried, what the evidence said, and what to do next.",
 	},
 	{
 		question: "What does Council add beyond Adoption?",
 		answer:
-			"Council adds a monthly cohort room with other member teams, member case reviews, an industry expert presentation, and pattern notes your team can use when the adoption problem benefits from more than one company's perspective.",
+			"A monthly cohort session with the other Council member teams, case reviews of live docs, demos, and launches, an industry expert presentation with working Q&A, and written pattern notes your team can bring to its own roadmap.",
 	},
 	{
 		question: "What do you need from our team?",
 		answer:
-			"Rough context is enough to start: product, category, target developers, team stakeholders, current adoption challenge, current GTM, DevRel, or product rhythm, and links if they help.",
+			"Rough context is enough to start: your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.",
 	},
 	{
 		question: "What is intentionally out of scope?",
 		answer:
-			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings practitioner signal, strategic critique, and useful adoption patterns.",
+			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings a practitioner's read, strategic critique, and adoption patterns that have worked elsewhere.",
 	},
 ];
 
-const packages = partnershipTiers.map((tier) => ({
-	...tier,
-	cta: "Get in Touch",
-	href: tier.mailto,
-}));
+const packages = [
+	{
+		name: "Signal",
+		price: "£1,000 / month",
+		label: "Entry",
+		bestFor:
+			"Teams that want a recurring outside read on what developers understand, question, trust, or ignore.",
+		outcome:
+			"A clearer picture, every month, of where adoption is getting stuck and what is worth improving next.",
+		included: [
+			"A written monthly brief covering your docs, demos, positioning, and what developers are saying in public",
+			"A running log of adoption blockers, tracked month over month",
+			"One clear recommendation: what to keep, change, prove, pause, or escalate",
+			"An optional public field note when the learning belongs in the community",
+		],
+		cta: "Ask about Signal",
+		href: mailto("Signal partnership", "Signal"),
+	},
+	{
+		name: "Adoption",
+		price: "£2,000 / month",
+		label: "Default",
+		bestFor:
+			"Teams ready to turn that recurring read into one focused adoption experiment each month.",
+		outcome:
+			"One adoption blocker per month moved from vague concern to a tested answer your team can act on.",
+		included: [
+			"Everything in Signal",
+			"A monthly working session with your team on one adoption blocker",
+			"A written experiment plan: the audience, the blocker, the hypothesis, and what success looks like",
+			"A shared artifact your team can reuse in docs, demos, onboarding, or sales conversations",
+			"An adoption map updated each month: what changed, what is still unclear, what to test next",
+		],
+		cta: "Ask about Adoption",
+		href: mailto("Adoption partnership", "Adoption"),
+		featured: true,
+	},
+	{
+		name: "Council",
+		price: "£3,000 / month",
+		label: "Cohort",
+		bestFor:
+			"Teams that want peer comparison, expert perspective, and a shared room for serious developer adoption problems.",
+		outcome:
+			"Patterns from other member teams and outside experts, applied to your own adoption decisions.",
+		included: [
+			"Everything in Adoption",
+			"A monthly cohort session with the other Council member teams",
+			"Case reviews of live docs, demos, onboarding, and launches: yours and theirs",
+			"A monthly industry expert presentation with working Q&A",
+			"Written pattern notes: risks, experiments, and expert takeaways you can bring to your roadmap",
+		],
+		cta: "Ask about Council",
+		href: mailto("Council partnership", "Council"),
+	},
+];
 
 const inspectAreas = [
 	{
@@ -78,30 +133,30 @@ const inspectAreas = [
 
 const loopSteps = [
 	{
-		title: "Read the signal.",
-		body: "Look at public developer discussion, product surfaces, docs, demos, field notes, and the questions your team is hearing.",
+		title: "Look at what developers actually see.",
+		body: "Your docs, demos, positioning, public discussion, and the questions your team keeps hearing from evaluators.",
 	},
 	{
-		title: "Choose the friction.",
-		body: "Decide which adoption blocker matters now: unclear positioning, missing proof, weak evaluation path, disconnected education, or unresolved technical objection.",
+		title: "Pick the blocker that matters.",
+		body: "One adoption blocker per month: unclear positioning, missing proof, a weak evaluation path, or an unresolved technical objection.",
 	},
 	{
-		title: "Turn it into motion.",
-		body: "Shape the next experiment, field note, adoption map, cohort discussion, or internal narrative your team can actually use.",
+		title: "Ship something your team can use.",
+		body: "A written brief, an experiment plan, or sharper language for your docs, demos, and sales conversations.",
 	},
 ];
 
 const heroProofPoints = [
 	{
-		label: "Keep",
-		body: "Your team owns execution.",
+		label: "You own",
+		body: "Execution. Content, community, and shipping stay with your team.",
 	},
 	{
-		label: "Bring",
-		body: "Practitioner signal and strategic critique.",
+		label: "We bring",
+		body: "A practitioner's read on your product, docs, demos, and story.",
 	},
 	{
-		label: "Decide",
+		label: "You decide",
 		body: "What to prove, change, or stop before the next investment.",
 	},
 ];
@@ -122,14 +177,17 @@ const heroProofPoints = [
 			<div class="partnerships-hero__grid">
 				<div class="partnerships-hero__copy">
 					<p class="partnerships-hero__lead">
-						Rawkode works with the teams already shaping your product story: product, marketing, DevRel, sales engineering, and engineering. We help turn technical reality into the strategy, proof, education, and narrative developers need before they trust, try, and adopt your product.
+						Rawkode works with the people shaping your product story: product, marketing, DevRel, sales engineering, and engineering. Every month, you get an outside practitioner's read on what developers see when they evaluate your product, and what to fix, prove, or test next.
 					</p>
 					<div class="partnerships-actions">
-						<a class="partnerships-button" href={contactHref}>Get in Touch</a>
-						<a class="partnerships-link" href="#packages">View Plans</a>
+						<a class="partnerships-button" href={contactHref}>Email David</a>
+						<a class="partnerships-link" href="#packages">View plans and pricing</a>
 					</div>
+					<p class="partnerships-contact-note">
+						Prefer to write your own email? <a href={`mailto:${contactEmail}`}>{contactEmail}</a> works too. <a href="/organizations/lets-chat">See what a useful first email includes</a>.
+					</p>
 				</div>
-				<aside class="partnerships-hero__rail" aria-label="How the partnership helps">
+				<aside class="partnerships-hero__rail" aria-label="How the partnership works">
 					<p class="partnerships-hero__rail-label">Developer growth grounded in technical reality</p>
 					<ul>
 						{heroProofPoints.map((point) => (
@@ -145,20 +203,16 @@ const heroProofPoints = [
 
 		<section id="inspect" class="partnerships-section partnerships-section--inspect" aria-labelledby="inspect-title">
 			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Adoption clarity</p>
 				<h2 id="inspect-title">Where adoption gets unclear.</h2>
 				<p>
-					The problem is rarely that the team is not doing enough. It is usually that product, marketing, DevRel, sales engineering, and engineering are each seeing a different part of the adoption story. Developers feel that gap before the dashboard does.
+					The problem is rarely that the team is not doing enough. It is that product, marketing, DevRel, and engineering each see a different part of the adoption story. Developers feel that gap before your dashboard does.
 				</p>
 			</div>
 			<div class="partnerships-inspection-list">
-				{inspectAreas.map((area, index) => (
+				{inspectAreas.map((area) => (
 					<article class="partnerships-inspection-item">
-						<span class="partnerships-inspection-item__number">{String(index + 1).padStart(2, "0")}</span>
-						<div>
-							<h3>{area.title}</h3>
-							<p>{area.body}</p>
-						</div>
+						<h3>{area.title}</h3>
+						<p>{area.body}</p>
 					</article>
 				))}
 			</div>
@@ -166,10 +220,9 @@ const heroProofPoints = [
 
 		<section class="partnerships-section partnerships-section--split partnerships-section--loop" aria-labelledby="loop-title">
 			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Monthly loop</p>
-				<h2 id="loop-title">The work repeats monthly because adoption keeps moving.</h2>
+				<h2 id="loop-title">A monthly loop, not a one-off audit.</h2>
 				<p>
-					Each month should leave your team with a clearer read on what developers believe, where confidence breaks down, and what proof or experiment should come next.
+					Adoption keeps moving, so the work repeats. Every month ends with a written read on what developers believe about your product, where confidence breaks down, and what to do about it next.
 				</p>
 			</div>
 			<div class="partnerships-work-grid partnerships-work-grid--three">
@@ -185,23 +238,23 @@ const heroProofPoints = [
 		<section class="partnerships-section partnerships-section--split partnerships-section--proof" aria-labelledby="proof-title">
 			<div class="partnerships-section__header">
 				<p class="partnerships-kicker">Why Rawkode</p>
-				<h2 id="proof-title">The Work Behind the Signal</h2>
+				<h2 id="proof-title">The work is public. Judge it before you email.</h2>
 				<p>
-					Rawkode's public work sits close to the people your product needs to earn trust from: maintainers, platform engineers, DevTool builders, infrastructure teams, and technical practitioners. It brings outside pattern recognition while respecting the independence of the people doing the work.
+					Rawkode's shows and courses reach the people your product has to convince: platform engineers, maintainers, and the practitioners who veto tools. That same audience is where the partnership's read on your product comes from.
 				</p>
 			</div>
 			<div class="partnerships-work-grid">
 				<article class="partnerships-work">
-					<h3>Rawkode Live</h3>
-					<p><a href="/shows/rawkode-live">Maintainer-led live builds and product walkthroughs</a> show how technical people explain tradeoffs, evaluate tools, ask questions, and decide whether something is worth trying.</p>
+					<h3>Courses built with partners</h3>
+					<p>Teleport worked with Rawkode Academy on <a href="/courses/teleport-for-kubernetes">Teleport for Kubernetes</a>: a runnable course that meets developers where they evaluate, hands on, in a real cluster.</p>
 				</article>
 				<article class="partnerships-work">
 					<h3>Klustered</h3>
-					<p><a href="/shows/klustered">Public Kubernetes failure-mode triage</a> shows what practitioners trust under pressure: operational clarity, debugging paths, honest constraints, and proof that survives contact with real systems.</p>
+					<p>Engineers from Adobe, Red Hat, Pulumi, Kong, Chainguard, DigitalOcean, Zapier, Skyscanner, and Civo have <a href="/shows/klustered">debugged broken Kubernetes clusters live on Klustered</a>. It is a public record of what practitioners trust under pressure.</p>
 				</article>
 				<article class="partnerships-work">
-					<h3>Courses and education</h3>
-					<p><a href="/courses/teleport-for-kubernetes">Runnable technical education</a> shows where developers get stuck, what they need before they feel confident, and how learning turns into evaluation and repeated use.</p>
+					<h3>Rawkode Live</h3>
+					<p><a href="/shows/rawkode-live">Maintainer-led live builds and product walkthroughs</a> show how technical people explain tradeoffs, evaluate tools, ask questions, and decide whether something is worth trying.</p>
 				</article>
 			</div>
 		</section>
@@ -211,7 +264,7 @@ const heroProofPoints = [
 				<p class="partnerships-kicker">Partnership paths</p>
 				<h2 id="packages-title">Start where your adoption work needs support.</h2>
 				<p>
-					Each path is month-to-month. Start with outside signal, move into focused experiments, or join Council when peer comparison and expert perspective matter.
+					Each path is month-to-month, no annual lock-in. Start with Signal if you want a recurring outside read. Choose Adoption to turn that read into one focused experiment each month. Choose Council when peer comparison and expert perspective would make the work stronger.
 				</p>
 			</div>
 			<div class="partnerships-package-grid">
@@ -239,31 +292,29 @@ const heroProofPoints = [
 
 		<section class="partnerships-section partnerships-section--split" aria-labelledby="process-title">
 			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Process</p>
 				<h2 id="process-title">Send context first. Call only when there is a fit.</h2>
 			</div>
 			<div class="partnerships-process">
 				<article>
 					<span>01</span>
 					<h3>Send context</h3>
-					<p>Company, category, product, target developers, team stakeholders, current adoption challenge, current team rhythm, and links if they help.</p>
+					<p>Your company and product, the developers you need to reach, your current adoption challenge, and any links worth a look.</p>
 				</article>
 				<article>
 					<span>02</span>
 					<h3>Get a fit reply</h3>
-					<p>David will say whether this fits Signal, Adoption, or Council, or whether it is not a good fit.</p>
+					<p>David Flanagan, Rawkode Academy's founder, will reply with whether this fits Signal, Adoption, or Council, or say plainly that it is not a good fit.</p>
 				</article>
 				<article>
 					<span>03</span>
 					<h3>Work with your team</h3>
-					<p>Each month produces signal, experiment decisions, or cohort synthesis your team can reuse in strategy, narrative, education, proof, objections, and alignment.</p>
+					<p>Each month ends with something your team can reuse: a written brief, an experiment plan, or cohort notes that feed your strategy, docs, demos, and sales conversations.</p>
 				</article>
 			</div>
 		</section>
 
 		<section class="partnerships-section partnerships-section--split" aria-labelledby="faq-title">
 			<div class="partnerships-section__header">
-				<p class="partnerships-kicker">Questions</p>
 				<h2 id="faq-title">Questions before you start.</h2>
 			</div>
 			<div class="partnerships-faq-list">
@@ -277,28 +328,28 @@ const heroProofPoints = [
 		</section>
 
 		<section class="partnerships-final" aria-labelledby="final-title">
-			<p class="partnerships-kicker">Start here</p>
 			<h2 id="final-title">Start with the next adoption problem.</h2>
 			<p>
-				Rough context is enough: product, target developers, team stakeholders, adoption challenge, current team rhythm, and links if useful.
+				Rough context is enough: your product, the developers you need to reach, and the adoption problem in front of you.
 			</p>
-			<a class="partnerships-button" href={contactHref}>Get in Touch</a>
-			<ContactFallback
-				subject={partnershipFitSubject}
-				template={partnershipFitTemplate}
-			/>
+			<div class="partnerships-actions">
+				<a class="partnerships-button" href={contactHref}>Email David</a>
+			</div>
+			<p class="partnerships-contact-note">
+				Or write your own email to <a href={`mailto:${contactEmail}`}>{contactEmail}</a>. <a href="/organizations/lets-chat">Here is what a useful first email includes</a>.
+			</p>
 		</section>
 	</main>
 </Page>
 
 <style>
 	.partnerships-page {
-		--partnerships-ink: var(--editorial-ink, oklch(0.18 0.02 260));
-		--partnerships-muted: var(--editorial-ink-soft, oklch(0.42 0.025 260));
-		--partnerships-paper: var(--editorial-paper, oklch(0.985 0.006 95));
-		--partnerships-paper-deep: var(--editorial-paper-deep, oklch(0.955 0.012 95));
-		--partnerships-line: var(--editorial-hairline, oklch(0.82 0.018 95));
-		--partnerships-accent: var(--editorial-spruce, oklch(0.36 0.08 170));
+		--partnerships-ink: var(--editorial-ink);
+		--partnerships-muted: var(--editorial-ink-soft);
+		--partnerships-paper: var(--editorial-paper);
+		--partnerships-paper-deep: var(--editorial-paper-deep);
+		--partnerships-line: var(--editorial-hairline);
+		--partnerships-accent: var(--editorial-spruce);
 		background: var(--partnerships-paper);
 		color: var(--partnerships-ink);
 		font-family: var(--font-inter-tight), system-ui, sans-serif;
@@ -346,7 +397,7 @@ const heroProofPoints = [
 		font-family: var(--font-inter-tight), system-ui, sans-serif;
 		font-size: clamp(2.2rem, 4.4vw, 4.55rem);
 		font-style: normal;
-		font-weight: 780;
+		font-weight: 700;
 		letter-spacing: 0;
 		line-height: 1;
 		margin: 0;
@@ -384,7 +435,7 @@ const heroProofPoints = [
 	.partnerships-hero__rail-label {
 		color: var(--partnerships-ink);
 		font-size: 0.95rem;
-		font-weight: 760;
+		font-weight: 700;
 		line-height: 1.25;
 		margin: 0;
 	}
@@ -401,7 +452,7 @@ const heroProofPoints = [
 		border-top: 1px solid var(--partnerships-line);
 		display: grid;
 		gap: 0.5rem;
-		grid-template-columns: 4.5rem minmax(0, 1fr);
+		grid-template-columns: 5rem minmax(0, 1fr);
 		padding: 0.85rem 0;
 	}
 
@@ -414,7 +465,7 @@ const heroProofPoints = [
 		color: var(--partnerships-accent);
 		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
 		font-size: 0.7rem;
-		font-weight: 800;
+		font-weight: 700;
 		letter-spacing: 0.08em;
 		line-height: 1.25;
 		text-transform: uppercase;
@@ -423,7 +474,7 @@ const heroProofPoints = [
 	.partnerships-hero__rail p {
 		color: var(--partnerships-ink);
 		font-size: 1rem;
-		font-weight: 680;
+		font-weight: 600;
 		line-height: 1.35;
 		margin: 0;
 	}
@@ -434,6 +485,25 @@ const heroProofPoints = [
 		gap: 0.75rem;
 		margin-top: 1.5rem;
 		width: fit-content;
+	}
+
+	.partnerships-contact-note {
+		color: var(--partnerships-muted);
+		font-size: 0.88rem;
+		line-height: 1.5;
+		margin: 0.85rem 0 0;
+		max-width: 38rem;
+	}
+
+	.partnerships-contact-note a {
+		color: var(--partnerships-ink);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.18em;
+	}
+
+	.partnerships-contact-note a:hover {
+		color: var(--partnerships-accent);
 	}
 
 	.partnerships-button {
@@ -448,7 +518,7 @@ const heroProofPoints = [
 		color: var(--partnerships-paper);
 		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
 		font-size: 0.72rem;
-		font-weight: 750;
+		font-weight: 700;
 		letter-spacing: 0.08em;
 		line-height: 1.1;
 		text-align: center;
@@ -468,7 +538,7 @@ const heroProofPoints = [
 		color: var(--partnerships-ink);
 		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
 		font-size: 0.72rem;
-		font-weight: 750;
+		font-weight: 700;
 		letter-spacing: 0.08em;
 		line-height: 1.2;
 		min-height: 2.85rem;
@@ -515,7 +585,7 @@ const heroProofPoints = [
 		font-family: var(--font-inter-tight), system-ui, sans-serif;
 		font-size: clamp(1.65rem, 6vw, 4rem);
 		font-style: normal;
-		font-weight: 760;
+		font-weight: 700;
 		letter-spacing: 0;
 		line-height: 0.98;
 		margin: 0;
@@ -560,7 +630,7 @@ const heroProofPoints = [
 	.partnerships-work h3,
 	.partnerships-process h3 {
 		font-size: 1.25rem;
-		font-weight: 730;
+		font-weight: 600;
 		line-height: 1.1;
 		letter-spacing: 0;
 		margin: 0;
@@ -657,28 +727,12 @@ const heroProofPoints = [
 	.partnerships-inspection-item {
 		border-top: 1px solid var(--partnerships-line);
 		display: grid;
-		gap: 0.85rem;
-		grid-template-columns: 2.4rem minmax(0, 1fr);
+		gap: 0.35rem;
 		padding: 0.95rem 0;
 	}
 
 	.partnerships-inspection-item:first-child {
 		border-top: 0;
-	}
-
-	.partnerships-inspection-item__number {
-		color: var(--partnerships-accent);
-		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-		font-size: 0.72rem;
-		font-weight: 800;
-		letter-spacing: 0.08em;
-		line-height: 1.2;
-		padding-top: 0.15rem;
-	}
-
-	.partnerships-inspection-item div {
-		display: grid;
-		gap: 0.35rem;
 	}
 
 	.partnerships-process span {
@@ -704,7 +758,7 @@ const heroProofPoints = [
 	.partnerships-faq-list summary {
 		cursor: pointer;
 		font-size: 1rem;
-		font-weight: 730;
+		font-weight: 600;
 		line-height: 1.3;
 	}
 
@@ -726,6 +780,14 @@ const heroProofPoints = [
 
 	.partnerships-final p {
 		max-width: 38rem;
+	}
+
+	.partnerships-final .partnerships-actions {
+		margin-top: 0;
+	}
+
+	.partnerships-final .partnerships-contact-note {
+		margin-top: 0;
 	}
 
 	@media (min-width: 640px) {

--- a/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
+++ b/projects/rawkode.academy/website/src/pages/organizations/partnerships/index.astro
@@ -34,6 +34,11 @@ const faqs = [
 			"No. One company per problem space at a time, across every plan. If a direct competitor applies while we work together, they wait. Community cohorts are screened the same way: no two member teams compete directly.",
 	},
 	{
+		question: "We already read the analyst reports. What does this add?",
+		answer:
+			"Keep them. Analysts tell you what developers think; this is help acting on it, week by week, on your own docs, demos, and plans.",
+	},
+	{
 		question: "Does a partnership affect Rawkode Live coverage?",
 		answer:
 			"No. Advisory clients get no coverage, and coverage decisions never consider who pays. The audience's trust is the product; it is not for sale.",
@@ -66,7 +71,7 @@ const faqs = [
 	{
 		question: "What is intentionally out of scope?",
 		answer:
-			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings a practitioner's read, strategic critique, and adoption patterns that have worked elsewhere. And if you have your own DevRel team, the advice goes through them, not around them.",
+			"This is not outsourced DevRel, campaign planning, custom content production on demand, lead generation, audience rental, or open-ended access. Your team owns execution; Rawkode brings a practitioner's read, strategic critique, and adoption patterns that have worked elsewhere. And if you have a DevRel team, or are hiring your first, the advice goes through them, not around them: it makes them more effective, not redundant.",
 	},
 ];
 
@@ -90,6 +95,11 @@ const anchors = [
 		term: "Instead of a fractional hire",
 		detail:
 			"A senior practitioner's judgement without a day rate, a ramp-up, or a seat on your payroll.",
+	},
+	{
+		term: "Never your competitor",
+		detail:
+			"One company per problem space at a time, on every plan. If a direct competitor applies while we work together, they wait.",
 	},
 ];
 
@@ -241,7 +251,7 @@ const heroProofPoints = [
 				<p class="editorial-kicker">Partnership paths</p>
 				<h2 id="packages-title" class="editorial-section__title">Start where your adoption work needs support</h2>
 				<p class="editorial-section__lede">
-					Every plan starts with an application, and not every application is a fit. All plans are month-to-month: start, pause, or cancel any month, or pay for twelve months up front and get two free. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room, capped at ten teams.
+					Every plan starts with an application, and not every application is a fit. All plans are month-to-month, with two months free when you pay for twelve. These are founding rates for the first teams; they will rise. Signal puts the advisor in your Slack. Adoption adds video sessions and reviews of the work itself, and is the recommended path. Community adds the room, capped at ten teams.
 				</p>
 			</div>
 			<dl class="partnerships-anchors">

--- a/projects/rawkode.academy/website/worker-configuration.d.ts
+++ b/projects/rawkode.academy/website/worker-configuration.d.ts
@@ -4,6 +4,7 @@
 interface __BaseEnv_Env {
 	SESSION: KVNamespace;
 	ASSETS: Fetcher;
+	PARTNERSHIP_APPLICATIONS: SendEmail;
 	CLOUDFLARE_ACCOUNT_ID: "0aeb879de8e3cdde5fb3d413025222ce";
 	NOTIFICATIONS_VAPID_PUBLIC_KEY: "BDgtSVztEoFZDmO0Iz-MpBNaYv8ukGIQQYS8SwUBt7vMLXQT60-zjsyMTY8opukUBHoptdgm2u-uonWthz6e1SE";
 	EMOJI_REACTIONS: Fetcher /* platform-emoji-reactions-write-model */;

--- a/projects/rawkode.academy/website/wrangler.jsonc
+++ b/projects/rawkode.academy/website/wrangler.jsonc
@@ -27,6 +27,12 @@
 			"id": "f3a5e01c10b144f5964d060cefa1b70c"
 		}
 	],
+	"send_email": [
+		{
+			"name": "PARTNERSHIP_APPLICATIONS",
+			"destination_address": "david@rawkode.academy"
+		}
+	],
 	"routes": [
 		{
 			"pattern": "rawkode.academy",


### PR DESCRIPTION
Reworks the primary partnerships sales page end to end: buyer-language copy, verifiable social proof, an application-based funnel with a real form, design-system alignment, and conversion-focused tier packaging. Rebased onto #1245 and consumes its `@/lib/partnerships` module and `ContactFallback` component.

## Offer & funnel

- **Every plan is application-based.** Tier CTAs read "Apply for Signal/Adoption/Community", the process section is apply → get an answer → start, and the pricing lede leads with "Every plan starts with an application, and not every application is a fit."
- **Application form replaces mailto as the primary CTA.** A new `partnership.apply` Astro Action emails submissions to David via a Cloudflare `send_email` binding (`PARTNERSHIP_APPLICATIONS`), with the applicant as Reply-To, MIME-injection-safe headers, RFC 2047 subject encoding, and a honeypot. The form is an editorial-styled Vue island; package CTAs anchor to it and preselect the plan. `ContactFallback` remains beneath it for email-first buyers.
- **Tiers are an access ladder** (Slack / Slack + video / Cohort):
  - **Signal (£1k)**: Slack Connect with Rawkode Academy for advice as questions come up, plus a monthly review of high-level plans and objectives.
  - **Adoption (£2k, recommended)**: adds a monthly video working session, tactical reviews of the work itself (docs, demos, onboarding, launch posts, pricing pages), and experiment plans when a blocker needs evidence.
  - **Community (£3k, was Council)**: adds the cohort room — **limited to 10 member teams, first cohort August 2026**.
- **Annual offer**: pay for twelve months up front, get two free, on any plan (pricing lede + FAQ).
- Price anchoring strip (vs. conferences, agencies, analyst reports — advice from the target audience itself); "How does Slack access work?" FAQ bounds access as advisory, not on-call support.
- Social proof: Teleport course partnership leads the proof section; Klustered names real companies (Adobe, Red Hat, Pulumi, Kong, Chainguard, DigitalOcean, Zapier, Skyscanner, Civo).

## Structure & system

- Page migrated onto `EditorialShell` and shared `editorial-*` classes; ~380 lines of bespoke CSS deleted; 118rem one-off container replaced by the shell's 72rem.
- Tier copy lives in `@/lib/partnerships` so all org pages stay in sync.

## Deployment requirements

- `wrangler.jsonc` gains a `send_email` binding to `david@rawkode.academy` — that address must be a **verified destination in Cloudflare Email Routing**, and `partnerships@rawkode.academy` is used as the sender (domain must have Email Routing enabled).
- `worker-configuration.d.ts` was hand-extended with the binding; re-run `wrangler types` to regenerate properly.
- `astro check` could not run in the working environment (`ski-*` workspace deps unresolvable on main); please run a local build and test a form submission in preview before merging.
- Other commitments now in writing: Community expert calendar "published a quarter ahead", August 2026 cohort.

https://claude.ai/code/session_01SinL5UwQMVkaix5SdAwUJY