### PR TITLE
feat: technology matrix content updates (Feb–Jun 2026) + matrix page UX improvements

### DIFF
--- a/content/technologies/agentgateway/index.mdx
+++ b/content/technologies/agentgateway/index.mdx
@@ -1,0 +1,19 @@
+---
+name: agentgateway
+website: 'https://agentgateway.dev/'
+source: 'https://github.com/agentgateway/agentgateway'
+documentation: 'https://agentgateway.dev/docs/'
+license: Apache-2.0
+status: beta
+category: Orchestration & Management
+subcategory: API Gateway
+matrix:
+  status: watch
+  trajectory: rising
+---
+
+agentgateway is an AI-native proxy, written in Rust, for the traffic patterns that agentic systems create: agent-to-LLM, agent-to-tool, and agent-to-agent communication. It speaks the protocols of that world natively — Model Context Protocol (MCP) and Agent2Agent (A2A) — and layers security, observability, and governance on top, so platform teams can see and control what their agents are actually saying to models and tools.
+
+Created by Solo.io and donated to the Linux Foundation, it slots into the existing cloud native stack rather than beside it: kgateway can act as its control plane, and at KubeCon + CloudNativeCon Europe 2026 the Istio project announced experimental agentgateway support alongside its Gateway API Inference Extension work. Capabilities include MCP multiplexing (federating many MCP servers behind one endpoint), tool-level RBAC, prompt guardrails, and OpenTelemetry-based tracing of agent conversations.
+
+It occupies the emerging "agent gateway" niche alongside LiteLLM, Portkey, and the LLM-routing features appearing in traditional API gateways; its bet is that agent traffic deserves a purpose-built, vendor-neutral data plane rather than bolt-ons to HTTP gateways.

--- a/content/technologies/agentregistry/index.mdx
+++ b/content/technologies/agentregistry/index.mdx
@@ -1,0 +1,18 @@
+---
+name: agentregistry
+website: 'https://agentregistry.dev/'
+source: 'https://github.com/agentregistry-dev/agentregistry'
+license: Apache-2.0
+status: alpha
+category: Provisioning
+subcategory: Container Registry
+matrix:
+  status: watch
+  trajectory: rising
+---
+
+agentregistry is a cloud native registry for the building blocks of agentic AI systems: MCP servers, agents, and skills. It gives organizations a curated, single source of truth for which agents and tools are approved for use, and handles discovery and deployment of those artifacts across local development environments and Kubernetes clusters.
+
+The project was created by Solo.io — its third agentic-infrastructure donation after kagent and agentgateway — and donated to the Linux Foundation, with a CNCF Sandbox application submitted in March 2026. It integrates with the projects you'd expect: Kubernetes for deployment, and Prometheus and OpenTelemetry for observability, with agentgateway as the natural enforcement point for what the registry curates.
+
+The problem it addresses is real and growing: as teams accumulate dozens of MCP servers and agents of varying provenance, "which of these are vetted, versioned, and safe to run?" needs an answer that isn't a wiki page. Whether the ecosystem standardizes on agentregistry or on registry features inside existing artifact stores (Artifact Hub, OCI registries) is the open question.

--- a/content/technologies/dagger/index.mdx
+++ b/content/technologies/dagger/index.mdx
@@ -12,6 +12,7 @@ category: App Definition and Development
 subcategory: Continuous Integration & Delivery
 matrix:
   status: learn
+  trajectory: rising
 ---
 Dagger is a portable CI/CD engine that lets you write pipelines as code in a real programming language — Go, Python, TypeScript, PHP, Java, or any language for which an SDK exists — and executes them as containerized DAGs on top of BuildKit. The same pipeline runs locally on your laptop and in any CI system (GitHub Actions, GitLab, Jenkins, CircleCI) because the CI system's only job is to call `dagger call`.
 

--- a/content/technologies/dragonfly/index.mdx
+++ b/content/technologies/dragonfly/index.mdx
@@ -40,8 +40,6 @@ cncf:
     - d7y
     - nydus
   releaseRate: Major release every 2 months.
-  integrations:
-    - '>-'
 community:
   twitter: 'https://twitter.com/dragonfly_oss'
   slack: 'https://cloud-native.slack.com/messages/dragonfly/'

--- a/content/technologies/fluid/index.mdx
+++ b/content/technologies/fluid/index.mdx
@@ -13,7 +13,7 @@ subcategory: Scheduling & Orchestration
 cncf:
   status: incubating
   accepted: '2021-04-28'
-  incubating: '2026-01-08'
+  incubating: '2026-03-24'
 matrix:
   status: skip
 ---

--- a/content/technologies/gitpod/index.mdx
+++ b/content/technologies/gitpod/index.mdx
@@ -1,11 +1,13 @@
 ---
 name: Gitpod
+aliases:
+  - Ona
 logos:
   horizontal: true
 website: 'https://www.gitpod.io/'
 documentation: 'https://www.gitpod.io/docs/'
 license: AGPL-3.0
-status: stable
+status: superseded
 category: App Definition and Development
 subcategory: Application Definition & Image Build
 matrix:
@@ -17,3 +19,5 @@ Gitpod is a cloud development environment platform — you push a `.gitpod.yml` 
 The original Gitpod Classic was an open-source, Kubernetes-based multi-tenant platform: each workspace was a pod with a containerized VS Code Server, backed by a workspace content sync service and a websocket-based IDE bridge. In 2024 Gitpod introduced Gitpod Flex, a rearchitected product that runs workspaces on dedicated VMs (including inside the customer's own AWS account) rather than shared Kubernetes nodes, to address the isolation and compliance complaints from larger customers. Workspaces can be prebuilt — Gitpod runs your init commands ahead of time on every commit, so opening one is effectively instant.
 
 It sits in the same category as GitHub Codespaces, Coder, JetBrains Space/Remote Dev, and DevPod. The historical selling point versus Codespaces was being cloud-and-host agnostic; the current selling point versus Coder is the prebuild system and the managed experience. Gitpod Classic is open source (AGPL); Flex is the commercial SaaS/self-hosted product.
+
+In September 2025 the company rebranded as Ona, repositioning from cloud development environments to "mission control" for software engineering agents: the same sandboxed, prebuild-backed workspaces, but driven by autonomous coding agents with humans reviewing. Gitpod Classic was sunset as part of the transition. On June 11, 2026, OpenAI announced it was acquiring Ona so Codex agents can run long, multi-hour tasks inside a customer's own cloud — making the Gitpod brand a historical artifact, though the workspace technology lives on inside Codex.

--- a/content/technologies/headlamp/index.mdx
+++ b/content/technologies/headlamp/index.mdx
@@ -20,7 +20,7 @@ matrix:
   status: explore
 ---
 
-Headlamp is an open-source Kubernetes dashboard, originally built by Kinvolk (now Microsoft) and donated to the CNCF Sandbox in 2022. It's a web UI — or a desktop app via Electron — for browsing and managing clusters: workloads, storage, networking, RBAC, custom resources, logs, exec, and port-forward.
+Headlamp is an open-source Kubernetes dashboard, originally built by Kinvolk (now Microsoft), donated to the CNCF Sandbox in 2022, and since adopted by Kubernetes SIG UI as an official Kubernetes subproject. It's a web UI — or a desktop app via Electron — for browsing and managing clusters: workloads, storage, networking, RBAC, custom resources, logs, exec, and port-forward.
 
 The interesting bit versus the older Kubernetes Dashboard is that Headlamp is built as an extensible React/TypeScript frontend with a first-class plugin API. You can ship a plugin that adds new pages, sidebar entries, resource detail tabs, action buttons, or entire custom-resource viewers, and load it into any Headlamp deployment without forking the project. That's what makes vendors (like Flux, Kubeflow, Kanister, Kubescape, KubeVirt) ship Headlamp plugins as the UI layer for their controllers. Authentication is whatever the kubeconfig or OIDC provider says — Headlamp itself doesn't store credentials — and it can run in-cluster, as a standalone app, or as a local desktop tool pointing at multiple kubeconfig contexts at once.
 

--- a/content/technologies/istio/index.mdx
+++ b/content/technologies/istio/index.mdx
@@ -15,6 +15,7 @@ status: stable
 matrix:
   grouping: platform
   status: adopt
+  trajectory: rising
 category: Orchestration & Management
 subcategory: Service Mesh
 cncf:

--- a/content/technologies/kaniko/index.mdx
+++ b/content/technologies/kaniko/index.mdx
@@ -5,16 +5,16 @@ logos:
 website: 'https://github.com/GoogleContainerTools/kaniko'
 documentation: 'https://github.com/GoogleContainerTools/kaniko/blob/main/README.md'
 license: Apache-2.0
-status: stable
+status: abandoned
 category: App Definition and Development
 subcategory: Application Definition & Image Build
 community:
   twitter: 'https://twitter.com/GCPcloud'
 matrix:
-  status: explore
+  status: skip
 ---
 Kaniko is a daemonless container image builder from Google that executes a Dockerfile entirely in userspace inside a container. It was created to solve one specific problem: building OCI images in a Kubernetes pod without Docker-in-Docker, `--privileged`, or a mounted Docker socket.
 
 The executor image (`gcr.io/kaniko-project/executor`) takes a build context (local tarball, Git URL, S3, GCS) and a Dockerfile, pulls the base image, then walks each instruction one at a time. For each `RUN` it executes the command in the container's root filesystem and then snapshots the filesystem changes by diffing against the previous state to produce a new layer. The resulting image is pushed directly to a registry. Because nothing calls `runc` or a daemon, Kaniko only needs its own container and does not require root on the host — though it does require elevated capabilities inside its own user namespace to chroot and manipulate the filesystem.
 
-It is the default builder inside Tekton, Jenkins X, Argo Workflows, and GitLab's Kubernetes executor for anyone allergic to DinD. The main trade-offs versus BuildKit (the modern default behind `docker build`): Kaniko is single-threaded per stage, layer caching is less sophisticated, and it is slower on large builds. Note the repo is in maintenance mode — the project still receives fixes but lags behind BuildKit on features and performance.
+It is the default builder inside Tekton, Jenkins X, Argo Workflows, and GitLab's Kubernetes executor for anyone allergic to DinD. The main trade-offs versus BuildKit (the modern default behind `docker build`): Kaniko is single-threaded per stage, layer caching is less sophisticated, and it is slower on large builds. Google archived the repository on June 3, 2025, and the remaining maintainers retired, ending upstream development. Community forks exist — Chainguard maintains one, and the osscontainertools fork keeps dependencies patched — but for new pipelines BuildKit, Buildah, or podman build are the recommended replacements; GitLab has removed its Kaniko documentation and now recommends Buildah.

--- a/content/technologies/kubevirt/index.mdx
+++ b/content/technologies/kubevirt/index.mdx
@@ -30,6 +30,7 @@ community:
   mailingList: 'https://groups.google.com/g/kubevirt-dev/'
 matrix:
   status: explore
+  trajectory: rising
 ---
 KubeVirt is a Kubernetes add-on that runs virtual machines as first-class workloads alongside containers. A VirtualMachine custom resource maps to a pod whose main container wraps libvirt and QEMU/KVM, so the guest gets real hardware virtualisation while Kubernetes schedules, networks, and stores it like any other pod.
 

--- a/content/technologies/llm-d/index.mdx
+++ b/content/technologies/llm-d/index.mdx
@@ -1,0 +1,22 @@
+---
+name: llm-d
+website: 'https://llm-d.ai/'
+source: 'https://github.com/llm-d/llm-d'
+documentation: 'https://llm-d.ai/docs'
+license: Apache-2.0
+status: beta
+category: CNAI
+subcategory: ML Serving
+cncf:
+  status: sandbox
+  accepted: '2026-03-24'
+matrix:
+  status: explore
+  trajectory: rising
+---
+
+llm-d is a Kubernetes-native distributed inference serving stack for large language models, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA, with AMD, Cisco, Hugging Face, Intel, Lambda, and Mistral AI contributing. It was accepted as a CNCF Sandbox project at KubeCon + CloudNativeCon Europe 2026, with the stated goal of making distributed LLM inference a first-class cloud native workload.
+
+Rather than inventing a new model server, llm-d composes proven pieces: vLLM as the inference engine, the Gateway API Inference Extension as a model-aware request scheduler, and Kubernetes as the orchestration layer. On top of that it adds the techniques that matter at scale — disaggregated prefill and decode phases, KV-cache-aware routing that sends requests to replicas already holding relevant cache state, and support for heterogeneous accelerators including NVIDIA and AMD GPUs and Google TPUs. Deployment is via Helm charts with "well-lit paths" for common topologies.
+
+It competes with (and complements) KServe, Ray Serve, and NVIDIA's serving stack; the differentiation is being vendor-neutral, Kubernetes-native, and tuned specifically for the traffic patterns of LLM inference rather than generic model serving.

--- a/content/technologies/microcks/index.mdx
+++ b/content/technologies/microcks/index.mdx
@@ -12,8 +12,9 @@ status: stable
 category: App Definition and Development
 subcategory: Application Definition & Image Build
 cncf:
-  status: sandbox
+  status: incubating
   accepted: '2023-06-22'
+  incubating: '2026-05-07'
   devStatsUrl: 'https://microcks.devstats.cncf.io/'
   personas:
     - API Owners
@@ -34,8 +35,6 @@ cncf:
     - grpc
     - asyncapi
   releaseRate: New release every 2 to 3 months.
-  integrations:
-    - '>-'
 community:
   twitter: 'https://twitter.com/microcksio'
   youtube: 'https://youtube.com/c/Microcks'

--- a/content/technologies/n8n/index.mdx
+++ b/content/technologies/n8n/index.mdx
@@ -11,6 +11,7 @@ category: App Definition and Development
 subcategory: Streaming & Messaging
 matrix:
   status: explore
+  trajectory: rising
 ---
 n8n is a source-available workflow automation tool that connects APIs, databases, and SaaS products through a node-based visual editor. It sits in the same category as Zapier and Make, but runs as a self-hostable Node.js application backed by PostgreSQL, SQLite, or MySQL for workflow state and execution history.
 

--- a/content/technologies/opentelemetry/index.mdx
+++ b/content/technologies/opentelemetry/index.mdx
@@ -14,9 +14,10 @@ status: stable
 category: Observability and Analysis
 subcategory: Observability
 cncf:
-  status: incubating
+  status: graduated
   accepted: '2019-05-07'
   incubating: '2021-08-26'
+  graduated: '2026-05-21'
   devStatsUrl: 'https://opentelemetry.devstats.cncf.io/'
   personas:
     - Developers

--- a/content/technologies/opentofu/index.mdx
+++ b/content/technologies/opentofu/index.mdx
@@ -17,7 +17,8 @@ cncf:
 community:
   twitter: 'https://twitter.com/opentofuorg'
 matrix:
-  status: skip
+  status: explore
+  trajectory: rising
 ---
 OpenTofu is a community-driven fork of Terraform created after HashiCorp relicensed Terraform from MPL-2.0 to the Business Source License in August 2023. It is hosted by the Linux Foundation, remains MPL-2.0, and is a drop-in replacement for `terraform`: the HCL language, provider protocol, state file format, and CLI surface all match.
 

--- a/content/technologies/quickwit/index.mdx
+++ b/content/technologies/quickwit/index.mdx
@@ -10,7 +10,7 @@ status: stable
 category: Observability and Analysis
 subcategory: Logging
 matrix:
-  status: explore
+  status: watch
 ---
 Quickwit is a distributed search engine for logs, traces, and general event data, written in Rust and built around Tantivy, the inverted-index library that also powers Meilisearch. Its core design decision is decoupling storage from compute: indexes are stored as immutable splits on object storage (S3, GCS, Azure Blob, or local filesystem) and queried by stateless search nodes that can be scaled independently of ingestion.
 

--- a/content/technologies/system-initiative/index.mdx
+++ b/content/technologies/system-initiative/index.mdx
@@ -10,7 +10,7 @@ status: abandoned
 category: Provisioning
 subcategory: Automation & Configuration
 matrix:
-  status: watch
+  status: graveyard
 terms:
   - SysInit
   - SI

--- a/content/technologies/tektoncd/index.mdx
+++ b/content/technologies/tektoncd/index.mdx
@@ -9,6 +9,10 @@ license: Apache-2.0
 status: stable
 category: App Definition and Development
 subcategory: Continuous Integration & Delivery
+cncf:
+  status: incubating
+  accepted: '2026-03-24'
+  incubating: '2026-03-24'
 matrix:
   status: skip
 ---

--- a/projects/rawkode.academy/website/src/components/explorer/TechnologyExplorer.vue
+++ b/projects/rawkode.academy/website/src/components/explorer/TechnologyExplorer.vue
@@ -29,7 +29,13 @@
  :aria-hidden="!showControls"
  >
  <div class="controls-content">
- <div class="controls-drawer-header">
+ <div
+ class="controls-drawer-header"
+ @touchstart.passive="onSheetTouchStart"
+ @touchmove.passive="onSheetTouchMove"
+ @touchend="onSheetTouchEnd"
+ >
+ <span class="drawer-handle" aria-hidden="true"></span>
  <h2>Advanced filters</h2>
  <button
  type="button"
@@ -71,6 +77,20 @@
 
  <!-- Visualization canvas -->
  <main class="explorer-canvas">
+ <!-- Persistent search on mobile: the filter drawer is closed by default
+ there, and search is the most common entry point. -->
+ <div class="mobile-search">
+ <input
+ type="search"
+ class="mobile-search-input"
+ placeholder="Search technologies…"
+ aria-label="Search technologies"
+ :value="filters.search"
+ @input="setSearch(($event.target as HTMLInputElement).value)"
+ />
+ <span class="mobile-search-count" aria-live="polite">{{ filteredTechnologies.length }} shown</span>
+ </div>
+
  <!-- Grid View (Phase 1) -->
  <GridView
  v-if="viewMode === 'grid'"
@@ -115,6 +135,21 @@
  </main>
  </div>
 
+ <!-- Floating filter button (mobile): keeps filters reachable after
+ scrolling a long results list. -->
+ <button
+ v-if="!showControls"
+ type="button"
+ class="filters-fab"
+ @click="toggleControls"
+ >
+ <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+ <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18l-7 8v6l-4 2v-8L3 4z" />
+ </svg>
+ <span>Filters</span>
+ <span v-if="filterCount > 0" class="fab-badge">{{ filterCount }}</span>
+ </button>
+
  <!-- Technology card popover (click to show) -->
  <TechCardPopover
  v-if="selectedTech"
@@ -135,7 +170,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onBeforeUnmount, onMounted, provide } from "vue";
+import { ref, computed, onBeforeUnmount, onMounted, provide, watch } from "vue";
 import type { NormalizedTechnology } from "@/lib/explorer/data-layer";
 import { useExplorerState } from "@/composables/useExplorerState";
 import { useUrlState } from "@/composables/useUrlState";
@@ -191,6 +226,38 @@ const {
 const closeControls = () => {
 	showControls.value = false;
 };
+
+const isMobile = () =>
+	typeof window !== "undefined" &&
+	window.matchMedia("(max-width: 768px)").matches;
+
+// On mobile the controls render as a bottom sheet; lock the page behind it.
+watch(showControls, (open) => {
+	if (typeof document === "undefined") return;
+	document.body.style.overflow = open && isMobile() ? "hidden" : "";
+});
+
+// Swipe-down on the sheet header dismisses it.
+let sheetTouchY: number | null = null;
+let sheetTouchDelta = 0;
+
+function onSheetTouchStart(event: TouchEvent) {
+	sheetTouchY = event.touches[0]?.clientY ?? null;
+	sheetTouchDelta = 0;
+}
+
+function onSheetTouchMove(event: TouchEvent) {
+	if (sheetTouchY === null) return;
+	sheetTouchDelta = (event.touches[0]?.clientY ?? sheetTouchY) - sheetTouchY;
+}
+
+function onSheetTouchEnd() {
+	if (sheetTouchDelta > 60 && isMobile()) {
+		closeControls();
+	}
+	sheetTouchY = null;
+	sheetTouchDelta = 0;
+}
 
 // URL state sync
 const urlState = useUrlState(explorer);
@@ -253,6 +320,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	window.removeEventListener("keydown", handleKeydown);
+	document.body.style.overflow = "";
 });
 
 function handleKeydown(event: KeyboardEvent) {
@@ -323,6 +391,13 @@ function handleKeydown(event: KeyboardEvent) {
 .explorer-canvas {
  flex: 1;
  min-width: 0;
+}
+
+/* Mobile-only affordances, hidden on desktop */
+.mobile-search,
+.filters-fab,
+.drawer-handle {
+ display: none;
 }
 
 /* Coming soon placeholder */
@@ -474,7 +549,92 @@ function handleKeydown(event: KeyboardEvent) {
  }
 
  .explorer-canvas {
- padding-bottom: 80px; /* Space for controls toggle */
+ padding-bottom: 80px; /* Space for the floating filter button */
+ }
+
+ .mobile-search {
+ display: flex;
+ align-items: center;
+ gap: 0.625rem;
+ margin-bottom: 0.875rem;
+ }
+
+ .mobile-search-input {
+ flex: 1;
+ min-width: 0;
+ min-height: 44px;
+ padding: 0.5rem 0.875rem;
+ background: var(--surface-card);
+ border: 1px solid var(--surface-border);
+ border-radius: 6px;
+ font-size: 1rem;
+ color: var(--text-primary-content);
+ }
+
+ .mobile-search-input:focus-visible {
+ outline: 2px solid rgb(var(--brand-primary));
+ outline-offset: 1px;
+ }
+
+ .mobile-search-count {
+ font-family: var(--font-jetbrains-mono), monospace;
+ font-size: 0.72rem;
+ font-weight: 700;
+ color: var(--text-muted);
+ white-space: nowrap;
+ }
+
+ .filters-fab {
+ position: fixed;
+ bottom: 1.25rem;
+ right: 1.25rem;
+ z-index: 48; /* below the sheet (50) and its backdrop (49) */
+ display: inline-flex;
+ align-items: center;
+ gap: 0.5rem;
+ min-height: 48px;
+ padding: 0.75rem 1.125rem;
+ background: var(--editorial-ink);
+ color: var(--editorial-paper);
+ border: 1px solid var(--editorial-ink);
+ border-radius: 9999px;
+ font-family: var(--font-jetbrains-mono), monospace;
+ font-size: 0.72rem;
+ font-weight: 700;
+ letter-spacing: 0.1em;
+ text-transform: uppercase;
+ cursor: pointer;
+ box-shadow: 0 4px 16px rgb(0 0 0 / 0.2);
+ }
+
+ .filters-fab svg {
+ width: 1rem;
+ height: 1rem;
+ }
+
+ .fab-badge {
+ display: inline-flex;
+ align-items: center;
+ justify-content: center;
+ min-width: 1.25rem;
+ height: 1.25rem;
+ padding: 0 0.3rem;
+ background: rgb(var(--brand-primary));
+ color: white;
+ border-radius: 9999px;
+ font-size: 0.65rem;
+ }
+
+ .drawer-handle {
+ display: block;
+ position: absolute;
+ top: 0.375rem;
+ left: 50%;
+ transform: translateX(-50%);
+ width: 2.5rem;
+ height: 0.25rem;
+ border-radius: 9999px;
+ background: var(--surface-border-strong, var(--surface-border));
  }
 }
 </style>

--- a/projects/rawkode.academy/website/src/components/explorer/cards/TechCardPopover.vue
+++ b/projects/rawkode.academy/website/src/components/explorer/cards/TechCardPopover.vue
@@ -1,8 +1,13 @@
 <template>
  <Teleport to="body">
- <div class="popover-backdrop" @click="$emit('close')"></div>
- <div class="tech-card-popover" @click.stop>
- <button type="button" class="close-btn" @click="$emit('close')" aria-label="Close">
+ <dialog
+ ref="dialogEl"
+ class="tech-card-popover"
+ :aria-label="technology.name"
+ @click="onDialogClick"
+ @close="$emit('close')"
+ >
+ <button type="button" class="close-btn" @click="dialogEl?.close()" aria-label="Close">
  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
  </svg>
@@ -45,8 +50,9 @@
  <span class="stat-value">{{ technology.metrics.videoCount || 0 }}</span>
  <span class="stat-label">Videos</span>
  </div>
- <div class="stat">
- <span class="stat-value">{{ technology.metrics.articleCount || 0 }}</span>
+ <!-- Hidden until article links are wired up; a permanent zero reads as broken -->
+ <div v-if="technology.metrics.articleCount" class="stat">
+ <span class="stat-value">{{ technology.metrics.articleCount }}</span>
  <span class="stat-label">Articles</span>
  </div>
  <div class="stat">
@@ -76,12 +82,12 @@
  </a>
  </div>
  </div>
- </div>
+ </dialog>
  </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from "vue";
+import { computed, onMounted, ref } from "vue";
 import type { NormalizedTechnology } from "@/lib/explorer/data-layer";
 import { getDimensionLabel } from "@/lib/explorer/dimensions";
 
@@ -91,23 +97,24 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const emit = defineEmits<{
+defineEmits<{
 	close: [];
 }>();
 
-const handleKeydown = (event: KeyboardEvent) => {
-	if (event.key === "Escape") {
-		emit("close");
-	}
-};
+// Native <dialog>: focus trapping, Escape, and focus return come from the
+// platform. The close event bubbles up as the component's close emit.
+const dialogEl = ref<HTMLDialogElement | null>(null);
 
 onMounted(() => {
-	document.addEventListener("keydown", handleKeydown);
+	dialogEl.value?.showModal();
 });
 
-onUnmounted(() => {
-	document.removeEventListener("keydown", handleKeydown);
-});
+const onDialogClick = (event: MouseEvent) => {
+	// Clicks on ::backdrop target the dialog element itself
+	if (event.target === dialogEl.value) {
+		dialogEl.value?.close();
+	}
+};
 
 const statusLabel = computed(() => {
 	return getDimensionLabel(
@@ -159,41 +166,54 @@ const formatDate = (dateStr: string | null): string => {
 
 <style scoped>
 /* =================================
- Modal Overlay & Container
+ Modal Container (native <dialog>)
  ================================= */
-.popover-backdrop {
- position: fixed;
- inset: 0;
- z-index: 999;
- background: rgba(0, 0, 0, 0.6);
- backdrop-filter: blur(4px);
- animation: fadeIn 0.2s ease;
-}
+dialog.tech-card-popover {
+ /* Stage colors derive from the editorial palette, mirroring the matrix page */
+ --stage-skip: var(--editorial-rust);
+ --stage-watch: var(--editorial-amber-text);
+ --stage-explore: color-mix(
+ in oklab,
+ var(--editorial-amber-text) 45%,
+ var(--editorial-spruce) 55%
+ );
+ --stage-learn: var(--editorial-violet);
+ --stage-adopt: var(--editorial-spruce);
+ --stage-advocate: var(--editorial-ink);
+ --stage-graveyard: var(--editorial-ink-mute);
 
-.tech-card-popover {
- position: fixed;
- z-index: 1000;
  width: 480px;
  max-width: calc(100vw - 3rem);
- top: 50%;
- left: 50%;
- transform: translate(-50%, -50%);
- animation: scaleIn 0.2s ease;
+ max-height: calc(100vh - 4rem);
+ padding: 0;
+ border: none;
+ background: transparent;
+ margin: auto;
+ overflow: visible;
 }
 
-@keyframes fadeIn {
- from { opacity: 0; }
- to { opacity: 1; }
+:global(html.dark) dialog.tech-card-popover {
+ --stage-learn: color-mix(in oklab, var(--editorial-violet) 60%, white 40%);
+}
+
+dialog.tech-card-popover::backdrop {
+ background: rgb(0 0 0 / 0.6);
+}
+
+dialog.tech-card-popover[open] {
+ animation: scaleIn 0.2s var(--ease-standard, ease);
 }
 
 @keyframes scaleIn {
  from {
  opacity: 0;
- transform: translate(-50%, -50%) scale(0.95);
+ transform: scale(0.97);
  }
- to {
- opacity: 1;
- transform: translate(-50%, -50%) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+ dialog.tech-card-popover[open] {
+ animation: none;
  }
 }
 
@@ -215,14 +235,12 @@ const formatDate = (dateStr: string | null): string => {
  border-radius: 50%;
  color: var(--text-muted);
  cursor: pointer;
- transition: all 0.15s ease;
- box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+ transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .close-btn:hover {
  background: var(--surface-card-muted);
  color: var(--text-primary-content);
- transform: scale(1.05);
 }
 
 /* =================================
@@ -230,12 +248,11 @@ const formatDate = (dateStr: string | null): string => {
  ================================= */
 .card-frame {
  background: var(--surface-card);
- border: 1px solid var(--surface-border);
- border-radius: 1.5rem;
+ border: 1px solid var(--editorial-hairline-strong);
+ border-radius: var(--radius-4xl);
  overflow: hidden;
- box-shadow:
- 0 25px 50px rgba(0, 0, 0, 0.25),
- 0 0 0 1px rgba(0, 0, 0, 0.05);
+ max-height: calc(100vh - 4rem);
+ overflow-y: auto;
 }
 
 /* =================================
@@ -250,12 +267,13 @@ const formatDate = (dateStr: string | null): string => {
  border-bottom: 4px solid var(--text-muted);
 }
 
-.card-header.status-skip { border-bottom-color: #ef4444; }
-.card-header.status-watch { border-bottom-color: #f97316; }
-.card-header.status-explore { border-bottom-color: #ca8a04; }
-.card-header.status-learn { border-bottom-color: #3b82f6; }
-.card-header.status-adopt { border-bottom-color: #22c55e; }
-.card-header.status-advocate { border-bottom-color: rgb(var(--brand-primary)); }
+.card-header.status-skip { border-bottom-color: var(--stage-skip); }
+.card-header.status-watch { border-bottom-color: var(--stage-watch); }
+.card-header.status-explore { border-bottom-color: var(--stage-explore); }
+.card-header.status-learn { border-bottom-color: var(--stage-learn); }
+.card-header.status-adopt { border-bottom-color: var(--stage-adopt); }
+.card-header.status-advocate { border-bottom-color: var(--stage-advocate); }
+.card-header.status-graveyard { border-bottom-color: var(--stage-graveyard); }
 
 .card-icon-wrapper {
  flex-shrink: 0;
@@ -265,7 +283,7 @@ const formatDate = (dateStr: string | null): string => {
  width: 80px;
  height: 80px;
  object-fit: contain;
- border-radius: 1rem;
+ border-radius: var(--radius-4xl);
  background: var(--surface-card);
  padding: 0.875rem;
  border: 1px solid var(--surface-border);
@@ -278,7 +296,7 @@ const formatDate = (dateStr: string | null): string => {
  align-items: center;
  justify-content: center;
  background: var(--surface-card);
- border-radius: 1rem;
+ border-radius: var(--radius-4xl);
  border: 1px solid var(--surface-border);
  font-size: 2rem;
  font-weight: 700;
@@ -311,17 +329,18 @@ const formatDate = (dateStr: string | null): string => {
  text-transform: uppercase;
  letter-spacing: 0.04em;
  padding: 0.375rem 0.75rem;
- border-radius: 0.375rem;
- color: white;
+ border-radius: var(--radius-md);
+ color: var(--surface-base);
  background: var(--text-muted);
 }
 
-.card-status-badge.status-skip { background: #ef4444; }
-.card-status-badge.status-watch { background: #f97316; }
-.card-status-badge.status-explore { background: #ca8a04; }
-.card-status-badge.status-learn { background: #3b82f6; }
-.card-status-badge.status-adopt { background: #22c55e; }
-.card-status-badge.status-advocate { background: rgb(var(--brand-primary)); }
+.card-status-badge.status-skip { background: var(--stage-skip); }
+.card-status-badge.status-watch { background: var(--stage-watch); }
+.card-status-badge.status-explore { background: var(--stage-explore); }
+.card-status-badge.status-learn { background: var(--stage-learn); }
+.card-status-badge.status-adopt { background: var(--stage-adopt); }
+.card-status-badge.status-advocate { background: var(--stage-advocate); }
+.card-status-badge.status-graveyard { background: var(--stage-graveyard); }
 
 .card-category {
  font-size: 0.875rem;
@@ -363,7 +382,7 @@ const formatDate = (dateStr: string | null): string => {
 /* Stats */
 .card-stats {
  display: grid;
- grid-template-columns: repeat(4, 1fr);
+ grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
  gap: 0.75rem;
 }
 
@@ -374,7 +393,7 @@ const formatDate = (dateStr: string | null): string => {
  gap: 0.25rem;
  padding: 0.875rem 0.5rem;
  background: var(--surface-card-muted);
- border-radius: 0.75rem;
+ border-radius: var(--radius-3xl);
 }
 
 .stat-value {
@@ -398,9 +417,9 @@ const formatDate = (dateStr: string | null): string => {
  align-items: flex-start;
  gap: 0.75rem;
  padding: 1rem;
- background: rgba(239, 68, 68, 0.08);
- border: 1px solid rgba(239, 68, 68, 0.15);
- border-radius: 0.75rem;
+ background: color-mix(in oklab, var(--editorial-rust) 8%, transparent);
+ border: 1px solid color-mix(in oklab, var(--editorial-rust) 18%, transparent);
+ border-radius: var(--radius-3xl);
 }
 
 .spicy-icon {
@@ -412,12 +431,8 @@ const formatDate = (dateStr: string | null): string => {
 .spicy-text {
  font-size: 0.875rem;
  font-style: italic;
- color: #be123c;
+ color: var(--editorial-rust);
  line-height: 1.5;
-}
-
-:global(html.dark) .spicy-text {
- color: #fda4af;
 }
 
 /* =================================
@@ -434,20 +449,21 @@ const formatDate = (dateStr: string | null): string => {
  gap: 0.625rem;
  width: 100%;
  padding: 1rem 1.5rem;
- background: linear-gradient(135deg, rgb(var(--brand-primary)) 0%, rgb(var(--brand-secondary)) 100%);
- color: white;
- border-radius: 0.75rem;
+ background: var(--editorial-ink);
+ color: var(--editorial-paper);
+ border: 1px solid var(--editorial-ink);
+ border-radius: var(--radius-md);
  font-size: 0.875rem;
  font-weight: 700;
  text-transform: uppercase;
  letter-spacing: 0.04em;
  text-decoration: none;
- transition: all 0.2s ease;
+ transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .card-cta:hover {
- transform: translateY(-2px);
- box-shadow: 0 8px 20px rgb(var(--brand-primary) / 0.35);
+ background: var(--editorial-spruce);
+ border-color: var(--editorial-spruce);
 }
 
 .card-cta svg {
@@ -462,8 +478,9 @@ const formatDate = (dateStr: string | null): string => {
  Mobile
  ================================= */
 @media (max-width: 540px) {
- .tech-card-popover {
+ dialog.tech-card-popover {
  width: calc(100vw - 2rem);
+ max-width: calc(100vw - 2rem);
  }
 
  .card-header {

--- a/projects/rawkode.academy/website/src/components/explorer/views/GridView.vue
+++ b/projects/rawkode.academy/website/src/components/explorer/views/GridView.vue
@@ -57,11 +57,12 @@
  <img
  v-if="tech.icon"
  :src="tech.icon"
- :alt="tech.name"
+ alt=""
  class="icon-img"
  loading="lazy"
  />
- <span v-else class="icon-initial">{{ tech.name[0] }}</span>
+ <span v-else class="icon-initial" aria-hidden="true">{{ tech.name[0] }}</span>
+ <span class="tech-name">{{ tech.name }}</span>
  <span
  v-if="tech.dimensions['matrix.trajectory']"
  class="icon-trajectory"
@@ -78,15 +79,22 @@
 
  <!-- Empty state -->
  <div v-if="technologies.length === 0" class="empty-state">
- <div class="empty-icon">🔍</div>
- <h3>No technologies found</h3>
- <p>Try adjusting your filters or search query</p>
+ <h3>No technologies match</h3>
+ <p>Loosen a filter, clear the search, or switch an axis to a broader dimension.</p>
+ <button
+ v-if="explorer"
+ type="button"
+ class="empty-clear"
+ @click="explorer.clearFilters()"
+ >
+ Clear all filters
+ </button>
  </div>
  </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject, onMounted, onUnmounted, ref } from "vue";
 import type { NormalizedTechnology } from "@/lib/explorer/data-layer";
 import type { DimensionKey } from "@/lib/explorer/dimensions";
 import {
@@ -112,6 +120,24 @@ defineEmits<{
 	select: [id: string | null];
 }>();
 
+// Explorer state (provided by TechnologyExplorer) — used by the empty state
+// to offer a one-click way out of an over-filtered view.
+const explorer = inject<{ clearFilters: () => void } | null>("explorer", null);
+
+// Dimension colors have light/dark variants; track the active scheme so the
+// header and tab colors adapt instead of always using the light palette.
+const isDark = ref(false);
+const updateScheme = () => {
+	isDark.value = document.documentElement.classList.contains("dark");
+};
+onMounted(() => {
+	updateScheme();
+	window.addEventListener("color-scheme-change", updateScheme);
+});
+onUnmounted(() => {
+	window.removeEventListener("color-scheme-change", updateScheme);
+});
+
 // Grid columns CSS - row header fixed, columns fill available space equally
 const gridColumns = computed(() => {
 	const colCount = props.xAxisValues.length;
@@ -130,7 +156,7 @@ const getXAxisLabel = (value: string | null): string => {
 };
 
 const getXAxisColor = (value: string | null): string => {
-	return getDimensionColor(props.xAxis, value);
+	return getDimensionColor(props.xAxis, value, isDark.value);
 };
 
 const getColumnCount = (xValue: string | null): number => {
@@ -153,7 +179,7 @@ const getYAxisLabel = (value: string | null): string => {
 };
 
 const getYAxisColor = (value: string | null): string => {
-	return getDimensionColor(props.yAxis, value);
+	return getDimensionColor(props.yAxis, value, isDark.value);
 };
 
 const getRowCount = (yValue: string | null): number => {
@@ -192,7 +218,8 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  display: flex;
  flex-direction: column;
  gap: 0;
- overflow-x: auto;
+ /* No overflow-x: columns are 1fr and compress instead of scrolling, and an
+    auto-overflow container would clip the name tooltips. */
  min-width: 0;
 }
 
@@ -203,7 +230,7 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  position: sticky;
  top: 0;
  z-index: 10;
- background: var(--surface-background);
+ background: var(--surface-base);
  padding-bottom: 0.5rem;
 }
 
@@ -217,6 +244,11 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  border-radius: 6px 6px 0 0;
  color: white;
  text-align: center;
+}
+
+/* Dark-scheme dimension colors are light pastels; flip the label to ink. */
+:global(html.dark) .header-cell {
+ color: oklch(0.2 0.015 280);
 }
 
 .header-label {
@@ -284,13 +316,24 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  text-align: center;
 }
 
+:global(html.dark) .tab-count {
+ color: oklch(0.2 0.015 280);
+}
+
 .grid-row {
  display: grid;
  gap: 0;
  background: var(--surface-card);
  border: 1px solid var(--surface-border);
  border-radius: 8px;
- overflow: hidden;
+ /* overflow must stay visible or the name tooltips are clipped */
+ overflow: visible;
+}
+
+.grid-row:has(.tech-icon:hover),
+.grid-row:has(.tech-icon:focus-visible) {
+ position: relative;
+ z-index: 10;
 }
 
 /* Grid cells */
@@ -299,7 +342,15 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  min-height: 50px;
  background: rgb(from var(--cell-color) r g b / 0.05);
  border-left: 1px solid var(--surface-border);
- overflow: hidden;
+}
+
+.grid-cell:first-child {
+ border-radius: 8px 0 0 8px;
+ border-left: none;
+}
+
+.grid-cell:last-child {
+ border-radius: 0 8px 8px 0;
 }
 
 .cell-content {
@@ -378,10 +429,26 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
 }
 
 .tech-icon:hover::after,
-.tech-icon:hover::before {
+.tech-icon:hover::before,
+.tech-icon:focus-visible::after,
+.tech-icon:focus-visible::before {
  opacity: 1;
  visibility: visible;
  transform: translateX(-50%) translateY(0);
+}
+
+/* Screen-reader-only on desktop (tooltip carries the visible name); shown as
+   a chip label on mobile where there is no hover. */
+.tech-name {
+ position: absolute;
+ width: 1px;
+ height: 1px;
+ padding: 0;
+ margin: -1px;
+ overflow: hidden;
+ clip-path: inset(50%);
+ white-space: nowrap;
+ border: 0;
 }
 
 .icon-img {
@@ -422,15 +489,15 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
 }
 
 .trajectory-rising {
- color: rgb(34, 197, 94);
+ color: var(--editorial-spruce);
 }
 
 .trajectory-stable {
- color: rgb(156, 163, 175);
+ color: var(--editorial-ink-mute);
 }
 
 .trajectory-falling {
- color: rgb(239, 68, 68);
+ color: var(--editorial-rust);
 }
 
 /* Empty state */
@@ -439,13 +506,33 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  flex-direction: column;
  align-items: center;
  justify-content: center;
+ gap: 0.5rem;
  padding: 4rem 2rem;
  text-align: center;
+ background: var(--surface-card);
+ border: 1px dashed var(--surface-border);
+ border-radius: 8px;
 }
 
-.empty-icon {
- font-size: 3rem;
- margin-bottom: 1rem;
+.empty-clear {
+ margin-top: 0.75rem;
+ padding: 0.625rem 1rem;
+ background: var(--editorial-ink);
+ color: var(--editorial-paper);
+ border: 1px solid var(--editorial-ink);
+ border-radius: var(--radius-md);
+ font-family: var(--font-jetbrains-mono), monospace;
+ font-size: 0.72rem;
+ font-weight: 700;
+ letter-spacing: 0.1em;
+ text-transform: uppercase;
+ cursor: pointer;
+ transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.empty-clear:hover {
+ background: var(--editorial-spruce);
+ border-color: var(--editorial-spruce);
 }
 
 .empty-state h3 {
@@ -509,23 +596,55 @@ const getTrajectoryEmoji = (trajectory: string | null): string => {
  }
 
  .cell-content {
- gap: 0.75rem;
+ gap: 0.5rem;
  }
 
+ /* Icon + name chips: bare icons are unidentifiable without hover */
  .tech-icon {
- width: 40px;
- height: 40px;
+ width: auto;
+ height: auto;
+ min-height: 44px;
+ padding: 0.5rem 0.75rem;
+ gap: 0.5rem;
+ border-radius: 6px;
+ }
+
+ .tech-name {
+ position: static;
+ width: auto;
+ height: auto;
+ margin: 0;
+ overflow: visible;
+ clip-path: none;
+ white-space: normal;
+ overflow-wrap: anywhere;
+ text-align: left;
+ font-size: 0.8rem;
+ font-weight: 600;
+ color: var(--text-primary-content);
  }
 
  .icon-img {
- width: 24px;
- height: 24px;
+ width: 22px;
+ height: 22px;
+ }
+
+ .icon-initial {
+ width: 22px;
+ height: 22px;
  }
 
  /* Hide tooltips on mobile */
  .tech-icon::after,
  .tech-icon::before {
  display: none;
+ }
+}
+
+@media (prefers-reduced-motion: reduce) {
+ .tech-icon:hover,
+ .tech-icon.is-hovered {
+ transform: none;
  }
 }
 </style>

--- a/projects/rawkode.academy/website/src/pages/technology/matrix.astro
+++ b/projects/rawkode.academy/website/src/pages/technology/matrix.astro
@@ -60,6 +60,7 @@ const categoryDescriptions: Record<string, string> = {
 	Wasm: "WebAssembly technologies",
 	Serverless: "Function-as-a-service and event-driven",
 	CNAI: "Cloud Native AI and ML",
+	Uncategorized: "Not yet assigned a landscape category",
 };
 
 const stageLabels = Object.fromEntries(
@@ -89,11 +90,11 @@ const trajectoryEmoji: Record<Trajectory, string> = {
 // Get all technologies with matrix data
 const allTechnologies = await getCollection("technologies");
 const matrixTechnologies = allTechnologies
-	.filter((tech) => tech.data.matrix?.status && tech.data.category)
+	.filter((tech) => tech.data.matrix?.status)
 	.map((tech) => ({
 		id: tech.id,
 		name: tech.data.name,
-		category: tech.data.category as string,
+		category: (tech.data.category as string | undefined) ?? "Uncategorized",
 		status: tech.data.matrix!.status as PipelineStage,
 		icon: resolveTechnologyIconUrl(tech.id, tech.data.logos),
 		confidence: tech.data.matrix!.confidence as Confidence | undefined,
@@ -285,7 +286,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		<div class="matrix-content">
 
 			<!-- Pipeline Header -->
-			<div class="pipeline-header" role="img" aria-label="Pipeline stages from Skip to Advocate">
+			<div class="pipeline-header" role="group" aria-label="Pipeline stages from Watch to Advocate">
 				<div class="header-flow-line"></div>
 				{pipelineStages.map((stage, idx) => (
 					<div class={`header-stage header-${stage}`} style={`--stage-index: ${idx}`}>
@@ -336,10 +337,11 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 														data-icon={tech.icon || ""}
 													>
 														{tech.icon ? (
-															<img src={tech.icon} alt={tech.name} class="icon-img" loading="lazy" />
+															<img src={tech.icon} alt="" class="icon-img" loading="lazy" />
 														) : (
-															<span class="icon-initial">{tech.name[0]}</span>
+															<span class="icon-initial" aria-hidden="true">{tech.name[0]}</span>
 														)}
+														<span class="tech-name">{tech.name}</span>
 														{tech.trajectory && (
 															<span class={`icon-trajectory trajectory-${tech.trajectory}`}>
 																{trajectoryEmoji[tech.trajectory]}
@@ -403,10 +405,11 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 											data-icon={tech.icon || ""}
 										>
 											{tech.icon ? (
-												<img src={tech.icon} alt={tech.name} class="other-icon" loading="lazy" />
+												<img src={tech.icon} alt="" class="other-icon" loading="lazy" />
 											) : (
-												<span class="other-initial">{tech.name[0]}</span>
+												<span class="other-initial" aria-hidden="true">{tech.name[0]}</span>
 											)}
+											<span class="other-name">{tech.name}</span>
 										</button>
 									))}
 								</div>
@@ -440,10 +443,11 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 											data-icon={tech.icon || ""}
 										>
 											{tech.icon ? (
-												<img src={tech.icon} alt={tech.name} class="other-icon" loading="lazy" />
+												<img src={tech.icon} alt="" class="other-icon" loading="lazy" />
 											) : (
-												<span class="other-initial">{tech.name[0]}</span>
+												<span class="other-initial" aria-hidden="true">{tech.name[0]}</span>
 											)}
+											<span class="other-name">{tech.name}</span>
 										</button>
 									))}
 								</div>
@@ -457,8 +461,8 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	</Container>
 
 	<!-- Card Popup Modal -->
-	<div id="tech-card-modal" class="modal-backdrop" aria-hidden="true">
-		<div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-tech-name">
+	<dialog id="tech-card-modal" class="tech-modal" aria-labelledby="modal-tech-name">
+		<div class="modal-content">
 			<button type="button" class="modal-close" aria-label="Close">
 				<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -493,7 +497,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 							<span id="modal-videos" class="stat-value">0</span>
 							<span class="stat-label">Videos</span>
 						</div>
-						<div class="modal-stat">
+						<div class="modal-stat" id="modal-articles-stat">
 							<span id="modal-articles" class="stat-value">0</span>
 							<span class="stat-label">Articles</span>
 						</div>
@@ -524,7 +528,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 				</div>
 			</div>
 		</div>
-	</div>
+	</dialog>
 </Page>
 
 <style>
@@ -534,7 +538,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	.matrix-hero,
 	.matrix-legend,
 	.matrix-content,
-	.modal-backdrop {
+	.tech-modal {
 		--stage-skip: var(--editorial-rust);
 		--stage-watch: var(--editorial-amber-text);
 		--stage-explore: color-mix(
@@ -553,7 +557,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	:global(html.dark) .matrix-hero,
 	:global(html.dark) .matrix-legend,
 	:global(html.dark) .matrix-content,
-	:global(html.dark) .modal-backdrop {
+	:global(html.dark) .tech-modal {
 		--stage-learn: color-mix(in oklab, var(--editorial-violet) 60%, white 40%);
 	}
 
@@ -890,18 +894,17 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	}
 
 	/* ===== PIPELINE HEADER ===== */
+	/* Sticky so the stage columns keep their identity while scrolling 14 lanes.
+	   Stages share the same 1fr tracks as the lane cells (no min-width), so the
+	   header and lanes can never drift out of alignment. */
 	.pipeline-header {
 		display: flex;
-		position: relative;
-		z-index: 1;
+		position: sticky;
+		top: 0;
+		z-index: 20;
 		gap: 0.25rem;
-		padding: 0 0 0.5rem;
-		overflow-x: auto;
-		scrollbar-width: none;
-	}
-
-	.pipeline-header::-webkit-scrollbar {
-		display: none;
+		padding: 0.5rem 0;
+		background: var(--surface-base);
 	}
 
 	.header-flow-line {
@@ -910,7 +913,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 
 	.header-stage {
 		flex: 1;
-		min-width: 130px;
+		min-width: 0;
 	}
 
 	.stage-arrow {
@@ -979,7 +982,9 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	.lane-wrapper {
 		position: relative;
 		animation: fadeInUp 0.4s ease-out backwards;
-		animation-delay: calc(var(--lane-index) * 0.1s);
+		/* Capped: with 14 lanes an uncapped stagger leaves the last lane
+		   invisible for over a second. */
+		animation-delay: min(calc(var(--lane-index) * 0.05s), 0.3s);
 	}
 
 	.lane-wrapper:has(.tech-icon:hover) {
@@ -1170,10 +1175,26 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	}
 
 	.tech-icon:hover::after,
-	.tech-icon:hover::before {
+	.tech-icon:hover::before,
+	.tech-icon:focus-visible::after,
+	.tech-icon:focus-visible::before {
 		opacity: 1;
 		visibility: visible;
 		transform: translateX(-50%) translateY(0);
+	}
+
+	/* Visually hidden on desktop (tooltips carry the name there), but kept in
+	   the accessibility tree so buttons stay labelled with alt="" icons. */
+	.tech-name {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
 	}
 
 
@@ -1222,8 +1243,16 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 
 	/* ===== RESPONSIVE ===== */
 	@media (max-width: 1024px) {
-		.pipeline-header {
-			padding-bottom: 1rem;
+		.stage-sublabel {
+			display: none;
+		}
+
+		.stage-content {
+			padding: 0.6rem 0.5rem;
+		}
+
+		.stage-label {
+			font-size: 0.7rem;
 		}
 
 		.lane-desc {
@@ -1236,12 +1265,23 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 			padding: 2rem 0 1.75rem;
 		}
 
+		/* Horizontal strip instead of a 4-row grid: keeps the hero compact and
+		   the stage order (skip → advocate → graveyard) readable. */
 		.hero-pipeline-preview {
+			display: flex;
 			gap: 0.375rem;
-			grid-template-columns: repeat(2, minmax(0, 1fr));
+			overflow-x: auto;
+			padding-bottom: 0.25rem;
+			scrollbar-width: none;
+		}
+
+		.hero-pipeline-preview::-webkit-scrollbar {
+			display: none;
 		}
 
 		.preview-stage {
+			flex: 0 0 auto;
+			min-width: 5.25rem;
 			padding: 0.5rem 0.75rem;
 		}
 
@@ -1250,7 +1290,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		}
 
 		.preview-label {
-			font-size: 0.55rem;
+			font-size: 0.65rem;
 		}
 
 		.hero-actions {
@@ -1313,52 +1353,86 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		.cell-advocate::before { content: 'Advocate'; color: var(--stage-advocate); }
 
 		.cell-content {
-			gap: 0.75rem;
+			gap: 0.5rem;
 		}
 
+		/* Icon + name chips: bare icons are unidentifiable on touch screens
+		   where there is no hover tooltip. */
 		.tech-icon {
-			width: 40px;
-			height: 40px;
+			width: auto;
+			height: auto;
+			min-height: 44px;
+			padding: 0.5rem 0.75rem;
+			gap: 0.5rem;
+			border-radius: 6px;
+		}
+
+		.tech-icon::after,
+		.tech-icon::before {
+			display: none;
+		}
+
+		.tech-name {
+			position: static;
+			width: auto;
+			height: auto;
+			margin: 0;
+			overflow: visible;
+			clip-path: none;
+			white-space: normal;
+			overflow-wrap: anywhere;
+			text-align: left;
+			font-size: 0.8rem;
+			font-weight: 600;
+			color: var(--text-primary-content);
 		}
 
 		.icon-img {
-			width: 24px;
-			height: 24px;
+			width: 22px;
+			height: 22px;
+		}
+
+		.icon-initial {
+			width: 22px;
+			height: 22px;
 		}
 
 	}
 
-	/* ===== MODAL POPUP ===== */
-	.modal-backdrop {
-		position: fixed;
-		inset: 0;
-		z-index: 999;
-		background: rgba(0, 0, 0, 0.6);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		opacity: 0;
-		visibility: hidden;
-		transition: opacity 0.2s ease, visibility 0.2s ease;
+	/* ===== MODAL POPUP =====
+	   Native <dialog>: focus trapping, Escape, and focus return come from the
+	   platform; ::backdrop replaces the hand-rolled overlay. */
+	dialog.tech-modal {
+		padding: 0;
+		border: none;
+		background: transparent;
+		margin: auto;
+		max-width: calc(100vw - 3rem);
+		max-height: calc(100vh - 4rem);
+		overflow: visible;
 	}
 
-	.modal-backdrop.visible {
-		opacity: 1;
-		visibility: visible;
+	dialog.tech-modal::backdrop {
+		background: rgb(0 0 0 / 0.6);
+	}
+
+	dialog.tech-modal[open] {
+		animation: modal-in var(--duration-base) var(--ease-out);
+	}
+
+	@keyframes modal-in {
+		from {
+			opacity: 0;
+			transform: scale(0.97);
+		}
 	}
 
 	.modal-content {
 		position: relative;
 		width: 480px;
-		max-width: calc(100vw - 3rem);
+		max-width: 100%;
 		max-height: calc(100vh - 4rem);
 		overflow-y: auto;
-		transform: scale(0.95);
-		transition: transform 0.2s ease;
-	}
-
-	.modal-backdrop.visible .modal-content {
-		transform: scale(1);
 	}
 
 	.modal-close {
@@ -1510,7 +1584,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 
 	.modal-stats {
 		display: grid;
-		grid-template-columns: repeat(4, 1fr);
+		grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
 		gap: 0.75rem;
 	}
 
@@ -1603,6 +1677,10 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	}
 
 	@media (max-width: 540px) {
+		dialog.tech-modal {
+			max-width: calc(100vw - 2rem);
+		}
+
 		.modal-content {
 			width: calc(100vw - 2rem);
 		}
@@ -1751,8 +1829,8 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 28px;
-		height: 28px;
+		width: 32px;
+		height: 32px;
 		padding: 0;
 		background: var(--surface-card);
 		border: 1px solid var(--surface-border);
@@ -1795,10 +1873,25 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		z-index: 100;
 	}
 
-	.other-item:hover::after {
+	.other-item:hover::after,
+	.other-item:focus-visible::after {
 		opacity: 1;
 		visibility: visible;
 		transform: translateX(-50%) translateY(0);
+	}
+
+	/* Same treatment as .tech-name: screen-reader-only on desktop, visible
+	   chip label on mobile. */
+	.other-name {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.other-icon {
@@ -1841,6 +1934,55 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 		.other-group {
 			min-width: 100%;
 		}
+
+		.other-item {
+			width: auto;
+			height: auto;
+			min-height: 40px;
+			padding: 0.375rem 0.625rem;
+			gap: 0.4rem;
+			opacity: 1;
+		}
+
+		.other-item::after {
+			display: none;
+		}
+
+		.other-name {
+			position: static;
+			width: auto;
+			height: auto;
+			margin: 0;
+			overflow: visible;
+			clip-path: none;
+			white-space: normal;
+			overflow-wrap: anywhere;
+			text-align: left;
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: var(--text-secondary-content);
+		}
+	}
+
+	/* ===== REDUCED MOTION ===== */
+	@media (prefers-reduced-motion: reduce) {
+		.lane-wrapper {
+			animation: none;
+		}
+
+		.tech-icon:hover {
+			transform: none;
+		}
+
+		dialog.tech-modal[open] {
+			animation: none;
+		}
+
+		.advanced-mode-link:hover svg,
+		.modal-cta:hover svg,
+		.other-advanced-link:hover svg {
+			transform: none;
+		}
 	}
 
 </style>
@@ -1871,7 +2013,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	}
 
 	// Modal elements
-	const modal = document.getElementById('tech-card-modal');
+	const modal = document.getElementById('tech-card-modal') as HTMLDialogElement | null;
 	const modalIcon = document.getElementById('modal-icon') as HTMLImageElement;
 	const modalIconPlaceholder = document.getElementById('modal-icon-placeholder');
 	const modalName = document.getElementById('modal-tech-name');
@@ -1882,6 +2024,7 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 	const modalWhy = document.getElementById('modal-why');
 	const modalVideos = document.getElementById('modal-videos');
 	const modalArticles = document.getElementById('modal-articles');
+	const modalArticlesStat = document.getElementById('modal-articles-stat');
 	const modalFirstUsed = document.getElementById('modal-first-used');
 	const modalTrajectory = document.getElementById('modal-trajectory');
 	const modalSpicySection = document.getElementById('modal-spicy-section');
@@ -1940,6 +2083,9 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 
 		if (modalVideos) modalVideos.textContent = videoCount;
 		if (modalArticles) modalArticles.textContent = articleCount;
+		// Hide the articles stat until article links are wired up — a permanent
+		// zero reads as broken rather than empty.
+		if (modalArticlesStat) modalArticlesStat.style.display = articleCount === '0' ? 'none' : 'flex';
 		if (modalFirstUsed) modalFirstUsed.textContent = formatDate(firstUsed);
 		if (modalTrajectory) modalTrajectory.textContent = trajectoryIcons[trajectory] || "–";
 
@@ -1956,34 +2102,32 @@ const legendStages = ["skip", ...pipelineStages, "graveyard"].map((stage) => ({
 			modalCtaLink.href = `/technology/${id}`;
 		}
 
-		// Show modal
-		modal?.classList.add('visible');
-		modal?.setAttribute('aria-hidden', 'false');
+		// Native <dialog> handles focus trapping, Escape, and focus return.
+		modal?.showModal();
 		document.body.style.overflow = 'hidden';
 	}
 
-	function hideModal() {
-		modal?.classList.remove('visible');
-		modal?.setAttribute('aria-hidden', 'true');
+	// Restore page scroll whenever the dialog closes (button, Escape, backdrop)
+	modal?.addEventListener('close', () => {
 		document.body.style.overflow = '';
-	}
+	});
 
-	// Close modal on backdrop click
+	// Close modal on backdrop click — clicks on ::backdrop target the dialog itself
 	modal?.addEventListener('click', (e) => {
 		if (e.target === modal) {
-			hideModal();
+			modal.close();
 		}
 	});
 
 	// Close modal on close button click
-	modalClose?.addEventListener('click', hideModal);
+	modalClose?.addEventListener('click', () => modal?.close());
 
-	// Close modal on escape key
-	document.addEventListener('keydown', (e) => {
-		if (e.key === 'Escape' && modal?.classList.contains('visible')) {
-			hideModal();
-		}
-	});
+	// Stage definitions are the only explanation of what the stages mean on
+	// mobile (the pipeline header is hidden there), so open them by default.
+	const legend = document.querySelector('.legend-details');
+	if (legend && window.matchMedia('(max-width: 768px)').matches) {
+		legend.setAttribute('open', '');
+	}
 
 	// Add click handlers to all tech icons
 	document.querySelectorAll('.tech-icon').forEach(button => {


### PR DESCRIPTION
Two commits: content updates to the technology matrix based on the last four months of ecosystem changes, and UX improvements to the matrix pages from a mobile/desktop audit.

## Commit 1 — Content: ecosystem changes, Feb–Jun 2026

All 354 entries validate against the frontmatter schema.

### CNCF lifecycle (factual)

| Entry | Change | Source |
|---|---|---|
| OpenTelemetry | incubating → **graduated** (`2026-05-21`) | [CNCF announcement](``https://www.cncf.io/announcements/2026/05/21/cloud-native-computing-foundation-announces-opentelemetrys-graduation-solidifying-status-as-the-de-facto-observability-standard/)`` |
| Tekton | added missing `cncf` block — joined CNCF as **incubating** (`2026-03-24`) | [CNCF blog](https://www.cncf.io/blog/2026/03/24/tekton-becomes-a-cncf-incubating-project/) |
| Microcks | sandbox → **incubating** (`2026-05-07`) | [CNCF blog](https://www.cncf.io/blog/2026/05/07/microcks-becomes-a-cncf-incubating-project/) |
| Fluid | incubating date aligned to announcement (`2026-03-24`) | [CNCF blog](https://www.cncf.io/blog/2026/03/24/fluid-becomes-a-cncf-incubating-project/) |

### Project health

- **Kaniko** → `status: abandoned`, matrix `explore → skip` (upstream archived June 2025, maintainers retired; forks noted)
- **Gitpod** → `status: superseded`, alias **Ona** ([OpenAI acquired Ona, June 11, 2026](https://siliconangle.com/2026/06/11/openai-acquires-ai-agent-orchestration-startup-ona/))
- **System Initiative** → matrix `watch → graveyard` (shutdown announced Feb 2026)
- **Quickwit** → matrix `explore → watch` (post-Datadog acquisition)
- **Headlamp** — body notes Kubernetes SIG UI adoption

### Momentum

- **OpenTofu** `skip → explore`, rising ([1.12, May 14](https://www.infoq.com/news/2026/05/opentofu-release-terraform/), ~12% IaC adoption)
- Rising trajectory added: **Istio**, **KubeVirt**, **Dagger**, **n8n** (SAP investment at $5.2B, May 2026)

### New entries (logos still needed ⚠️)

- **llm-d** — CNCF Sandbox, Kubernetes-native distributed LLM inference (`explore`, rising)
- **agentgateway** — LF, AI-native proxy for MCP/A2A traffic (`watch`, rising)
- **agentregistry** — LF, registry for agents/MCP servers/skills (`watch`, rising)

Plus hygiene: stray `integrations: ['>-']` YAML artifacts removed from microcks and dragonfly.

## Commit 2 — UX: `/technology/matrix` + `/technology/matrix/advanced`

**Mobile**
- Icon + **name chips** replace anonymous icon grids (names were hover-tooltip-only, which doesn't exist on touch)
- Persistent search with live result count above the explorer canvas
- Floating **Filters** button so the drawer stays reachable after scrolling; bottom sheet locks page scroll, gains a drag handle and swipe-down dismiss
- Stage definitions legend auto-opens (the pipeline header is hidden on mobile); hero stage counters become a horizontal strip with readable labels

**Desktop**
- Sticky pipeline stage header sharing `1fr` tracks with lane cells (fixes 768–1024px column misalignment)
- Tech card modals migrated to native `<dialog>` — focus trap, Escape, and focus return from the platform
- Fixed tooltip clipping in the advanced grid; tooltips now also fire on `:focus-visible`

**Both**
- TechCardPopover restyled onto editorial tokens (was hardcoded hex, gradient CTA, backdrop blur)
- Advanced grid colors adapt to dark mode; fixed undefined `--surface-background` token
- Permanently-zero Articles stat hidden until wired; `prefers-reduced-motion` guards added; lane stagger capped at 0.3s
- Overview now includes matrix-rated entries without a category (Uncategorized lane), removing count drift vs the advanced view
- Empty state teaches recovery and offers one-click "Clear all filters"

> Note: `astro check`/vitest could not run in the CI sandbox — the website depends on `ski-*` workspace packages that aren't present in the repo. Changes were verified by review; please rely on CI here.

https://claude.ai/code/session_01MBsPoNe3wVsGKU7kZCbPNF