### PR TITLE
feat(rawkode.academy/website): design system & UX improvements — tokens, view transitions, pagination, empty states, typography

### DIFF
--- a/projects/rawkode.academy/website/CLAUDE.md
+++ b/projects/rawkode.academy/website/CLAUDE.md
@@ -39,6 +39,11 @@ There is **no `tailwind.config.ts`**. There is **no `@tailwindcss/vite` plugin**
 - **Rust** `oklch(0.55 0.13 40)` — secondary accent (difficulty tags, kickers)
 - **Violet** `oklch(0.50 0.13 290)` — third accent (reserved for variant work)
 
+Supporting surface tokens:
+
+- `--surface-skeleton` — bone colour for the `Skeleton*` loading family; flips with the scheme.
+- `--terminal-bg` / `--terminal-surface` / `--terminal-border` / `--terminal-text` / `--terminal-text-dim` — theme-invariant chrome for terminals, WebContainers, and other "screen within the page" surfaces. These stay dark in light mode; never swap them for `--surface-*`.
+
 Dark mode replaces paper with `oklch(0.14 0.01 280)` (ink-dark), surface-card with `oklch(0.26 0.014 280)` (paper-dark), and the ink/hairline triplet flips to whites at varying opacity. The token *names* survive: `--surface-card`, `--editorial-ink`, etc. consume the active mode automatically.
 
 #### Token surfaces
@@ -146,6 +151,8 @@ Negative letter-spacing tightens display sizes (`-0.035em` on h1, `-0.025em` on 
 | `StatRow.vue` | N-column band with serif italic numerals and `MLabel` captions. Hairline column dividers. |
 | `SectionRail.vue` | Anchor rail (e.g. `§01..§06`). Hairline-bordered grid; each cell hovers to `--surface-card-muted`. |
 | `HairlinePanel.vue` | Paper / paper-deep / muted / ink surface with 1px hairline. Optional `heavy` variant uses 2px ink border. |
+| `EmptyState.vue` | "Loaded, but nothing here" counterpart to the `Skeleton*` family. Serif italic `title`, optional `body`, mono uppercase links via the `actions` slot, `align`: `center`/`start`. Use it for zero-result search, filtered-out lists, empty comments. |
+| `PagerStrip.astro` | Editorial pager: prev/next links around a mono `Page N [of M]` label. Server-rendered `?page=N` links; used by `/watch` and `/read`. |
 
 Every editorial primitive has a `*.stories.tsx` under the same folder. Run `bun run storybook` to explore.
 
@@ -203,8 +210,17 @@ The following class names from the Rawkode Blue era still work — they're alias
 - Don't add box-shadows for elevation. Use hairline borders.
 - Don't `rounded-2xl` and above for cards. Editorial is sharp.
 - Don't hardcode hex values. Reach for `--editorial-*` or the semantic `text-*` / `bg-*` classes.
+- Don't use raw `gray-*` colour utilities (`bg-gray-800`, `text-gray-500`, `dark:bg-gray-900`, …). They're blocked in `uno.config.ts` (no CSS is generated) and `src/tests/design-tokens.test.ts` fails CI with the offending file:line. Use `text-primary-content` / `text-secondary-content` / `text-muted`, `bg-[var(--surface-*)]`, `border-[var(--surface-border)]`, or the `--terminal-*` tokens.
 - Don't write `rgb(95 94 215 / 0.x)` (the old Rawkode Blue purple). The triplet is now spruce; you almost always want `var(--editorial-spruce)` instead.
 - Don't reach for `react-type-animation` or other type-on effects. The editorial system is static.
+
+#### View transitions
+
+The site uses **native cross-document view transitions** (`@view-transition { navigation: auto }` in `global.css`), not Astro's `ClientRouter`. Full page loads still happen, so per-page `<script>` blocks need no `astro:page-load` wiring. Conventions:
+
+- Persistent chrome (topbar, sidebar) carries a fixed `view-transition-name` so it reads as static during navigation.
+- Matching elements across two pages morph by sharing a name: use `videoTransitionName(slug)` from `src/utils/view-transition-name.ts` (video stills on `/watch` morph into the watch-page player frame). Names must be unique per page — never name elements that can render the same slug twice (e.g. the continue-watching rail).
+- `prefers-reduced-motion: reduce` disables navigation transitions globally; no per-component guards needed.
 
 ## Light / Dark / System mode
 

--- a/projects/rawkode.academy/website/src/components/articles/RelatedVideos.astro
+++ b/projects/rawkode.academy/website/src/components/articles/RelatedVideos.astro
@@ -91,7 +91,7 @@ if (articleTechnologySet.size > 0) {
 					href={`/watch/${video.slug}`}
 					class="group block paper-card-muted rounded-sm overflow-hidden"
 				>
-					<div class="relative aspect-video overflow-hidden bg-gray-100 dark:bg-gray-800">
+					<div class="relative aspect-video overflow-hidden bg-[var(--surface-card)]">
 						<img
 							src={video.thumbnailUrl}
 							alt={video.title}

--- a/projects/rawkode.academy/website/src/components/articles/Resources.astro
+++ b/projects/rawkode.academy/website/src/components/articles/Resources.astro
@@ -110,7 +110,7 @@ const getCategoryLabel = (category: string) => {
 											href={resource.url || resource.filePath || "#"}
 											target={resource.type === "url" ? "_blank" : undefined}
 											rel={resource.type === "url" ? "noopener noreferrer" : undefined}
-											class="resource-link flex items-start gap-3 p-3 rounded-sm bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-smooth group"
+											class="resource-link flex items-start gap-3 p-3 rounded-sm bg-[var(--surface-card-muted)] hover:bg-[var(--surface-card)] transition-smooth group"
 										>
 									<svg
 										class="w-5 h-5 mt-0.5 text-muted group-hover:text-primary flex-shrink-0"

--- a/projects/rawkode.academy/website/src/components/articles/Updates.astro
+++ b/projects/rawkode.academy/website/src/components/articles/Updates.astro
@@ -21,7 +21,7 @@ const formatDate = (date: Date) => {
 
 {
 	updates && updates.length > 0 && (
-		<div class="mb-4 text-sm text-muted bg-gray-50 dark:bg-gray-900/50 rounded-md px-3 py-2 border border-surface">
+		<div class="mb-4 text-sm text-muted bg-[var(--surface-card-muted)] rounded-md px-3 py-2 border border-surface">
 			<div class="flex items-start gap-2">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"

--- a/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.stories.tsx
@@ -145,32 +145,32 @@ export const AllVariations: Story = {
 				template: `
           <div class="space-y-8">
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Single Author</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Single Author</h3>
               <AuthorAvatarGroup :authors="authors.slice(0, 1)" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Two Authors</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Two Authors</h3>
               <AuthorAvatarGroup :authors="authors.slice(0, 2)" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Multiple Authors (Default)</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Multiple Authors (Default)</h3>
               <AuthorAvatarGroup :authors="authors" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Without Names</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Without Names</h3>
               <AuthorAvatarGroup :authors="authors" :showNames="false" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Max Display = 2</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Max Display = 2</h3>
               <AuthorAvatarGroup :authors="authors" :maxDisplay="2" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Without Active Indicator</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Without Active Indicator</h3>
               <AuthorAvatarGroup :authors="authors.slice(0, 2)" :showActiveIndicator="false" />
             </div>
           </div>
@@ -192,14 +192,14 @@ export const InContext: Story = {
 		<VueInReact
 			component={{
 				template: `
-          <article class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+          <article class="p-6 bg-[var(--surface-card)] rounded-lg shadow">
             <h2 class="text-xl font-bold mb-2">Understanding Kubernetes Deployments</h2>
             <div class="flex items-center gap-4 mb-4">
               <AuthorAvatarGroup :authors="authors.slice(0, 2)" />
-              <span class="text-sm text-gray-500">•</span>
-              <span class="text-sm text-gray-500">March 15, 2024</span>
-              <span class="text-sm text-gray-500">•</span>
-              <span class="text-sm text-gray-500">5 min read</span>
+              <span class="text-sm text-muted">•</span>
+              <span class="text-sm text-muted">March 15, 2024</span>
+              <span class="text-sm text-muted">•</span>
+              <span class="text-sm text-muted">5 min read</span>
             </div>
             <p class="text-secondary-content">
               Learn how to effectively manage and scale your applications using Kubernetes deployments...

--- a/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.vue
+++ b/projects/rawkode.academy/website/src/components/common/AuthorAvatarGroup.vue
@@ -8,14 +8,14 @@
  :style="`z-index: ${10 - index}`"
  >
  <img
- class="w-10 h-10 rounded-full object-cover border-2 border-secondary p-0.5 bg-white dark:bg-gray-800"
+ class="w-10 h-10 rounded-full object-cover border-2 border-secondary p-0.5 bg-[var(--surface-card)]"
  :src="author.data.avatarUrl ?? '/apple-touch-icon.png'"
  :alt="`Profile picture of ${author.data.name}`"
  loading="lazy"
  />
  <span
  v-if="showActiveIndicator && index === 0"
- class="absolute bottom-0 right-0 h-2.5 w-2.5 bg-green-400 rounded-full border-2 border-white dark:border-gray-800"
+ class="absolute bottom-0 right-0 h-2.5 w-2.5 bg-green-400 rounded-full border-2 border-[var(--surface-card)]"
  ></span>
  </div>
  <div
@@ -23,7 +23,7 @@
  class="relative"
  style="z-index: 0;"
  >
- <div class="w-10 h-10 rounded-full bg-secondary/10 dark:bg-secondary/20 border-2 border-secondary p-0.5 bg-white dark:bg-gray-800 flex items-center justify-center text-xs text-secondary dark:text-secondary font-medium">
+ <div class="w-10 h-10 rounded-full bg-secondary/10 dark:bg-secondary/20 border-2 border-secondary p-0.5 bg-[var(--surface-card)] flex items-center justify-center text-xs text-secondary dark:text-secondary font-medium">
  +{{ remainingCount }}
  </div>
  </div>

--- a/projects/rawkode.academy/website/src/components/common/Badge.vue
+++ b/projects/rawkode.academy/website/src/components/common/Badge.vue
@@ -33,8 +33,8 @@ const baseClasses = "inline-flex items-center font-semibold transition-smooth";
 
 const variantClasses = {
 	default: props.outline
-		? "border border-gray-300/50 text-gray-700 dark:border-gray-500/60 dark:text-gray-100 bg-white/30 dark:bg-gray-700/40"
-		: "bg-gray-500/20 text-gray-800 dark:bg-gray-600/40 dark:text-gray-100 border border-gray-400/30 dark:border-gray-500/50",
+		? "border border-[var(--surface-border)] text-secondary-content bg-[var(--surface-card)]"
+		: "bg-[var(--surface-card-muted)] text-primary-content border border-[var(--surface-border)]",
 	primary: props.outline
 		? "border border-primary/50 text-primary dark:text-white bg-white/30 dark:bg-primary/40"
 		: "bg-primary/20 text-primary dark:bg-primary/40 dark:text-white border border-primary/30 dark:border-primary/50",

--- a/projects/rawkode.academy/website/src/components/common/BaseCard.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/BaseCard.stories.tsx
@@ -140,7 +140,7 @@ export const WithFooter: Story = {
                 </p>
               </template>
               <template #footer>
-                <div class="flex items-center justify-between text-sm text-gray-500">
+                <div class="flex items-center justify-between text-sm text-muted">
                   <FormattedDate :date="publishDate" />
                   <span>5 min read</span>
                 </div>
@@ -188,7 +188,7 @@ export const CompleteExample: Story = {
                   Master advanced deployment patterns, custom operators, and production-ready
                   configurations for enterprise Kubernetes deployments.
                 </p>
-                <div class="flex items-center gap-4 mt-4 text-sm text-gray-500">
+                <div class="flex items-center gap-4 mt-4 text-sm text-muted">
                   <span>24 lessons</span>
                   <span>•</span>
                   <span>6 hours</span>

--- a/projects/rawkode.academy/website/src/components/common/Button.astro
+++ b/projects/rawkode.academy/website/src/components/common/Button.astro
@@ -26,9 +26,9 @@ const variantClasses = {
 	primary:
 		"text-white bg-primary hover:bg-primary/90 dark:bg-primary/20 dark:hover:bg-primary/90",
 	secondary:
-		"text-gray-900 bg-white border border-gray-300 hover:bg-gray-100 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600",
+		"text-primary-content bg-[var(--surface-card)] border border-[var(--surface-border)] hover:bg-[var(--surface-card-muted)]",
 	ghost:
-		"text-gray-700 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700",
+		"text-secondary-content hover:text-primary-content hover:bg-[var(--surface-card-muted)]",
 	danger:
 		"text-white bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600",
 };

--- a/projects/rawkode.academy/website/src/components/common/FormattedDate.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/FormattedDate.stories.tsx
@@ -80,27 +80,27 @@ export const AllVariants: Story = {
 				template: `
           <div class="space-y-4">
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Short Format</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Short Format</h3>
               <FormattedDate :date="date" format="short" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Long Format</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Long Format</h3>
               <FormattedDate :date="date" format="long" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Full Format</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Full Format</h3>
               <FormattedDate :date="date" format="full" />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">With Icon</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">With Icon</h3>
               <FormattedDate :date="date" showIcon />
             </div>
             
             <div>
-              <h3 class="text-sm font-medium text-gray-700 mb-2">Long Format with Icon</h3>
+              <h3 class="text-sm font-medium text-secondary-content mb-2">Long Format with Icon</h3>
               <FormattedDate :date="date" format="long" showIcon />
             </div>
           </div>
@@ -165,7 +165,7 @@ export const InContext: Story = {
 		<VueInReact
 			component={{
 				template: `
-          <article class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+          <article class="p-6 bg-[var(--surface-card)] rounded-lg shadow">
             <h2 class="text-xl font-bold mb-2">Understanding Kubernetes Deployments</h2>
             <div class="flex items-center gap-4 text-sm text-muted">
               <span>By John Doe</span>

--- a/projects/rawkode.academy/website/src/components/common/GridLayout.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/GridLayout.stories.tsx
@@ -54,7 +54,7 @@ export const ResponsiveColumns: Story = {
             <div>
               <h3 class="text-lg font-semibold text-primary-content mb-4">1 column on mobile, 2 on tablet, 4 on desktop</h3>
               <GridLayout :cols="{ default: 1, md: 2, lg: 4 }" :gap="4">
-                <div v-for="i in 8" :key="i" class="bg-gray-100 dark:bg-gray-700 p-4 rounded text-center">
+                <div v-for="i in 8" :key="i" class="bg-[var(--surface-card-muted)] p-4 rounded text-center">
                   {{ i }}
                 </div>
               </GridLayout>
@@ -63,7 +63,7 @@ export const ResponsiveColumns: Story = {
             <div>
               <h3 class="text-lg font-semibold text-primary-content mb-4">2 columns on mobile, 3 on tablet, 5 on desktop</h3>
               <GridLayout :cols="{ default: 2, md: 3, lg: 5 }" :gap="6">
-                <div v-for="i in 10" :key="i" class="bg-gray-100 dark:bg-gray-700 p-4 rounded text-center">
+                <div v-for="i in 10" :key="i" class="bg-[var(--surface-card-muted)] p-4 rounded text-center">
                   {{ i }}
                 </div>
               </GridLayout>
@@ -122,27 +122,27 @@ export const CardGrid: Story = {
 			component={{
 				template: `
           <GridLayout :cols="{ default: 1, md: 2, lg: 3 }" :gap="6">
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 1</h3>
               <p class="text-secondary-content">Description of the first feature goes here.</p>
             </div>
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 2</h3>
               <p class="text-secondary-content">Description of the second feature goes here.</p>
             </div>
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 3</h3>
               <p class="text-secondary-content">Description of the third feature goes here.</p>
             </div>
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 4</h3>
               <p class="text-secondary-content">Description of the fourth feature goes here.</p>
             </div>
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 5</h3>
               <p class="text-secondary-content">Description of the fifth feature goes here.</p>
             </div>
-            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-surface">
+            <div class="bg-[var(--surface-card)] p-6 rounded-lg shadow-md border border-surface">
               <h3 class="text-lg font-semibold text-primary-content mb-2">Feature 6</h3>
               <p class="text-secondary-content">Description of the sixth feature goes here.</p>
             </div>
@@ -166,27 +166,27 @@ export const AlignmentOptions: Story = {
             <div>
               <h3 class="text-lg font-semibold text-primary-content mb-4">Align: start</h3>
               <GridLayout :cols="{ default: 3 }" :gap="4" align="start">
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-20">Short</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-32">Tall</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-24">Medium</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-20">Short</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-32">Tall</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-24">Medium</div>
               </GridLayout>
             </div>
             
             <div>
               <h3 class="text-lg font-semibold text-primary-content mb-4">Align: center</h3>
               <GridLayout :cols="{ default: 3 }" :gap="4" align="center">
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-20">Short</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-32">Tall</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-24">Medium</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-20">Short</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-32">Tall</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-24">Medium</div>
               </GridLayout>
             </div>
             
             <div>
               <h3 class="text-lg font-semibold text-primary-content mb-4">Align: end</h3>
               <GridLayout :cols="{ default: 3 }" :gap="4" align="end">
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-20">Short</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-32">Tall</div>
-                <div class="bg-gray-100 dark:bg-gray-700 p-4 rounded h-24">Medium</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-20">Short</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-32">Tall</div>
+                <div class="bg-[var(--surface-card-muted)] p-4 rounded h-24">Medium</div>
               </GridLayout>
             </div>
           </div>

--- a/projects/rawkode.academy/website/src/components/common/Section.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/Section.stories.tsx
@@ -171,19 +171,19 @@ export const RealWorldExample: Story = {
             <Section>
               <Heading as="h2" size="2xl" class="mb-6">Features</Heading>
               <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+                <div class="p-6 bg-[var(--surface-card)] rounded-lg shadow">
                   <Heading as="h3" size="lg">Feature One</Heading>
                   <p class="mt-2 text-secondary-content">
                     Description of the first feature goes here.
                   </p>
                 </div>
-                <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+                <div class="p-6 bg-[var(--surface-card)] rounded-lg shadow">
                   <Heading as="h3" size="lg">Feature Two</Heading>
                   <p class="mt-2 text-secondary-content">
                     Description of the second feature goes here.
                   </p>
                 </div>
-                <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+                <div class="p-6 bg-[var(--surface-card)] rounded-lg shadow">
                   <Heading as="h3" size="lg">Feature Three</Heading>
                   <p class="mt-2 text-secondary-content">
                     Description of the third feature goes here.

--- a/projects/rawkode.academy/website/src/components/common/SectionHeader.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/common/SectionHeader.stories.tsx
@@ -114,27 +114,27 @@ export const InContext: Story = {
             <SectionHeader title="Technologies" />
             
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">Kubernetes</h3>
                 <p class="text-sm text-muted">Container orchestration</p>
               </div>
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">Docker</h3>
                 <p class="text-sm text-muted">Container runtime</p>
               </div>
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">Terraform</h3>
                 <p class="text-sm text-muted">Infrastructure as code</p>
               </div>
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">Prometheus</h3>
                 <p class="text-sm text-muted">Monitoring & alerting</p>
               </div>
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">Istio</h3>
                 <p class="text-sm text-muted">Service mesh</p>
               </div>
-              <div class="p-4 bg-gray-100 dark:bg-gray-800 rounded">
+              <div class="p-4 bg-[var(--surface-card-muted)] rounded">
                 <h3 class="font-semibold">ArgoCD</h3>
                 <p class="text-sm text-muted">GitOps deployment</p>
               </div>

--- a/projects/rawkode.academy/website/src/components/common/Skeleton.vue
+++ b/projects/rawkode.academy/website/src/components/common/Skeleton.vue
@@ -2,7 +2,7 @@
 	<div :class="className" role="status" :aria-label="ariaLabel">
 		<span class="sr-only">{{ ariaLabel }}</span>
 		<div
-			class="animate-pulse bg-gray-200 dark:bg-gray-700"
+			class="animate-pulse bg-[var(--surface-skeleton)]"
 			:class="[rounded ? 'rounded-full' : 'rounded']"
 			:style="{ width, height }"
 		/>

--- a/projects/rawkode.academy/website/src/components/common/SkeletonCard.vue
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonCard.vue
@@ -3,7 +3,7 @@
 		<span class="sr-only">{{ ariaLabel }}</span>
 		<div
 			v-if="showImage"
-			class="mb-4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
+			class="mb-4 animate-pulse rounded bg-[var(--surface-skeleton)]"
 			:style="{ height: imageHeight }"
 		/>
 		<SkeletonText :lines="1" line-height="1.25rem" last-line-width="70%" />
@@ -16,7 +16,7 @@
 		/>
 		<div v-if="showFooter" class="mt-4 flex items-center gap-3">
 			<div
-				class="h-8 w-8 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"
+				class="h-8 w-8 animate-pulse rounded-full bg-[var(--surface-skeleton)]"
 			/>
 			<SkeletonText
 				class-name="flex-1"

--- a/projects/rawkode.academy/website/src/components/common/SkeletonComment.vue
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonComment.vue
@@ -7,7 +7,7 @@
 		<span class="sr-only">{{ ariaLabel }}</span>
 		<!-- Avatar skeleton -->
 		<div
-			class="animate-pulse bg-gray-200 dark:bg-gray-700 rounded-full shrink-0"
+			class="animate-pulse bg-[var(--surface-skeleton)] rounded-full shrink-0"
 			:style="{
 				width: '2.5rem',
 				height: '2.5rem',
@@ -19,11 +19,11 @@
 			<!-- Header with author and timestamp -->
 			<div class="flex items-center gap-2 mb-2">
 				<div
-					class="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-4"
+					class="animate-pulse bg-[var(--surface-skeleton)] rounded h-4"
 					style="width: 120px"
 				/>
 				<div
-					class="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-3"
+					class="animate-pulse bg-[var(--surface-skeleton)] rounded h-3"
 					style="width: 80px"
 				/>
 			</div>

--- a/projects/rawkode.academy/website/src/components/common/SkeletonList.tsx
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonList.tsx
@@ -32,7 +32,7 @@ export function SkeletonList({
 				>
 					{showIcon && (
 						<div
-							className={`animate-pulse bg-gray-200 dark:bg-gray-700 shrink-0 ${
+							className={`animate-pulse bg-[var(--surface-skeleton)] shrink-0 ${
 								iconRounded ? "rounded-full" : "rounded"
 							}`}
 							style={{
@@ -44,12 +44,12 @@ export function SkeletonList({
 
 					<div className="flex-1">
 						<div
-							className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-4 mb-1"
+							className="animate-pulse bg-[var(--surface-skeleton)] rounded h-4 mb-1"
 							style={{ width: getTitleWidth(index) }}
 						/>
 						{showSubtitle && (
 							<div
-								className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-3"
+								className="animate-pulse bg-[var(--surface-skeleton)] rounded h-3"
 								style={{ width: "50%" }}
 							/>
 						)}
@@ -57,7 +57,7 @@ export function SkeletonList({
 
 					{showAction && (
 						<div
-							className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded shrink-0"
+							className="animate-pulse bg-[var(--surface-skeleton)] rounded shrink-0"
 							style={{
 								width: "1.5rem",
 								height: "1.5rem",

--- a/projects/rawkode.academy/website/src/components/common/SkeletonList.vue
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonList.vue
@@ -8,24 +8,24 @@
 		>
 			<div
 				v-if="showIcon"
-				class="shrink-0 animate-pulse bg-gray-200 dark:bg-gray-700"
+				class="shrink-0 animate-pulse bg-[var(--surface-skeleton)]"
 				:class="[iconRounded ? 'rounded-full' : 'rounded']"
 				:style="{ width: iconSize, height: iconSize }"
 			/>
 			<div class="flex-1">
 				<div
-					class="mb-1 h-4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
+					class="mb-1 h-4 animate-pulse rounded bg-[var(--surface-skeleton)]"
 					:style="{ width: getTitleWidth(index) }"
 				/>
 				<div
 					v-if="showSubtitle"
-					class="h-3 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
+					class="h-3 animate-pulse rounded bg-[var(--surface-skeleton)]"
 					:style="{ width: getSubtitleWidth(index) }"
 				/>
 			</div>
 			<div
 				v-if="showAction"
-				class="h-6 w-6 shrink-0 animate-pulse rounded bg-gray-200 dark:bg-gray-700"
+				class="h-6 w-6 shrink-0 animate-pulse rounded bg-[var(--surface-skeleton)]"
 			/>
 		</div>
 	</div>

--- a/projects/rawkode.academy/website/src/components/common/SkeletonText.vue
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonText.vue
@@ -5,7 +5,7 @@
 			v-for="(line, index) in lines"
 			:key="index"
 			:class="[
-				'animate-pulse bg-gray-200 dark:bg-gray-700',
+				'animate-pulse bg-[var(--surface-skeleton)]',
 				index < lines.length - 1 ? 'mb-2' : '',
 			]"
 			:style="{

--- a/projects/rawkode.academy/website/src/components/common/SkeletonTranscript.vue
+++ b/projects/rawkode.academy/website/src/components/common/SkeletonTranscript.vue
@@ -8,7 +8,7 @@
 		<!-- Search bar skeleton -->
 		<div class="mb-4">
 			<div
-				class="animate-pulse bg-gray-200 dark:bg-gray-700 rounded-sm"
+				class="animate-pulse bg-[var(--surface-skeleton)] rounded-sm"
 				style="height: 42px"
 			/>
 		</div>

--- a/projects/rawkode.academy/website/src/components/common/TerminalWindow.vue
+++ b/projects/rawkode.academy/website/src/components/common/TerminalWindow.vue
@@ -1,15 +1,15 @@
 <template>
- <div :class="['terminal dark: rounded-sm overflow-hidden border border-gray-700/40 dark:border-gray-600/60', className]">
- <div class="terminal-header bg-gray-800/80 dark:bg-gray-700/90 px-4 py-2 flex items-center justify-between border-b border-gray-700/40 dark:border-gray-600/60">
+ <div :class="['terminal rounded-sm overflow-hidden border border-[var(--terminal-border)]', className]">
+ <div class="terminal-header bg-[var(--terminal-surface)] px-4 py-2 flex items-center justify-between border-b border-[var(--terminal-border)]">
  <div class="flex space-x-2">
  <div class="w-3 h-3 bg-red-500 rounded-full"></div>
  <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
  <div class="w-3 h-3 bg-green-500 rounded-full"></div>
  </div>
- <div class="text-gray-400 dark:text-gray-300 text-sm font-mono">{{ title }}</div>
+ <div class="text-[var(--terminal-text-dim)] text-sm font-mono">{{ title }}</div>
  <div class="w-14"></div>
  </div>
- <div class="terminal-body bg-gray-900/90 dark:bg-gray-800/95 text-gray-100 dark:text-gray-50 p-4 font-mono text-sm">
+ <div class="terminal-body bg-[var(--terminal-bg)] text-[var(--terminal-text)] p-4 font-mono text-sm">
  <slot />
  </div>
  </div>

--- a/projects/rawkode.academy/website/src/components/courses/CourseSignupFormClient.vue
+++ b/projects/rawkode.academy/website/src/components/courses/CourseSignupFormClient.vue
@@ -12,7 +12,7 @@
  </p>
  </div>
 
- <div class="rounded-sm border border-white/40 bg-white/60 p-6 dark:border-white/8 dark:bg-gray-950/30">
+ <div class="rounded-sm border border-white/40 bg-[var(--surface-card)] p-6 dark:border-white/8">
  <!-- Checking Subscription -->
  <div v-if="checkingSubscription" class="text-center py-8">
  <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 mb-6">
@@ -72,17 +72,17 @@
  name="email"
  required
  placeholder="your@email.com"
- class="w-full rounded-sm border border-white/60 bg-white/80 px-4 py-3 text-primary-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-white/10 dark:bg-gray-950/35"
+ class="w-full rounded-sm border border-white/60 bg-[var(--surface-card)] px-4 py-3 text-primary-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-white/10"
  />
  </div>
 
- <div v-if="disclaimer" class="rounded-sm bg-white/65 p-3 text-sm text-muted dark:bg-gray-950/30">
+ <div v-if="disclaimer" class="rounded-sm bg-[var(--surface-card-muted)] p-3 text-sm text-muted">
  <p>{{ disclaimer }}</p>
  </div>
 
  <div
  v-if="allowSponsorContact && sponsor"
- class="rounded-sm border border-white/40 bg-white/55 px-4 py-3 dark:border-white/8 dark:bg-gray-950/25"
+ class="rounded-sm border border-white/40 bg-[var(--surface-card-muted)] px-4 py-3 dark:border-white/8"
  >
  <div class="flex items-start">
  <input
@@ -91,7 +91,7 @@
  id="sponsor-contact"
  name="allowSponsorContact"
  value="true"
- class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+ class="mt-1 h-4 w-4 rounded border-[var(--surface-border-strong)] text-primary focus:ring-primary"
  />
  <label for="sponsor-contact" class="ml-2 text-sm text-secondary-content">
  I agree to allow {{ sponsor }} to contact me with relevant offers and product updates.

--- a/projects/rawkode.academy/website/src/components/courses/CourseSignupFormCompact.vue
+++ b/projects/rawkode.academy/website/src/components/courses/CourseSignupFormCompact.vue
@@ -50,21 +50,21 @@
  id="email"
  placeholder="Enter your email"
  required
- class="w-full rounded-sm border border-white/60 bg-white/80 px-4 py-3 text-primary-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-white/10 dark:bg-gray-950/35"
+ class="w-full rounded-sm border border-white/60 bg-[var(--surface-card)] px-4 py-3 text-primary-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-white/10"
  :disabled="loading"
  />
  </div>
 
  <div
  v-if="signupConfig.sponsor && signupConfig.allowSponsorContact"
- class="rounded-sm border border-white/40 bg-white/55 px-4 py-3 dark:border-white/8 dark:bg-gray-950/25"
+ class="rounded-sm border border-white/40 bg-[var(--surface-card-muted)] px-4 py-3 dark:border-white/8"
  >
  <div class="flex items-start gap-3">
  <input
  v-model="sponsorConsent"
  type="checkbox"
  id="sponsor-consent"
- class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+ class="mt-1 h-4 w-4 rounded border-[var(--surface-border-strong)] text-primary focus:ring-primary"
  :disabled="loading"
  />
  <label for="sponsor-consent" class="text-sm leading-6 text-secondary-content">

--- a/projects/rawkode.academy/website/src/components/courses/EmbeddedAppModal.vue
+++ b/projects/rawkode.academy/website/src/components/courses/EmbeddedAppModal.vue
@@ -22,7 +22,7 @@
  </h3>
  <button
  @click="close"
- class="p-2 text-muted hover:text-secondary-content transition-smooth rounded-sm hover:bg-[var(--surface-card-muted)] hover:"
+ class="p-2 text-muted hover:text-secondary-content transition-smooth rounded-sm hover:bg-[var(--surface-card-muted)]"
  aria-label="Close"
  >
  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -71,7 +71,7 @@
  :href="getExternalUrl()"
  target="_blank"
  rel="noopener noreferrer"
- class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-content bg-[var(--surface-card)] border border-[var(--surface-border)] rounded-sm hover:bg-[var(--surface-card-muted)] hover:scale-105 transition-smooth shadow-md hover:"
+ class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-content bg-[var(--surface-card)] border border-[var(--surface-border)] rounded-sm hover:bg-[var(--surface-card-muted)] hover:scale-105 transition-smooth shadow-md"
  >
  Open in new tab
  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/projects/rawkode.academy/website/src/components/courses/EmbeddedAppModal.vue
+++ b/projects/rawkode.academy/website/src/components/courses/EmbeddedAppModal.vue
@@ -12,17 +12,17 @@
  @click.self="close"
  >
  <div
- class="relative w-full max-w-6xl bg-white/90 dark:bg-gray-900/90 rounded-sm dark: border border-white/50 dark:border-gray-700/50"
+ class="relative w-full max-w-6xl bg-[var(--surface-card)] rounded-sm border border-[var(--surface-border)]"
  @click.stop
  >
  <!-- Header -->
- <div class="flex items-center justify-between p-4 border-b border-white/30 dark:border-gray-700/50 ">
+ <div class="flex items-center justify-between p-4 border-b border-[var(--surface-border)] ">
  <h3 class="text-lg font-semibold text-primary-content">
  {{ resource.title }}
  </h3>
  <button
  @click="close"
- class="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-smooth rounded-sm hover:bg-white/60 dark:hover:bg-gray-700/60 hover:"
+ class="p-2 text-muted hover:text-secondary-content transition-smooth rounded-sm hover:bg-[var(--surface-card-muted)] hover:"
  aria-label="Close"
  >
  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -32,10 +32,10 @@
  </div>
 
  <!-- Container -->
- <div class="relative bg-gray-50 dark:bg-gray-800" :style="{ height: containerHeight }">
+ <div class="relative bg-[var(--surface-card-muted)]" :style="{ height: containerHeight }">
  <div v-if="loading" class="absolute inset-0 flex items-center justify-center">
  <div class="text-center">
- <div class="inline-block animate-spin rounded-full h-8 w-8 border-4 border-gray-300 border-t-primary"></div>
+ <div class="inline-block animate-spin rounded-full h-8 w-8 border-4 border-[var(--surface-border-strong)] border-t-primary"></div>
  <p class="mt-2 text-sm text-muted">Loading application...</p>
  </div>
  </div>
@@ -61,7 +61,7 @@
  </div>
 
  <!-- Footer -->
- <div class="flex items-center justify-between p-4 border-t border-white/30 dark:border-gray-700/50 bg-white/30 dark:bg-gray-800/30 ">
+ <div class="flex items-center justify-between p-4 border-t border-[var(--surface-border)] bg-[var(--surface-card-muted)] ">
  <p v-if="resource.description" class="text-sm text-muted">
  {{ resource.description }}
  </p>
@@ -71,7 +71,7 @@
  :href="getExternalUrl()"
  target="_blank"
  rel="noopener noreferrer"
- class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-content bg-white/50 dark:bg-gray-700/50 border border-white/50 dark:border-gray-600/50 rounded-sm hover:bg-white/70 dark:hover:bg-gray-600/70 hover:scale-105 transition-smooth shadow-md hover:"
+ class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-secondary-content bg-[var(--surface-card)] border border-[var(--surface-border)] rounded-sm hover:bg-[var(--surface-card-muted)] hover:scale-105 transition-smooth shadow-md hover:"
  >
  Open in new tab
  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/projects/rawkode.academy/website/src/components/courses/ResourceList.vue
+++ b/projects/rawkode.academy/website/src/components/courses/ResourceList.vue
@@ -206,7 +206,7 @@ const getResourceIconClass = (type: string) => {
 		case "embed":
 			return "bg-secondary/10 dark:bg-secondary/20 text-secondary dark:text-secondary";
 		default:
-			return "bg-gray-100 dark:bg-gray-800 text-muted";
+			return "bg-[var(--surface-card-muted)] text-muted";
 	}
 };
 

--- a/projects/rawkode.academy/website/src/components/courses/WebContainerEmbed.vue
+++ b/projects/rawkode.academy/website/src/components/courses/WebContainerEmbed.vue
@@ -1,11 +1,11 @@
 <template>
- <div class="h-full flex flex-col bg-gray-900 text-gray-100">
+ <div class="h-full flex flex-col bg-[var(--terminal-bg)] text-[var(--terminal-text)]">
  <!-- Header -->
- <div class="flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700">
+ <div class="flex items-center justify-between p-4 bg-[var(--terminal-surface)] border-b border-[var(--terminal-border)]">
  <div class="flex items-center gap-4">
  <h3 class="text-lg font-semibold">{{ title }}</h3>
- <div v-if="status === 'booting'" class="flex items-center gap-2 text-sm text-gray-400">
- <div class="animate-spin rounded-full h-4 w-4 border-2 border-gray-400 border-t-transparent"></div>
+ <div v-if="status === 'booting'" class="flex items-center gap-2 text-sm text-[var(--terminal-text-dim)]">
+ <div class="animate-spin rounded-full h-4 w-4 border-2 border-[var(--terminal-text-dim)] border-t-transparent"></div>
  <span>Starting container...</span>
  </div>
  <div v-else-if="status === 'installing'" class="flex items-center gap-2 text-sm text-primary">
@@ -21,7 +21,7 @@
  <button
  @click="restart"
  :disabled="status !== 'ready'"
- class="p-2 text-gray-400 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+ class="p-2 text-[var(--terminal-text-dim)] hover:text-[var(--terminal-text)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
  title="Restart"
  >
  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -34,11 +34,11 @@
  <!-- Split View -->
  <div class="flex-1 flex overflow-hidden">
  <!-- Editor -->
- <div class="w-1/2 flex flex-col border-r border-gray-700">
- <div class="p-2 bg-gray-800 border-b border-gray-700 relative z-10">
+ <div class="w-1/2 flex flex-col border-r border-[var(--terminal-border)]">
+ <div class="p-2 bg-[var(--terminal-surface)] border-b border-[var(--terminal-border)] relative z-10">
  <select
  v-model="selectedFile"
- class="w-full px-3 py-1 bg-gray-700 text-white rounded border border-gray-600 hover:bg-gray-600 focus:border-primary focus:outline-none cursor-pointer transition-colors"
+ class="w-full px-3 py-1 bg-[var(--terminal-bg)] text-[var(--terminal-text)] rounded border border-[var(--terminal-border)] hover:bg-[var(--terminal-surface)] focus:border-primary focus:outline-none cursor-pointer transition-colors"
  :disabled="fileList.length === 0"
  >
  <option v-if="fileList.length === 0" value="">No files loaded</option>
@@ -52,11 +52,11 @@
  v-if="selectedFile && fileContents[selectedFile] !== undefined"
  v-model="fileContents[selectedFile]"
  @input="onFileChange"
- class="absolute inset-0 w-full h-full p-4 bg-gray-900 text-gray-100 font-mono text-sm resize-none focus:outline-none"
+ class="absolute inset-0 w-full h-full p-4 bg-[var(--terminal-bg)] text-[var(--terminal-text)] font-mono text-sm resize-none focus:outline-none"
  :placeholder="`Edit ${selectedFile}...`"
  spellcheck="false"
  ></textarea>
- <div v-else class="absolute inset-0 w-full h-full p-4 bg-gray-900 text-gray-500 font-mono text-sm">
+ <div v-else class="absolute inset-0 w-full h-full p-4 bg-[var(--terminal-bg)] text-[var(--terminal-text-dim)] font-mono text-sm">
  Select a file to edit
  </div>
  </div>
@@ -64,9 +64,9 @@
 
  <!-- Preview -->
  <div class="w-1/2 flex flex-col">
- <div class="p-2 bg-gray-800 border-b border-gray-700">
+ <div class="p-2 bg-[var(--terminal-surface)] border-b border-[var(--terminal-border)]">
  <div class="flex items-center gap-2">
- <span class="text-sm text-gray-400">Preview:</span>
+ <span class="text-sm text-[var(--terminal-text-dim)]">Preview:</span>
  <a 
  v-if="previewUrl"
  :href="previewUrl" 
@@ -80,19 +80,19 @@
  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
  </svg>
  </a>
- <span v-else class="text-sm text-gray-500 italic">{{ status === 'ready' ? 'Server ready (check terminal for URL)' : 'Waiting for server...' }}</span>
+ <span v-else class="text-sm text-[var(--terminal-text-dim)] italic">{{ status === 'ready' ? 'Server ready (check terminal for URL)' : 'Waiting for server...' }}</span>
  </div>
  </div>
- <div class="flex-1 relative bg-white dark:bg-gray-900">
+ <div class="flex-1 relative bg-[var(--surface-card)]">
  <iframe
  v-if="previewUrl"
  :src="previewUrl"
  class="absolute inset-0 w-full h-full"
  frameborder="0"
  ></iframe>
- <div v-else class="absolute inset-0 flex items-center justify-center text-gray-500">
+ <div v-else class="absolute inset-0 flex items-center justify-center text-muted">
  <div class="text-center">
- <svg class="w-16 h-16 mx-auto mb-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+ <svg class="w-16 h-16 mx-auto mb-4 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
  </svg>
  <p>Waiting for server...</p>
@@ -103,12 +103,12 @@
  </div>
 
  <!-- Terminal -->
- <div class="h-48 flex-shrink-0 bg-black border-t border-gray-700 overflow-hidden flex flex-col">
- <div class="p-2 bg-gray-800 border-b border-gray-700 flex items-center justify-between">
- <span class="text-sm text-gray-400">Terminal</span>
+ <div class="h-48 flex-shrink-0 bg-black border-t border-[var(--terminal-border)] overflow-hidden flex flex-col">
+ <div class="p-2 bg-[var(--terminal-surface)] border-b border-[var(--terminal-border)] flex items-center justify-between">
+ <span class="text-sm text-[var(--terminal-text-dim)]">Terminal</span>
  <button
  @click="clearTerminal"
- class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+ class="text-xs text-[var(--terminal-text-dim)] hover:text-[var(--terminal-text)] transition-colors"
  >
  Clear
  </button>
@@ -176,8 +176,8 @@ const clearTerminal = () => {
 const getTerminalLineClass = (line: string) => {
 	if (line.startsWith("[error]")) return "text-red-400";
 	if (line.startsWith("[success]")) return "text-green-400";
-	if (line.startsWith("[info]")) return "text-gray-300";
-	return "text-gray-400";
+	if (line.startsWith("[info]")) return "text-[var(--terminal-text)]";
+	return "text-[var(--terminal-text-dim)]";
 };
 
 const formatTerminalLine = (line: string) => {

--- a/projects/rawkode.academy/website/src/components/faq/list.vue
+++ b/projects/rawkode.academy/website/src/components/faq/list.vue
@@ -25,7 +25,7 @@ const faqItems = props.items.map((item, index) => ({
 </script>
 
 <template>
-	<section class="bg-white dark:bg-gray-900">
+	<section class="bg-[var(--surface-base)]">
 		<div class="py-8 px-4 mx-auto max-w-(--breakpoint-xl) sm:py-16 lg:px-6">
 			<h2
 				class="mb-6 lg:mb-8 text-3xl lg:text-4xl tracking-tight font-extrabold text-center text-primary-content"

--- a/projects/rawkode.academy/website/src/components/feature/grid.vue
+++ b/projects/rawkode.academy/website/src/components/feature/grid.vue
@@ -1,5 +1,5 @@
 <template>
- <div class="bg-white dark:bg-gray-900 py-24 sm:py-32">
+ <div class="bg-[var(--surface-base)] py-24 sm:py-32">
 											 <div class="mx-auto px-6 lg:px-8">
 										 <div class="mx-auto lg:text-center">
 							 <h2>Deploy faster</h2>

--- a/projects/rawkode.academy/website/src/components/feature/list-icons.vue
+++ b/projects/rawkode.academy/website/src/components/feature/list-icons.vue
@@ -114,7 +114,7 @@ const offerings: Offering[] = [
 ];
 </script>
 <template>
-	<section class="bg-white dark:bg-gray-900">
+	<section class="bg-[var(--surface-base)]">
 		<div class="py-8 px-4 mx-auto max-w-(--breakpoint-xl) sm:py-16 lg:px-6">
 			<div class="max-w-(--breakpoint-md) mb-8 lg:mb-16">
 				<h2 class="mb-4 text-4xl tracking-tight font-extrabold text-primary-content">Partner With Industry
@@ -127,7 +127,7 @@ const offerings: Offering[] = [
 			</div>
 			<div class="space-y-12 md:grid md:grid-cols-1 lg:grid-cols-3 md:gap-8 xl:gap-12 md:space-y-0">
 				<div v-for="offer in offerings"
-					class="p-6 bg-gray-50 dark:bg-gray-800 rounded-sm border border-surface shadow-sm hover: transition-card">
+					class="p-6 bg-[var(--surface-card-muted)] rounded-sm border border-surface shadow-sm hover: transition-card">
 					<div class="flex items-center mb-4">
 						<div
 							:class="`flex justify-center items-center mr-4 w-12 h-12 bg-${offer.color} rounded-full dark:bg-${offer.color} lg:h-14 lg:w-14`">

--- a/projects/rawkode.academy/website/src/components/feature/list-icons.vue
+++ b/projects/rawkode.academy/website/src/components/feature/list-icons.vue
@@ -127,7 +127,7 @@ const offerings: Offering[] = [
 			</div>
 			<div class="space-y-12 md:grid md:grid-cols-1 lg:grid-cols-3 md:gap-8 xl:gap-12 md:space-y-0">
 				<div v-for="offer in offerings"
-					class="p-6 bg-[var(--surface-card-muted)] rounded-sm border border-surface shadow-sm hover: transition-card">
+					class="p-6 bg-[var(--surface-card-muted)] rounded-sm border border-surface shadow-sm transition-card">
 					<div class="flex items-center mb-4">
 						<div
 							:class="`flex justify-center items-center mr-4 w-12 h-12 bg-${offer.color} rounded-full dark:bg-${offer.color} lg:h-14 lg:w-14`">

--- a/projects/rawkode.academy/website/src/components/learning-paths/LearningPathHero.astro
+++ b/projects/rawkode.academy/website/src/components/learning-paths/LearningPathHero.astro
@@ -53,7 +53,7 @@ const hasTechnologies = technologies.length > 0;
 const hasPrerequisites = prerequisites.length > 0;
 ---
 
-<section class="relative overflow-hidden rounded-sm border border-surface bg-white dark:bg-gray-900">
+<section class="relative overflow-hidden rounded-sm border border-surface bg-[var(--surface-card)]">
 	<div class="absolute inset-0 bg-[var(--surface-card)]"></div>
 	<div class="relative z-10 px-6 py-12 md:px-10 lg:px-16 lg:py-16">
 		<div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
@@ -100,7 +100,7 @@ const hasPrerequisites = prerequisites.length > 0;
 			</div>
 
 			<div class="w-full max-w-sm lg:w-auto lg:min-w-[280px]">
-				<div class="rounded-sm border border-surface bg-white/80 dark:bg-gray-900/70 p-6 ">
+				<div class="rounded-sm border border-surface bg-[var(--surface-card)] p-6 ">
 					<div class="flex items-center justify-between mb-4">
 						<h2 class="text-sm font-semibold uppercase tracking-wide text-muted">
 							Your Guides

--- a/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
+++ b/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
@@ -373,6 +373,9 @@ function isCurrentPath(itemPath: string): boolean {
 		width: var(--ed-sidebar-expanded-width, 16rem);
 		transition: width var(--duration-slow) var(--ease-standard);
 		overflow: hidden;
+		/* Static chrome during cross-document view transitions — same
+		   reasoning as .ed-topbar in app.astro. */
+		view-transition-name: ed-sidebar;
 	}
 
 	.ed-sidebar--collapsed {

--- a/projects/rawkode.academy/website/src/components/stats/simple.vue
+++ b/projects/rawkode.academy/website/src/components/stats/simple.vue
@@ -13,7 +13,7 @@ defineProps<Props>();
 </script>
 
 <template>
-	<section class="bg-white dark:bg-gray-900">
+	<section class="bg-[var(--surface-base)]">
 		<div class="px-4 mx-auto max-w-(--breakpoint-xl) lg:px-6 xl:px-0">
 			<div class="mx-auto max-w-(--breakpoint-md) text-center">
 				<h2 class="text-3xl tracking-tight font-extrabold text-primary-content md:text-4xl">{{ title }}</h2>

--- a/projects/rawkode.academy/website/src/components/technology/TopicHub.astro
+++ b/projects/rawkode.academy/website/src/components/technology/TopicHub.astro
@@ -109,7 +109,7 @@ function formatLearningPathDuration(minutes: number): string {
  {learningPaths.map((path) => (
  <a
  href={`/learning-paths/${path.id}`}
- class="group block rounded-sm border border-black/10 dark:border-white/10 bg-white dark:bg-gray-900 p-6 shadow-sm hover:border-primary/40 hover:bg-primary/[0.03] transition-colors"
+ class="group block rounded-sm border border-black/10 dark:border-white/10 bg-[var(--surface-card)] p-6 shadow-sm hover:border-primary/40 hover:bg-primary/[0.03] transition-colors"
  >
  <div class="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted mb-2">
  <span>{difficultyLabel[path.data.difficulty] ?? path.data.difficulty}</span>
@@ -188,7 +188,7 @@ function formatLearningPathDuration(minutes: number): string {
  {videos.map((video) => (
  <a
  href={`/watch/${video.slug}`}
- class="group relative block overflow-hidden rounded-sm bg-gray-100 dark:bg-gray-800 aspect-video"
+ class="group relative block overflow-hidden rounded-sm bg-[var(--surface-card)] aspect-video"
  >
  <img
  src={video.thumbnailUrl}

--- a/projects/rawkode.academy/website/src/components/testimonial/slider.vue
+++ b/projects/rawkode.academy/website/src/components/testimonial/slider.vue
@@ -162,7 +162,7 @@ const formattedPosition = computed(() => {
 										<img
 											:src="activeTestimonial.author.image"
 											:alt="`${activeTestimonial.author.name} profile picture`"
-											class="h-16 w-16 rounded-full border-4 border-white object-cover shadow-md dark:border-gray-800 sm:h-[4.5rem] sm:w-[4.5rem]"
+											class="h-16 w-16 rounded-full border-4 border-[var(--surface-card)] object-cover shadow-md sm:h-[4.5rem] sm:w-[4.5rem]"
 											loading="lazy"
 										/>
 									</div>

--- a/projects/rawkode.academy/website/src/components/ui/EmptyState.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/ui/EmptyState.stories.tsx
@@ -1,0 +1,65 @@
+import type { StoryObj } from "@storybook/vue3";
+import EmptyState from "./EmptyState.vue";
+
+const meta = {
+	title: "UI/Editorial/EmptyState",
+	component: EmptyState,
+	tags: ["autodocs"],
+	argTypes: {
+		align: {
+			control: "select",
+			options: ["center", "start"],
+		},
+	},
+};
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { EmptyState },
+		setup: () => ({ args }),
+		template: `<EmptyState v-bind="args" />`,
+	}),
+	args: {
+		title: "No articles match these filters.",
+		body: "Try a broader keyword, or clear the active filters to browse the full archive.",
+	},
+};
+
+export const WithActions: Story = {
+	render: (args) => ({
+		components: { EmptyState },
+		setup: () => ({ args }),
+		template: `
+			<EmptyState v-bind="args">
+				<template #actions>
+					<a href="#">Clear filters</a>
+					<a href="#">Browse all videos →</a>
+				</template>
+			</EmptyState>
+		`,
+	}),
+	args: {
+		title: "Nothing matched “service mesh”.",
+	},
+};
+
+export const StartAligned: Story = {
+	render: (args) => ({
+		components: { EmptyState },
+		setup: () => ({ args }),
+		template: `
+			<EmptyState v-bind="args">
+				<template #actions>
+					<a href="#">Get notified →</a>
+				</template>
+			</EmptyState>
+		`,
+	}),
+	args: {
+		title: "More courses launching soon",
+		body: "Kubernetes, platform engineering, and identity deep dives are next.",
+		align: "start",
+	},
+};

--- a/projects/rawkode.academy/website/src/components/ui/EmptyState.vue
+++ b/projects/rawkode.academy/website/src/components/ui/EmptyState.vue
@@ -1,0 +1,96 @@
+<template>
+	<div class="empty-state" role="status">
+		<p class="empty-state__title">{{ title }}</p>
+		<p v-if="body || $slots.default" class="empty-state__body">
+			<slot>{{ body }}</slot>
+		</p>
+		<div v-if="$slots.actions" class="empty-state__actions">
+			<slot name="actions" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Editorial empty state — the "loaded, but nothing here" counterpart to the
+ * Skeleton* loading family. Serif italic line, optional body copy, and a row
+ * of mono uppercase action links via the `actions` slot.
+ */
+withDefaults(
+	defineProps<{
+		title: string;
+		body?: string;
+		align?: "center" | "start";
+	}>(),
+	{
+		body: undefined,
+		align: "center",
+	},
+);
+</script>
+
+<style scoped>
+.empty-state {
+	display: flex;
+	flex-direction: column;
+	align-items: v-bind("align === 'center' ? 'center' : 'flex-start'");
+	text-align: v-bind("align === 'center' ? 'center' : 'left'");
+	gap: 0.625rem;
+	padding: 2.5rem 1.5rem;
+	border: 1px solid var(--editorial-hairline);
+	border-radius: var(--radius-sm);
+	background: var(--surface-card-muted);
+}
+
+.empty-state__title {
+	margin: 0;
+	font-family: var(--font-instrument-serif), serif;
+	font-style: italic;
+	font-weight: 400;
+	font-size: 1.5rem;
+	line-height: 1.15;
+	color: var(--editorial-ink-soft);
+	text-wrap: balance;
+}
+
+.empty-state__body {
+	margin: 0;
+	max-width: 44rem;
+	font-family: var(--font-inter-tight), system-ui, sans-serif;
+	font-size: 0.9375rem;
+	line-height: 1.5;
+	color: var(--editorial-ink-mute);
+}
+
+.empty-state__body :deep(a) {
+	color: var(--editorial-spruce);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.empty-state__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem 1.5rem;
+	margin-top: 0.375rem;
+}
+
+.empty-state__actions :deep(a) {
+	display: inline-flex;
+	align-items: center;
+	min-height: 2.75rem;
+	font-family: var(--font-jetbrains-mono), monospace;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--editorial-spruce);
+	text-decoration: none;
+}
+
+.empty-state__actions :deep(a:hover) {
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.35em;
+}
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/EmptyState.vue
+++ b/projects/rawkode.academy/website/src/components/ui/EmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="empty-state" role="status">
+	<div class="empty-state">
 		<p class="empty-state__title">{{ title }}</p>
 		<p v-if="body || $slots.default" class="empty-state__body">
 			<slot>{{ body }}</slot>

--- a/projects/rawkode.academy/website/src/components/ui/Hero.stories.tsx
+++ b/projects/rawkode.academy/website/src/components/ui/Hero.stories.tsx
@@ -157,7 +157,7 @@ export const SplitLayout: Story = {
 				</template>
 				<template #stats>
 					<div class="flex items-center gap-3">
-						<div class="w-10 h-10 bg-gray-200 dark:bg-gray-800 rounded-lg flex items-center justify-center">
+						<div class="w-10 h-10 bg-[var(--surface-card-muted)] rounded-lg flex items-center justify-center">
 							<svg class="w-5 h-5 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
 							</svg>
@@ -168,7 +168,7 @@ export const SplitLayout: Story = {
 						</div>
 					</div>
 					<div class="flex items-center gap-3">
-						<div class="w-10 h-10 bg-gray-200 dark:bg-gray-800 rounded-lg flex items-center justify-center">
+						<div class="w-10 h-10 bg-[var(--surface-card-muted)] rounded-lg flex items-center justify-center">
 							<svg class="w-5 h-5 text-secondary dark:text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
 							</svg>

--- a/projects/rawkode.academy/website/src/components/ui/PagerStrip.astro
+++ b/projects/rawkode.academy/website/src/components/ui/PagerStrip.astro
@@ -1,0 +1,63 @@
+---
+import MLabel from "@/components/ui/MLabel.vue";
+
+/**
+ * Editorial pager — prev/next links around a mono "Page N [of M]" label.
+ * Server-rendered links only; pages indexed from 1. Render it inside a
+ * collection footer (see /watch) or standalone (see /read).
+ */
+interface Props {
+	page: number;
+	totalPages?: number | undefined;
+	prevHref?: string | undefined;
+	nextHref?: string | undefined;
+	ariaLabel?: string;
+}
+
+const {
+	page,
+	totalPages,
+	prevHref,
+	nextHref,
+	ariaLabel = "Pagination",
+} = Astro.props;
+---
+
+<nav class="pager-strip" aria-label={ariaLabel}>
+	{prevHref && (
+		<a class="pager-strip__btn focus-ring" href={prevHref} rel="prev">
+			<MLabel tone="ink">← Previous</MLabel>
+		</a>
+	)}
+	<MLabel>
+		Page {page}{typeof totalPages === "number" ? ` of ${totalPages}` : ""}
+	</MLabel>
+	{nextHref && (
+		<a class="pager-strip__btn focus-ring" href={nextHref} rel="next">
+			<MLabel tone="ink">Next →</MLabel>
+		</a>
+	)}
+</nav>
+
+<style>
+	.pager-strip {
+		display: flex;
+		gap: 1rem;
+		align-items: center;
+	}
+
+	.pager-strip__btn {
+		display: inline-flex;
+		align-items: center;
+		min-height: 2.75rem;
+		padding: 0 0.5rem;
+		text-decoration: none;
+	}
+
+	.pager-strip__btn:hover {
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.35em;
+		color: var(--editorial-ink);
+	}
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/index.ts
+++ b/projects/rawkode.academy/website/src/components/ui/index.ts
@@ -19,3 +19,4 @@ export { default as MastheadBar } from "./MastheadBar.vue";
 export { default as EditorialButton } from "./EditorialButton.vue";
 export { default as StatRow } from "./StatRow.vue";
 export { default as SectionRail } from "./SectionRail.vue";
+export { default as EmptyState } from "./EmptyState.vue";

--- a/projects/rawkode.academy/website/src/components/video/ShowVideoSection.astro
+++ b/projects/rawkode.academy/website/src/components/video/ShowVideoSection.astro
@@ -55,7 +55,7 @@ const hasMoreVideos =
 					href={`/watch/${video.slug}`}
 					class="group block paper-card-muted rounded-sm overflow-hidden"
 				>
-					<div class="relative aspect-video overflow-hidden bg-gray-100 dark:bg-gray-800">
+					<div class="relative aspect-video overflow-hidden bg-[var(--surface-card-muted)]">
 						<img
 							src={video.thumbnailUrl}
 							alt={video.title}

--- a/projects/rawkode.academy/website/src/components/video/TechnologyVideoSection.astro
+++ b/projects/rawkode.academy/website/src/components/video/TechnologyVideoSection.astro
@@ -65,7 +65,7 @@ const hasMoreVideos = totalVideos && totalVideos > videos.length;
 					href={`/watch/${video.slug}`}
 					class="group block paper-card-muted rounded-sm overflow-hidden"
 				>
-					<div class="relative aspect-video overflow-hidden bg-gray-100 dark:bg-gray-800">
+					<div class="relative aspect-video overflow-hidden bg-[var(--surface-card-muted)]">
 						<img
 							src={video.thumbnailUrl}
 							alt={video.title}

--- a/projects/rawkode.academy/website/src/components/video/VideoGridItem.astro
+++ b/projects/rawkode.academy/website/src/components/video/VideoGridItem.astro
@@ -12,6 +12,9 @@ interface Props {
 	author?: string | undefined;
 	date?: string | undefined;
 	viewerCount?: number | undefined;
+	/** Cross-document view-transition name. The same name on the watch
+	 * page's player frame morphs this still into the player on click. */
+	vtName?: string | undefined;
 }
 
 const {
@@ -24,17 +27,23 @@ const {
 	author,
 	date,
 	viewerCount,
+	vtName,
 } = Astro.props as Props;
 ---
 
 <a class="video-grid-item" href={href}>
-	<VideoStill
-		episodeNum={episodeNum}
-		title={title}
-		series={series}
-		duration={duration}
-		thumbnailUrl={thumbnailUrl}
-	/>
+	<div
+		class="video-grid-item__still"
+		style={vtName ? `view-transition-name: ${vtName}` : undefined}
+	>
+		<VideoStill
+			episodeNum={episodeNum}
+			title={title}
+			series={series}
+			duration={duration}
+			thumbnailUrl={thumbnailUrl}
+		/>
+	</div>
 
 	<div class="video-grid-item__body">
 		<MLabel tone="spruce">

--- a/projects/rawkode.academy/website/src/components/video/VideoHero.astro
+++ b/projects/rawkode.academy/website/src/components/video/VideoHero.astro
@@ -16,6 +16,9 @@ interface Props {
 	viewerCount?: number | undefined;
 	primaryCtaLabel?: string | undefined;
 	secondaryCtaLabel?: string | undefined;
+	/** Cross-document view-transition name. The same name on the watch
+	 * page's player frame morphs this still into the player on click. */
+	vtName?: string | undefined;
 }
 
 const {
@@ -32,6 +35,7 @@ const {
 	viewerCount,
 	primaryCtaLabel,
 	secondaryCtaLabel,
+	vtName,
 } = Astro.props as Props;
 
 const primaryLabel =
@@ -49,7 +53,11 @@ const metaParts = [
 ---
 
 <section class="video-hero">
-	<a class="video-hero__still" href={href}>
+	<a
+		class="video-hero__still"
+		href={href}
+		style={vtName ? `view-transition-name: ${vtName}` : undefined}
+	>
 		<VideoStill
 			episodeNum={episodeNum}
 			title={title}

--- a/projects/rawkode.academy/website/src/components/video/VideoProgressBar.vue
+++ b/projects/rawkode.academy/website/src/components/video/VideoProgressBar.vue
@@ -40,7 +40,7 @@ const heightClass = computed(() => {
 const colorClass = computed(() => {
 	const colors: Record<string, string> = {
 		default: "bg-[rgb(var(--brand-primary))]",
-		subtle: "bg-gray-400 dark:bg-gray-500",
+		subtle: "bg-[var(--editorial-ink-mute)]",
 		accent: "bg-[rgb(var(--brand-secondary))]",
 	};
 	return colors[props.variant] || "bg-[rgb(var(--brand-primary))]";

--- a/projects/rawkode.academy/website/src/components/video/comments.vue
+++ b/projects/rawkode.academy/website/src/components/video/comments.vue
@@ -15,27 +15,27 @@
  retry-text="Retry loading comments"
  />
 
- <div v-else-if="comments.length === 0" class="text-center py-8 text-muted">
- <p>No comments yet. Join the discussion on Discord!</p>
+ <EmptyState
+ v-else-if="comments.length === 0"
+ title="No comments yet."
+ body="Be the first to start the discussion."
+ >
+ <template v-if="discordInviteUrl" #actions>
  <a
- v-if="discordInviteUrl"
  :href="discordInviteUrl"
  target="_blank"
  rel="noopener noreferrer"
- class="inline-flex items-center mt-2 text-primary hover:text-primary/90"
  >
- Join the discussion on Discord
- <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
- <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002-2v-2M14 4h6m0 0v6m0-6L10 14"></path>
- </svg>
+ Join the discussion on Discord →
  </a>
- </div>
+ </template>
+ </EmptyState>
 
  <div v-else class="space-y-4">
  <div
  v-for="comment in comments"
  :key="comment.id"
- class="bg-white dark:bg-gray-800 border border-surface rounded-sm p-4"
+ class="bg-[var(--surface-card)] border border-surface rounded-sm p-4"
  >
  <div class="flex items-start space-x-3">
  <div class="flex-shrink-0">
@@ -93,6 +93,7 @@
 import { onMounted, ref } from "vue";
 import SkeletonComment from "@/components/common/SkeletonComment.vue";
 import ErrorState from "@/components/common/ErrorState.vue";
+import EmptyState from "@/components/ui/EmptyState.vue";
 import { handleApiResponse, getErrorMessage } from "@/utils/error-handler";
 
 interface Comment {

--- a/projects/rawkode.academy/website/src/components/video/transcript.vue
+++ b/projects/rawkode.academy/website/src/components/video/transcript.vue
@@ -8,7 +8,7 @@
  type="text"
  placeholder="Search transcript..."
  aria-label="Search transcript"
- class="w-full px-4 py-2 pl-10 border border-surface rounded-sm bg-white dark:bg-gray-800 text-primary-content focus-ring"
+ class="w-full px-4 py-2 pl-10 border border-surface rounded-sm bg-[var(--surface-card)] text-primary-content focus-ring"
  />
  <svg
  class="absolute left-3 top-2.5 w-5 h-5 text-muted"

--- a/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
+++ b/projects/rawkode.academy/website/src/components/video/video-content-tabs.vue
@@ -1,5 +1,6 @@
 <template>
  <div class="paper-card bleed-x-mobile">
+ <h2 class="sr-only">Comments, transcript, and resources</h2>
  <!-- Tab Navigation -->
  <div class="border-b border-subtle relative z-10">
  <!-- Dropdown for Mobile -->
@@ -77,9 +78,10 @@
  role="tabpanel"
  aria-labelledby="video-tab-resources"
  >
- <div v-if="!resources || resources.length === 0" class="prose prose-lg dark:prose-invert max-w-none">
- <p class="text-muted">No resources for this episode yet.</p>
- </div>
+ <EmptyState
+ v-if="!resources || resources.length === 0"
+ title="No resources for this episode yet."
+ />
  <div v-else class="space-y-6">
  <div v-for="group in groupedResources" :key="group.category">
  <h3 class="text-sm font-semibold text-muted uppercase tracking-wider mb-3">
@@ -92,7 +94,7 @@
  :href="resource.url || resource.filePath || '#'"
  :target="resource.type === 'url' ? '_blank' : undefined"
  :rel="resource.type === 'url' ? 'noopener noreferrer' : undefined"
- class="flex items-start gap-3 p-3 rounded-sm bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-smooth group"
+ class="flex items-start gap-3 p-3 rounded-sm bg-[var(--surface-card-muted)] hover:bg-[var(--surface-card)] transition-smooth group"
  >
  <svg
  class="w-5 h-5 mt-0.5 text-muted group-hover:text-primary flex-shrink-0"
@@ -139,6 +141,7 @@
 </template>
 
 <script>
+import EmptyState from "@/components/ui/EmptyState.vue";
 import VideoComments from "./comments.vue";
 import VideoTranscript from "./transcript.vue";
 

--- a/projects/rawkode.academy/website/src/layouts/app.astro
+++ b/projects/rawkode.academy/website/src/layouts/app.astro
@@ -164,6 +164,10 @@ import { ThemeToggle } from "@/components/ui";
 			z-index: 50;
 			background: var(--editorial-paper);
 			border-bottom: 1px solid var(--editorial-hairline);
+			/* Identical on both sides of a cross-document view transition,
+			   so it gets its own group and reads as static chrome instead
+			   of crossfading with the page. */
+			view-transition-name: ed-topbar;
 		}
 
 		.ed-topbar__inner {

--- a/projects/rawkode.academy/website/src/pages/courses/index.astro
+++ b/projects/rawkode.academy/website/src/pages/courses/index.astro
@@ -4,6 +4,7 @@ import CourseCard from "@/components/courses/CourseCard.astro";
 import CoursesHero from "@/components/courses/CoursesHero.astro";
 import CourseItemListJsonLd from "@/components/html/course-itemlist-jsonld.astro";
 import CollectionMasthead from "@/components/ui/CollectionMasthead.astro";
+import EmptyState from "@/components/ui/EmptyState.vue";
 import MLabel from "@/components/ui/MLabel.vue";
 import { getCourseModuleSlug } from "@/utils/course-path";
 import Page from "@/wrappers/page.astro";
@@ -89,8 +90,11 @@ const pageDescription =
 				/>
 			) : (
 				<div class="courses-page__empty">
-					<h2>Courses are on the way</h2>
-					<p>Practical, engineering-first courses are being built now.</p>
+					<EmptyState
+						title="Courses are on the way"
+						body="Practical, engineering-first courses are being built now."
+						align="start"
+					/>
 				</div>
 			)}
 		</section>
@@ -109,8 +113,11 @@ const pageDescription =
 				</div>
 			) : (
 				<div class="courses-page__empty">
-					<h2>More courses launching soon</h2>
-					<p>Kubernetes, platform engineering, and identity deep dives are next.</p>
+					<EmptyState
+						title="More courses launching soon"
+						body="Kubernetes, platform engineering, and identity deep dives are next."
+						align="start"
+					/>
 				</div>
 			)}
 		</section>
@@ -139,8 +146,7 @@ const pageDescription =
 		margin-bottom: 1.25rem;
 	}
 
-	.courses-page__section-head h2,
-	.courses-page__empty h2 {
+	.courses-page__section-head h2 {
 		font-family: var(--font-inter-tight), sans-serif;
 		font-size: clamp(1.375rem, 2vw, 1.875rem);
 		font-weight: 700;
@@ -157,12 +163,6 @@ const pageDescription =
 
 	.courses-page__empty {
 		padding: 2rem var(--space-section-pad-x);
-	}
-
-	.courses-page__empty p {
-		font-family: var(--font-inter-tight), sans-serif;
-		color: var(--editorial-ink-soft);
-		margin: 0.5rem 0 0;
 	}
 
 	@media (max-width: 720px) {

--- a/projects/rawkode.academy/website/src/pages/games/secret-of-kubernetes-island/index.astro
+++ b/projects/rawkode.academy/website/src/pages/games/secret-of-kubernetes-island/index.astro
@@ -9,7 +9,7 @@ const disableAuth = DISABLE_GAME_AUTH === "true";
 	title="Secret of Kubernetes Island"
 	description="A verbal combat game where you breach Kubernetes clusters one insult at a time"
 >
-	<div class="game-wrapper bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950">
+	<div class="game-wrapper bg-[var(--surface-base)]">
 		<div id="game-root" data-disable-auth={disableAuth ? "true" : "false"}></div>
 	</div>
 </PageWrapper>

--- a/projects/rawkode.academy/website/src/pages/people/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/people/[id].astro
@@ -277,7 +277,7 @@ const relMeUrls = [
  <div class="flex flex-col md:flex-row items-center md:items-start gap-8 md:gap-12">
  <!-- Avatar -->
  <div class="flex-shrink-0">
- <div class="w-40 h-40 md:w-48 md:h-48 rounded-full overflow-hidden border-4 border-white/50 dark:border-gray-700/50 ">
+ <div class="w-40 h-40 md:w-48 md:h-48 rounded-full overflow-hidden border-4 border-[var(--surface-border-strong)] ">
  <img
  src={person.data.avatarUrl ?? '/apple-touch-icon.png'}
  alt={person.data.name}
@@ -307,7 +307,7 @@ const relMeUrls = [
  href={link.url}
  target="_blank"
  rel="me noopener noreferrer"
- class="p-3 rounded-full bg-gray-100 dark:bg-gray-800 text-muted hover:bg-primary hover:text-white dark:hover:bg-primary dark:hover:text-white transition-card shadow-sm "
+ class="p-3 rounded-full bg-[var(--surface-card-muted)] text-muted hover:bg-primary hover:text-white dark:hover:bg-primary dark:hover:text-white transition-card shadow-sm "
  aria-label={link.name}
  >
  <svg

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -10,6 +10,8 @@ import FilterRail from "@/components/read/FilterRail.astro";
 import ArticleGridItem from "@/components/read/ArticleGridItem.astro";
 import ReadFooter from "@/components/read/ReadFooter.astro";
 import MLabel from "@/components/ui/MLabel.vue";
+import EmptyState from "@/components/ui/EmptyState.vue";
+import PagerStrip from "@/components/ui/PagerStrip.astro";
 
 import { calculateReadingTime } from "@/utils/reading-time";
 import { getTypeBadgeConfig } from "@/utils/article-types";
@@ -71,17 +73,32 @@ const visibleArticles = allArticles.filter(
 	(article) => matchesType(article) && matchesTopic(article),
 );
 
+const page = Math.max(
+	1,
+	parseInt(Astro.url.searchParams.get("page") || "1", 10) || 1,
+);
+const articlesPerPage = 12;
+
 const readHref = (
-	overrides: { type?: string | undefined; topic?: string | undefined } = {},
+	overrides: {
+		type?: string | undefined;
+		topic?: string | undefined;
+		page?: number;
+	} = {},
 ) => {
 	const type = "type" in overrides ? overrides.type : selectedType;
 	const topic = "topic" in overrides ? overrides.topic : selectedTopic;
+	// Changing a filter always resets to page 1; only the pager carries pages.
+	const targetPage = overrides.page ?? 1;
 	const params = new URLSearchParams();
 	if (type) params.set("type", type);
 	if (topic) params.set("topic", topic);
+	if (targetPage > 1) params.set("page", String(targetPage));
 	const query = params.toString();
 	return `/read${query ? `?${query}` : ""}`;
 };
+
+const readPathFor = (targetPage: number) => readHref({ page: targetPage });
 
 const formatTopicLabel = (id: string) =>
 	id.replace(/[-_]/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
@@ -141,15 +158,25 @@ const activeTopicIndex = selectedTopic
 	: 0;
 
 // ─── Featured + grid ───────────────────────────────────────────
+// The featured article only fronts page 1; later pages are grid-only.
 
-const featured =
+const featuredCandidate =
 	visibleArticles.find((article) => article.data.cover) ?? visibleArticles[0];
+const featured = page === 1 ? featuredCandidate : undefined;
 const featuredIndex = featured
 	? allArticles.findIndex((article) => article.id === featured.id)
 	: -1;
-const rest = featured
-	? visibleArticles.filter((article) => article.id !== featured.id)
-	: [];
+// The candidate stays out of the grid on every page so page boundaries
+// don't shift between page 1 (featured rendered) and later pages.
+const gridArticles = visibleArticles.filter(
+	(article) => !featuredCandidate || article.id !== featuredCandidate.id,
+);
+const totalPages = Math.max(1, Math.ceil(gridArticles.length / articlesPerPage));
+const pagedArticles = gridArticles.slice(
+	(page - 1) * articlesPerPage,
+	page * articlesPerPage,
+);
+const hasNextPage = page < totalPages;
 const featuredAuthors = featured ? await getEntries(featured.data.authors) : [];
 
 // ─── Helpers ───────────────────────────────────────────────────
@@ -185,8 +212,9 @@ const dispatchNumForArticle = (article: (typeof allArticles)[number]) =>
 	);
 
 // Pre-resolve authors for the grid (Astro can't await in JSX iteration cleanly).
+// Only the current page's slice — not the whole archive.
 const restWithMeta = await Promise.all(
-	rest.map(async (article) => ({
+	pagedArticles.map(async (article) => ({
 		article,
 		dispatchNum: dispatchNumForArticle(article),
 		author: await articleAuthorName(article),
@@ -208,8 +236,10 @@ const pageDescription =
 
 <Page title={pageTitle} description={pageDescription} pageType="CollectionPage">
 	<Fragment slot="extra-head">
-		{isFiltered && <meta name="robots" content="noindex,follow" />}
-		{!isFiltered && (
+		{(isFiltered || page > 1) && <meta name="robots" content="noindex,follow" />}
+		{page > 1 && <link rel="prev" href={readPathFor(page - 1)} />}
+		{hasNextPage && <link rel="next" href={readPathFor(page + 1)} />}
+		{!isFiltered && page === 1 && (
 			<ArticleItemListJsonLd
 				articles={allArticles}
 				listUrl={new URL("/read", Astro.site ?? Astro.url).href}
@@ -278,8 +308,21 @@ const pageDescription =
 
 		{visibleArticles.length === 0 && (
 			<div class="read-empty">
-				<p>No articles match these filters.</p>
-				<a href="/read">Browse all articles →</a>
+				<EmptyState title="No articles match these filters.">
+					<Fragment slot="actions">
+						<a href="/read">Browse all articles →</a>
+					</Fragment>
+				</EmptyState>
+			</div>
+		)}
+
+		{visibleArticles.length > 0 && pagedArticles.length === 0 && (
+			<div class="read-empty">
+				<EmptyState title="No more articles on this page.">
+					<Fragment slot="actions">
+						<a href={readHref()}>Back to page one →</a>
+					</Fragment>
+				</EmptyState>
 			</div>
 		)}
 
@@ -303,6 +346,18 @@ const pageDescription =
 				/>
 			))}
 		</div>
+
+		{totalPages > 1 && (
+			<div class="read-pager">
+				<PagerStrip
+					page={page}
+					totalPages={totalPages}
+					prevHref={page > 1 ? readPathFor(page - 1) : undefined}
+					nextHref={hasNextPage ? readPathFor(page + 1) : undefined}
+					ariaLabel="Article pages"
+				/>
+			</div>
+		)}
 
 		<ReadFooter />
 	</div>
@@ -346,32 +401,7 @@ const pageDescription =
 	}
 
 	.read-empty {
-		padding: 3rem 2.5rem;
-		text-align: center;
-	}
-
-	.read-empty p {
-		margin: 0 0 0.75rem;
-		font-family: var(--font-instrument-serif), serif;
-		font-size: 1.5rem;
-		font-style: italic;
-		color: var(--editorial-ink-soft);
-	}
-
-	.read-empty a {
-		font-family: var(--font-jetbrains-mono), monospace;
-		font-size: 0.75rem;
-		font-weight: 600;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--editorial-spruce);
-		text-decoration: none;
-	}
-
-	.read-empty a:hover {
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 0.35em;
+		padding: 1.5rem 2.5rem;
 	}
 
 	.read-grid {
@@ -379,6 +409,12 @@ const pageDescription =
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 		gap: 0;
 		padding: 1.5rem 2.5rem 4rem;
+	}
+
+	.read-pager {
+		display: flex;
+		justify-content: center;
+		padding: 0 2.5rem 3rem;
 	}
 
 	@media (max-width: 960px) {

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -73,7 +73,7 @@ const visibleArticles = allArticles.filter(
 	(article) => matchesType(article) && matchesTopic(article),
 );
 
-const page = Math.max(
+const requestedPage = Math.max(
 	1,
 	parseInt(Astro.url.searchParams.get("page") || "1", 10) || 1,
 );
@@ -162,16 +162,19 @@ const activeTopicIndex = selectedTopic
 
 const featuredCandidate =
 	visibleArticles.find((article) => article.data.cover) ?? visibleArticles[0];
-const featured = page === 1 ? featuredCandidate : undefined;
-const featuredIndex = featured
-	? allArticles.findIndex((article) => article.id === featured.id)
-	: -1;
 // The candidate stays out of the grid on every page so page boundaries
 // don't shift between page 1 (featured rendered) and later pages.
 const gridArticles = visibleArticles.filter(
 	(article) => !featuredCandidate || article.id !== featuredCandidate.id,
 );
 const totalPages = Math.max(1, Math.ceil(gridArticles.length / articlesPerPage));
+// Clamp out-of-range requests so ?page=999 renders the last real page
+// instead of an empty grid with prev/next links into a phantom crawl space.
+const page = Math.min(requestedPage, totalPages);
+const featured = page === 1 ? featuredCandidate : undefined;
+const featuredIndex = featured
+	? allArticles.findIndex((article) => article.id === featured.id)
+	: -1;
 const pagedArticles = gridArticles.slice(
 	(page - 1) * articlesPerPage,
 	page * articlesPerPage,
@@ -311,16 +314,6 @@ const pageDescription =
 				<EmptyState title="No articles match these filters.">
 					<Fragment slot="actions">
 						<a href="/read">Browse all articles →</a>
-					</Fragment>
-				</EmptyState>
-			</div>
-		)}
-
-		{visibleArticles.length > 0 && pagedArticles.length === 0 && (
-			<div class="read-empty">
-				<EmptyState title="No more articles on this page.">
-					<Fragment slot="actions">
-						<a href={readHref()}>Back to page one →</a>
 					</Fragment>
 				</EmptyState>
 			</div>

--- a/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
+++ b/projects/rawkode.academy/website/src/pages/resources/kubernetes/1.35-cheatsheet.astro
@@ -71,7 +71,7 @@ const pageDescription =
 				</div>
 
 				<!-- Release Info Banner -->
-				<div class="bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-sm sm:rounded-sm p-4 sm:p-6 mb-6 sm:mb-8 border border-blue-200 dark:border-blue-800/50">
+				<div class="bg-[var(--surface-card-muted)] rounded-sm sm:rounded-sm p-4 sm:p-6 mb-6 sm:mb-8 border border-blue-200 dark:border-blue-800/50">
 					<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
 						<div>
 							<h2 class="text-base sm:text-lg font-semibold text-primary-content">Release Date: December 17, 2025</h2>
@@ -104,12 +104,12 @@ const pageDescription =
 								<!-- cgroup v1 -->
 								<div>
 									<h4 class="font-semibold text-primary-content mb-2 text-sm sm:text-base">cgroup v1 Support Disabled by Default</h4>
-									<p class="text-muted text-xs sm:text-sm mb-3">The Kubelet config <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-xs">failCgroupV1</code> now defaults to <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-xs">true</code>. If a node boots with legacy cgroup v1 hierarchy, the Kubelet <strong>crashes immediately on startup</strong>.</p>
-									<div class="bg-gray-900 rounded-sm p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto space-y-1 sm:space-y-2">
+									<p class="text-muted text-xs sm:text-sm mb-3">The Kubelet config <code class="bg-[var(--surface-card-muted)] px-1 rounded text-xs">failCgroupV1</code> now defaults to <code class="bg-[var(--surface-card-muted)] px-1 rounded text-xs">true</code>. If a node boots with legacy cgroup v1 hierarchy, the Kubelet <strong>crashes immediately on startup</strong>.</p>
+									<div class="bg-[var(--terminal-bg)] rounded-sm p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto space-y-1 sm:space-y-2">
 										<div>
-											<p class="text-gray-400"># Check if your nodes use cgroups v2</p>
+											<p class="text-[var(--terminal-text-dim)]"># Check if your nodes use cgroups v2</p>
 											<p class="text-green-400 break-all">stat -fc %T /sys/fs/cgroup/</p>
-											<p class="text-gray-400"># Returns: cgroup2fs (v2) or tmpfs (v1 - WILL FAIL!)</p>
+											<p class="text-[var(--terminal-text-dim)]"># Returns: cgroup2fs (v2) or tmpfs (v1 - WILL FAIL!)</p>
 										</div>
 									</div>
 								</div>
@@ -118,8 +118,8 @@ const pageDescription =
 								<div>
 									<h4 class="font-semibold text-primary-content mb-2 text-sm sm:text-base">containerd 1.x End of Support</h4>
 									<p class="text-muted text-xs sm:text-sm mb-3">Kubernetes 1.35 is the <strong>last version</strong> to support containerd 1.7. You must upgrade to containerd 2.0+ before upgrading to Kubernetes 1.36.</p>
-									<div class="bg-gray-900 rounded-sm p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto">
-										<p class="text-gray-400"># Monitor affected nodes with this metric</p>
+									<div class="bg-[var(--terminal-bg)] rounded-sm p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto">
+										<p class="text-[var(--terminal-text-dim)]"># Monitor affected nodes with this metric</p>
 										<p class="text-green-400">kubelet_cri_losing_support</p>
 									</div>
 								</div>
@@ -127,7 +127,7 @@ const pageDescription =
 								<!-- Image Pull -->
 								<div>
 									<h4 class="font-semibold text-primary-content mb-2 text-sm sm:text-base">Image Pull Credential Verification (Enabled by Default)</h4>
-									<p class="text-muted text-xs sm:text-sm mb-3">The <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-xs">KubeletEnsureSecretPulledImages</code> feature is now enabled. Pods must have valid credentials for cached images.</p>
+									<p class="text-muted text-xs sm:text-sm mb-3">The <code class="bg-[var(--surface-card-muted)] px-1 rounded text-xs">KubeletEnsureSecretPulledImages</code> feature is now enabled. Pods must have valid credentials for cached images.</p>
 								</div>
 							</div>
 						</div>
@@ -144,7 +144,7 @@ const pageDescription =
 										<div class="min-w-0">
 											<strong class="text-sm sm:text-base">In-place Pod Resource Updates</strong>
 											<p class="text-xs sm:text-sm text-muted mt-1">Adjust CPU and memory without restarting pods! No more recreating stateful workloads for vertical scaling.</p>
-											<div class="bg-gray-900 rounded-sm p-2 sm:p-3 mt-2 font-mono text-[10px] sm:text-xs overflow-x-auto">
+											<div class="bg-[var(--terminal-bg)] rounded-sm p-2 sm:p-3 mt-2 font-mono text-[10px] sm:text-xs overflow-x-auto">
 												<p class="text-green-400 whitespace-nowrap">kubectl patch pod my-pod --subresource='resize' -p '&#123;"spec":&#123;"containers":[&#123;"name":"app","resources":&#123;"requests":&#123;"memory":"512Mi"&#125;&#125;&#125;]&#125;&#125;'</p>
 											</div>
 										</div>
@@ -196,7 +196,7 @@ const pageDescription =
 										<span class="text-blue-500 mt-0.5 sm:mt-1 font-bold flex-shrink-0">β</span>
 										<div class="min-w-0">
 											<strong class="text-sm sm:text-base">User Namespaces Support</strong>
-											<p class="text-xs sm:text-sm text-muted mt-1">Run containers as UID 0 inside, but unprivileged on the host. Set <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-xs">hostUsers: false</code> in your pod spec.</p>
+											<p class="text-xs sm:text-sm text-muted mt-1">Run containers as UID 0 inside, but unprivileged on the host. Set <code class="bg-[var(--surface-card-muted)] px-1 rounded text-xs">hostUsers: false</code> in your pod spec.</p>
 										</div>
 									</li>
 									<li class="flex items-start gap-2 sm:gap-3">
@@ -218,23 +218,23 @@ const pageDescription =
 							<div class="bg-purple-50 dark:bg-purple-900/20 rounded-sm sm:rounded-sm p-4 sm:p-6 border border-purple-200 dark:border-purple-800/50">
 								<ul class="space-y-3">
 									<li class="flex items-start gap-2 sm:gap-3">
-										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
-										<span class="text-primary-content text-xs sm:text-sm"><strong>Verify cgroups v2</strong> - Run <code class="bg-gray-200 dark:bg-gray-700 px-1 rounded text-xs break-all">stat -fc %T /sys/fs/cgroup/</code> on all nodes</span>
+										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-[var(--surface-border)] text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
+										<span class="text-primary-content text-xs sm:text-sm"><strong>Verify cgroups v2</strong> - Run <code class="bg-[var(--surface-card-muted)] px-1 rounded text-xs break-all">stat -fc %T /sys/fs/cgroup/</code> on all nodes</span>
 									</li>
 									<li class="flex items-start gap-2 sm:gap-3">
-										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
+										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-[var(--surface-border)] text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
 										<span class="text-primary-content text-xs sm:text-sm"><strong>Check containerd version</strong> - Must be 1.7+ (2.0+ recommended)</span>
 									</li>
 									<li class="flex items-start gap-2 sm:gap-3">
-										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
+										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-[var(--surface-border)] text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
 										<span class="text-primary-content text-xs sm:text-sm"><strong>Verify image pull secrets</strong> - Pods need valid credentials for cached images</span>
 									</li>
 									<li class="flex items-start gap-2 sm:gap-3">
-										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
+										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-[var(--surface-border)] text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
 										<span class="text-primary-content text-xs sm:text-sm"><strong>Test in staging</strong> - Upgrade staging cluster first</span>
 									</li>
 									<li class="flex items-start gap-2 sm:gap-3">
-										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
+										<input type="checkbox" class="w-4 h-4 sm:w-5 sm:h-5 rounded border-[var(--surface-border)] text-purple-600 focus:ring-purple-500 mt-0.5 flex-shrink-0" />
 										<span class="text-primary-content text-xs sm:text-sm"><strong>Backup etcd</strong> - Always before any upgrade</span>
 									</li>
 								</ul>
@@ -244,32 +244,32 @@ const pageDescription =
 						<!-- Feature Gates -->
 						<div>
 							<h3 class="text-lg sm:text-xl font-semibold text-primary-content mb-3 sm:mb-4 flex items-center gap-2">
-								<span class="text-gray-500">⚙️</span> Key Feature Gates
+								<span class="text-muted">⚙️</span> Key Feature Gates
 							</h3>
 							<!-- Mobile: Card view -->
 							<div class="block sm:hidden space-y-3">
-								<div class="bg-gray-50 dark:bg-gray-800/50 rounded-sm p-3 border border-surface">
+								<div class="bg-[var(--surface-card-muted)] rounded-sm p-3 border border-surface">
 									<div class="flex items-center justify-between mb-1">
 										<span class="px-2 py-0.5 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 font-medium">GA</span>
 										<span class="text-xs text-muted">true (locked)</span>
 									</div>
 									<p class="font-mono text-xs text-primary-content break-all">InPlacePodVerticalScaling</p>
 								</div>
-								<div class="bg-gray-50 dark:bg-gray-800/50 rounded-sm p-3 border border-surface">
+								<div class="bg-[var(--surface-card-muted)] rounded-sm p-3 border border-surface">
 									<div class="flex items-center justify-between mb-1">
 										<span class="px-2 py-0.5 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 font-medium">GA</span>
 										<span class="text-xs text-muted">true (locked)</span>
 									</div>
 									<p class="font-mono text-xs text-primary-content break-all">StructuredAuthenticationConfiguration</p>
 								</div>
-								<div class="bg-gray-50 dark:bg-gray-800/50 rounded-sm p-3 border border-surface">
+								<div class="bg-[var(--surface-card-muted)] rounded-sm p-3 border border-surface">
 									<div class="flex items-center justify-between mb-1">
 										<span class="px-2 py-0.5 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-medium">Beta</span>
 										<span class="text-xs text-muted">true</span>
 									</div>
 									<p class="font-mono text-xs text-primary-content break-all">UserNamespacesSupport</p>
 								</div>
-								<div class="bg-gray-50 dark:bg-gray-800/50 rounded-sm p-3 border border-surface">
+								<div class="bg-[var(--surface-card-muted)] rounded-sm p-3 border border-surface">
 									<div class="flex items-center justify-between mb-1">
 										<span class="px-2 py-0.5 rounded text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-medium">Beta</span>
 										<span class="text-xs text-muted">true</span>
@@ -333,7 +333,7 @@ const pageDescription =
 							</a>
 							<a
 								href="/watch"
-								class="inline-flex items-center justify-center px-5 sm:px-6 py-2.5 sm:py-3 rounded-sm sm:rounded-sm border-2 border-surface text-primary-content text-sm sm:text-base font-semibold hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+								class="inline-flex items-center justify-center px-5 sm:px-6 py-2.5 sm:py-3 rounded-sm sm:rounded-sm border-2 border-surface text-primary-content text-sm sm:text-base font-semibold hover:bg-[var(--surface-card-muted)] transition-colors"
 							>
 								Watch Kubernetes Videos
 							</a>

--- a/projects/rawkode.academy/website/src/pages/search.astro
+++ b/projects/rawkode.academy/website/src/pages/search.astro
@@ -2,6 +2,7 @@
 import { env } from "cloudflare:workers";
 import MLabel from "@/components/ui/MLabel.vue";
 import EditorialButton from "@/components/ui/EditorialButton.vue";
+import EmptyState from "@/components/ui/EmptyState.vue";
 import Page from "@/wrappers/page.astro";
 import { captureServerEvent, getDistinctId } from "@/server/analytics";
 import { shouldCaptureSearchAnalytics } from "@/lib/search-analytics";
@@ -190,8 +191,7 @@ const suggestions = [
 				</div>
 			) : ranked.length === 0 ? (
 				<div class="search-page__empty">
-					<MLabel>Nothing matched "{searchQuery}".</MLabel>
-					<p class="search-page__empty-body">
+					<EmptyState title={`Nothing matched "${searchQuery}".`}>
 						{activeType ? (
 							<>
 								No {SEARCH_TYPE_LABELS[activeType].toLowerCase()} matched. Try{" "}
@@ -203,7 +203,7 @@ const suggestions = [
 								<a href="/watch">the full video library</a>.
 							</>
 						)}
-					</p>
+					</EmptyState>
 				</div>
 			) : (
 				<div class="search-page__groups">
@@ -464,19 +464,6 @@ const suggestions = [
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
-	}
-
-	.search-page__empty-body {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.9375rem;
-		color: var(--editorial-ink-soft);
-		margin: 0;
-	}
-
-	.search-page__empty a {
-		color: var(--editorial-spruce);
-		text-decoration: underline;
-		text-underline-offset: 2px;
 	}
 
 	@media (max-width: 720px) {

--- a/projects/rawkode.academy/website/src/pages/technology/[id].astro
+++ b/projects/rawkode.academy/website/src/pages/technology/[id].astro
@@ -382,7 +382,7 @@ const cncfStatusColors: Record<string, string> = {
 	graduated:
 		"bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-800",
 	archived:
-		"bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300 border-surface",
+		"bg-[var(--surface-card-muted)] text-secondary-content border-surface",
 };
 
 // Check if we have community links to display

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -18,6 +18,7 @@ import { resolveTechnologyIconUrl } from "@/utils/resolve-technology-icon";
 import { normalizeTechnologyReferences } from "@/utils/normalize-technology-refs";
 import { getVideosForTechnology } from "@/utils/get-videos-for-technology";
 import { buildWatchVideoSeoText } from "@/utils/watch-video-seo";
+import { videoTransitionName } from "@/utils/view-transition-name";
 import { getVideoThumbnailUrl } from "@/lib/video-thumbnail";
 import { buildVideoClips, type VideoClip } from "@/lib/video-clips";
 import { formatVideoRuntimeLabel } from "@/lib/video-runtime";
@@ -462,7 +463,10 @@ const watchStatusLabel = isUpcomingLive
 				)}
 			</aside>
 
-			<div class="watch-detail__player-wrap">
+			<div
+				class="watch-detail__player-wrap"
+				style={`view-transition-name: ${videoTransitionName(video.data.slug)}`}
+			>
 				<input
 					id="watch-detail-player-state"
 					class="watch-detail__player-state"

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -571,8 +571,9 @@ const watchStatusLabel = isUpcomingLive
 			)}
 
 			{techEntries.length > 0 && (
-				<section class="watch-detail__tech">
-					<MLabel tone="spruce">Technologies featured</MLabel>
+				<section class="watch-detail__tech" aria-labelledby="watch-detail-tech-heading">
+					<h2 id="watch-detail-tech-heading" class="sr-only">Technologies featured</h2>
+					<MLabel tone="spruce" aria-hidden="true">Technologies featured</MLabel>
 					<div class="watch-detail__tech-grid">
 						{techEntries.map((tech) => (
 							<a

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -19,6 +19,7 @@ import SeriesFilter from "@/components/video/SeriesFilter.astro";
 import VideoGridItem from "@/components/video/VideoGridItem.astro";
 import ContinueWatchingRail from "@/components/video/ContinueWatchingRail.astro";
 import MLabel from "@/components/ui/MLabel.vue";
+import PagerStrip from "@/components/ui/PagerStrip.astro";
 
 const user = Astro.locals.user;
 
@@ -505,19 +506,12 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 				<a class="watch-footer__link" href="/api/feeds/videos.json">JSON Feed</a> ·
 				<a class="watch-footer__link" href="/watch">All videos</a>
 			</MLabel>
-			<div class="watch-footer__pager">
-				{page > 1 && (
-					<a class="watch-footer__pager-btn" href={watchPathFor(page - 1)}>
-						<MLabel tone="ink">← Previous</MLabel>
-					</a>
-				)}
-				<MLabel>Page {page}</MLabel>
-				{hasNextPage && (
-					<a class="watch-footer__pager-btn" href={watchPathFor(page + 1)}>
-						<MLabel tone="ink">Next →</MLabel>
-					</a>
-				)}
-			</div>
+			<PagerStrip
+				page={page}
+				prevHref={page > 1 ? watchPathFor(page - 1) : undefined}
+				nextHref={hasNextPage ? watchPathFor(page + 1) : undefined}
+				ariaLabel="Video pages"
+			/>
 		</footer>
 	</div>
 </Page>
@@ -731,20 +725,6 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 		text-decoration-color: var(--editorial-hairline-strong);
 	}
 	.watch-footer__link:hover { text-decoration-color: currentColor; }
-
-	.watch-footer__pager {
-		display: flex;
-		gap: 1rem;
-		align-items: center;
-	}
-
-	.watch-footer__pager-btn {
-		display: inline-flex;
-		align-items: center;
-		min-height: 2.75rem;
-		padding: 0 0.5rem;
-		text-decoration: none;
-	}
 
 	@media (max-width: 960px) {
 		.watch-grid {

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -41,7 +41,7 @@ if (user) {
 
 Astro.response.headers.set("X-Build-Time", new Date().toISOString());
 
-const page = Math.max(
+const requestedPage = Math.max(
 	1,
 	parseInt(Astro.url.searchParams.get("page") || "1", 10) || 1,
 );
@@ -130,6 +130,13 @@ const sortedVideos =
 			: visibleVideos;
 
 // Pagination. Page one promotes the first visible video, then starts the grid after it.
+// Out-of-range requests clamp to the last real page so ?page=999 never
+// renders an empty grid with prev/next links into a phantom crawl space.
+const totalPages = Math.max(
+	1,
+	Math.ceil((sortedVideos.length - 1) / videosPerPage),
+);
+const page = Math.min(requestedPage, totalPages);
 const featuredVideo = page === 1 ? (sortedVideos[0] ?? null) : null;
 const start = page === 1 ? 1 : 1 + (page - 1) * videosPerPage;
 const end = start + videosPerPage;
@@ -511,6 +518,7 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 			</MLabel>
 			<PagerStrip
 				page={page}
+				totalPages={totalPages}
 				prevHref={page > 1 ? watchPathFor(page - 1) : undefined}
 				nextHref={hasNextPage ? watchPathFor(page + 1) : undefined}
 				ariaLabel="Video pages"

--- a/projects/rawkode.academy/website/src/pages/watch/index.astro
+++ b/projects/rawkode.academy/website/src/pages/watch/index.astro
@@ -11,6 +11,7 @@ import { formatStreamingCountdown } from "@/lib/streaming-countdown";
 import { getVideoThumbnailUrl } from "@/lib/video-thumbnail";
 import { resolveTechnologyIconUrl } from "@/utils/resolve-technology-icon";
 import { normalizeTechnologyReferences } from "@/utils/normalize-technology-refs";
+import { videoTransitionName } from "@/utils/view-transition-name";
 
 import VideoMasthead from "@/components/video/VideoMasthead.astro";
 import VideoHero from "@/components/video/VideoHero.astro";
@@ -432,6 +433,7 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 						: new Date(featuredVideo.publishedAt),
 				)}
 				primaryCtaLabel="Watch session →"
+				vtName={videoTransitionName(featuredVideo.slug)}
 			/>
 		)}
 
@@ -496,6 +498,7 @@ const technologyLogosFor = (video: (typeof upcomingVideos)[number]) =>
 							? v.publishedAt
 							: new Date(v.publishedAt),
 					)}
+					vtName={videoTransitionName(v.slug)}
 				/>
 			))}
 		</div>

--- a/projects/rawkode.academy/website/src/stories/DesignTokens.stories.tsx
+++ b/projects/rawkode.academy/website/src/stories/DesignTokens.stories.tsx
@@ -24,8 +24,8 @@ const ColorSwatch = ({
 			className="w-24 h-24 rounded-lg shadow-md border border-surface mb-2"
 			style={{ backgroundColor: color }}
 		/>
-		<p className="text-sm font-medium text-gray-900 dark:text-white">{name}</p>
-		<code className="text-xs text-gray-500 dark:text-gray-400">{value}</code>
+		<p className="text-sm font-medium text-primary-content">{name}</p>
+		<code className="text-xs text-muted">{value}</code>
 	</div>
 );
 
@@ -39,34 +39,34 @@ const TextSample = ({
 	className: string;
 }) => (
 	<div className="space-y-2">
-		<h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+		<h3 className="text-lg font-semibold text-primary-content">
 			{name}
 		</h3>
 		<p
-			className={`${className} text-gray-700 dark:text-gray-300`}
+			className={`${className} text-secondary-content`}
 			style={{ fontFamily: font }}
 		>
 			The quick brown fox jumps over the lazy dog
 		</p>
 		<p
-			className={`${className} text-2xl text-gray-900 dark:text-white`}
+			className={`${className} text-2xl text-primary-content`}
 			style={{ fontFamily: font }}
 		>
 			ABCDEFGHIJKLMNOPQRSTUVWXYZ
 		</p>
 		<p
-			className={`${className} text-2xl text-gray-900 dark:text-white`}
+			className={`${className} text-2xl text-primary-content`}
 			style={{ fontFamily: font }}
 		>
 			abcdefghijklmnopqrstuvwxyz
 		</p>
 		<p
-			className={`${className} text-xl text-gray-900 dark:text-white`}
+			className={`${className} text-xl text-primary-content`}
 			style={{ fontFamily: font }}
 		>
 			0123456789
 		</p>
-		<code className="text-xs text-gray-500 dark:text-gray-400">{font}</code>
+		<code className="text-xs text-muted">{font}</code>
 	</div>
 );
 
@@ -74,7 +74,7 @@ export const Colors: Story = {
 	render: () => (
 		<div className="space-y-8">
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Brand Colors
 				</h2>
 				<div className="grid grid-cols-2 md:grid-cols-4 gap-6">
@@ -86,20 +86,40 @@ export const Colors: Story = {
 			</div>
 
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
-					Neutral Colors
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
+					Editorial Neutrals
 				</h2>
 				<div className="grid grid-cols-2 md:grid-cols-5 gap-6">
-					<ColorSwatch color="#111827" name="Black" value="#111827" />
-					<ColorSwatch color="#374151" name="Gray 700" value="#374151" />
-					<ColorSwatch color="#6B7280" name="Gray 500" value="#6B7280" />
-					<ColorSwatch color="#D1D5DB" name="Gray 300" value="#D1D5DB" />
-					<ColorSwatch color="#FFFFFF" name="White" value="#FFFFFF" />
+					<ColorSwatch
+						color="var(--editorial-ink)"
+						name="Ink"
+						value="var(--editorial-ink)"
+					/>
+					<ColorSwatch
+						color="var(--editorial-ink-soft)"
+						name="Ink soft"
+						value="var(--editorial-ink-soft)"
+					/>
+					<ColorSwatch
+						color="var(--editorial-ink-mute)"
+						name="Ink mute"
+						value="var(--editorial-ink-mute)"
+					/>
+					<ColorSwatch
+						color="var(--editorial-paper-deep)"
+						name="Paper deep"
+						value="var(--editorial-paper-deep)"
+					/>
+					<ColorSwatch
+						color="var(--editorial-paper)"
+						name="Paper"
+						value="var(--editorial-paper)"
+					/>
 				</div>
 			</div>
 
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Semantic Colors
 				</h2>
 				<div className="grid grid-cols-2 md:grid-cols-4 gap-6">
@@ -117,7 +137,7 @@ export const Typography: Story = {
 	render: () => (
 		<div className="space-y-8">
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Font Families
 				</h2>
 				<div className="space-y-8">
@@ -140,71 +160,71 @@ export const Typography: Story = {
 			</div>
 
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Type Scale
 				</h2>
 				<div className="space-y-4">
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-xs (12px)
 						</p>
-						<p className="text-xs text-gray-900 dark:text-white">
+						<p className="text-xs text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-sm (14px)
 						</p>
-						<p className="text-sm text-gray-900 dark:text-white">
+						<p className="text-sm text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-base (16px)
 						</p>
-						<p className="text-base text-gray-900 dark:text-white">
+						<p className="text-base text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-lg (18px)
 						</p>
-						<p className="text-lg text-gray-900 dark:text-white">
+						<p className="text-lg text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-xl (20px)
 						</p>
-						<p className="text-xl text-gray-900 dark:text-white">
+						<p className="text-xl text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-2xl (24px)
 						</p>
-						<p className="text-2xl text-gray-900 dark:text-white">
+						<p className="text-2xl text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-3xl (30px)
 						</p>
-						<p className="text-3xl text-gray-900 dark:text-white">
+						<p className="text-3xl text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
 					<div>
-						<p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+						<p className="text-xs text-muted mb-1">
 							text-4xl (36px)
 						</p>
-						<p className="text-4xl text-gray-900 dark:text-white">
+						<p className="text-4xl text-primary-content">
 							The quick brown fox jumps over the lazy dog
 						</p>
 					</div>
@@ -218,21 +238,21 @@ export const Spacing: Story = {
 	render: () => (
 		<div className="space-y-8">
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Spacing Scale
 				</h2>
 				<div className="space-y-4">
 					{[1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 56, 64].map(
 						(size) => (
 							<div key={size} className="flex items-center gap-4">
-								<code className="text-xs text-gray-500 dark:text-gray-400 w-16">
+								<code className="text-xs text-muted w-16">
 									{size}
 								</code>
 								<div
 									className="bg-primary h-4"
 									style={{ width: `${size * 0.25}rem` }}
 								/>
-								<span className="text-sm text-gray-600 dark:text-gray-400">
+								<span className="text-sm text-secondary-content">
 									{size * 0.25}rem / {size * 4}px
 								</span>
 							</div>
@@ -248,48 +268,48 @@ export const Shadows: Story = {
 	render: () => (
 		<div className="space-y-8">
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Box Shadows
 				</h2>
 				<div className="grid grid-cols-1 md:grid-cols-3 gap-6">
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow-sm flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow-sm flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow-sm
 							</span>
 						</div>
 					</div>
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow
 							</span>
 						</div>
 					</div>
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow-md flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow-md flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow-md
 							</span>
 						</div>
 					</div>
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow-lg flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow-lg flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow-lg
 							</span>
 						</div>
 					</div>
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow-xl flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow-xl flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow-xl
 							</span>
 						</div>
 					</div>
 					<div className="space-y-2">
-						<div className="w-full h-24 bg-white dark:bg-gray-800 rounded-lg shadow-2xl flex items-center justify-center">
-							<span className="text-sm text-gray-600 dark:text-gray-400">
+						<div className="w-full h-24 bg-[var(--surface-card)] rounded-lg shadow-2xl flex items-center justify-center">
+							<span className="text-sm text-secondary-content">
 								shadow-2xl
 							</span>
 						</div>
@@ -304,55 +324,55 @@ export const BorderRadius: Story = {
 	render: () => (
 		<div className="space-y-8">
 			<div>
-				<h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+				<h2 className="text-2xl font-bold text-primary-content mb-6">
 					Border Radius
 				</h2>
 				<div className="grid grid-cols-2 md:grid-cols-4 gap-6">
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-none mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-none
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-sm mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-sm
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-md mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-md
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-lg mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-lg
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-xl mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-xl
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-2xl mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-2xl
 						</code>
 					</div>
 					<div className="text-center">
 						<div className="w-24 h-24 bg-primary rounded-full mx-auto mb-2" />
-						<code className="text-xs text-gray-500 dark:text-gray-400">
+						<code className="text-xs text-muted">
 							rounded-full
 						</code>
 					</div>

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -256,7 +256,9 @@ html.dark {
 @layer base {
 	/* Editorial heading ramp — h1/h2 in serif italic at display sizes,
 	   h3/h4 in Inter Tight semibold. Negative letter-spacing pulls the
-	   display sizes tight without going into "decorative" territory. */
+	   display sizes tight without going into "decorative" territory.
+	   `text-wrap: balance` evens out multi-line display headings so the
+	   serif italic never strands a one-word orphan line. */
 	h1 {
 		@apply text-4xl md:text-5xl text-primary-content;
 		font-family: var(--font-instrument-serif), serif;
@@ -264,6 +266,7 @@ html.dark {
 		font-weight: 400;
 		line-height: 1.02;
 		letter-spacing: -0.035em;
+		text-wrap: balance;
 	}
 
 	h2 {
@@ -273,6 +276,7 @@ html.dark {
 		font-weight: 400;
 		line-height: 1.05;
 		letter-spacing: -0.025em;
+		text-wrap: balance;
 	}
 
 	h3 {
@@ -281,6 +285,7 @@ html.dark {
 		font-weight: 500;
 		line-height: 1.2;
 		letter-spacing: -0.015em;
+		text-wrap: balance;
 	}
 
 	h4 {

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -122,13 +122,42 @@ html.dark {
 	--text-muted: var(--editorial-ink-mute);
 }
 
+/* Cross-document view transitions — native MPA transitions, no client
+   router. Full page loads still happen (scripts, analytics, and auth all
+   behave exactly as before); supporting browsers crossfade between pages
+   and morph any element whose `view-transition-name` matches across the
+   two documents (video stills → the watch-page player frame). Browsers
+   without support simply navigate. */
+@view-transition {
+	navigation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation-duration: var(--duration-base);
+	animation-timing-function: var(--ease-standard);
+}
+
 /* Honour reduced-motion globally: components opt back in only where a
    motion alternative is genuinely needed. Covers the `scroll-smooth`
-   class on <html>, skeleton pulses, and Vue <transition> fades without
-   per-component guards. */
+   class on <html>, skeleton pulses, view transitions, and Vue
+   <transition> fades without per-component guards. */
 @media (prefers-reduced-motion: reduce) {
 	html {
 		scroll-behavior: auto !important;
+	}
+
+	@view-transition {
+		navigation: none;
+	}
+
+	/* Belt and braces for engines that ignore @view-transition inside a
+	   conditional group: the universal selector below can't reach the
+	   ::view-transition pseudo-tree, so kill its animations explicitly. */
+	::view-transition-group(*),
+	::view-transition-old(*),
+	::view-transition-new(*) {
+		animation: none !important;
 	}
 
 	*,

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -44,6 +44,18 @@
 	--surface-card-muted: oklch(0.18 0.02 60 / 0.04);
 	--surface-border: var(--editorial-hairline);
 	--surface-border-strong: var(--editorial-hairline-strong);
+	/* Skeleton bone — needs to read against both paper and card surfaces,
+	   so it sits between hairline and card-muted in weight. */
+	--surface-skeleton: oklch(0.18 0.02 60 / 0.10);
+
+	/* Theme-invariant terminal chrome. Terminals, WebContainers, and other
+	   "screen within the page" surfaces stay dark in both colour schemes;
+	   they must not flip with --surface-*. */
+	--terminal-bg: oklch(0.16 0.01 280);
+	--terminal-surface: oklch(0.22 0.012 280);
+	--terminal-border: oklch(1 0 0 / 0.12);
+	--terminal-text: oklch(0.92 0.005 85);
+	--terminal-text-dim: oklch(0.68 0.008 85);
 
 	/* Layout Spacing Tokens */
 	--space-page-sm: clamp(1rem, 3vw, 1.75rem);
@@ -101,6 +113,7 @@ html.dark {
 	--surface-overlay: oklch(0.14 0.01 280 / 0.92);
 	--surface-card: var(--editorial-paper-deep);
 	--surface-card-muted: oklch(1 0 0 / 0.04);
+	--surface-skeleton: oklch(1 0 0 / 0.10);
 	--surface-border: var(--editorial-hairline);
 	--surface-border-strong: var(--editorial-hairline-strong);
 

--- a/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
+++ b/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Design-system guard: raw Tailwind gray-* utilities are banned in favour
+ * of the editorial tokens (text-primary-content / text-secondary-content /
+ * text-muted, bg-[var(--surface-*)], border-[var(--surface-border)], the
+ * --terminal-* chrome tokens, …). Grays are cool-hued and drift from the
+ * warm paper/ink palette — worst in dark mode, where gray-900 clashes with
+ * the ink-dark ground. The UnoCSS blocklist in uno.config.ts stops the CSS
+ * from being generated; this test points CI at the offending files.
+ */
+
+const SCAN_ROOTS = ["src", ".storybook"];
+const SCAN_EXTENSIONS = [".astro", ".vue", ".tsx", ".jsx", ".ts", ".js", ".mdx"];
+const SKIP_DIRS = new Set(["node_modules", "dist", ".astro", "generated"]);
+const SKIP_FILES = new Set(["src/tests/design-tokens.test.ts"]);
+
+const BANNED_PATTERN =
+	/(?:bg|text|border|divide|ring|outline|decoration|from|to|via|fill|stroke|placeholder|caret|accent|shadow)-gray-\d+(?:\/\d+)?/g;
+
+// Vitest runs with cwd at the website project root; import.meta.url is not
+// usable here because Vite serves transformed modules behind an /@fs prefix.
+const projectRoot = process.cwd();
+
+function* walk(dir: string): Generator<string> {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			if (!SKIP_DIRS.has(entry.name)) yield* walk(join(dir, entry.name));
+		} else if (SCAN_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+			yield join(dir, entry.name);
+		}
+	}
+}
+
+describe("design tokens", () => {
+	it("uses editorial tokens instead of raw gray-* utilities", () => {
+		const violations: string[] = [];
+
+		for (const root of SCAN_ROOTS) {
+			for (const file of walk(join(projectRoot, root))) {
+				const relPath = relative(projectRoot, file);
+				if (SKIP_FILES.has(relPath)) continue;
+
+				const lines = readFileSync(file, "utf-8").split("\n");
+				lines.forEach((line, index) => {
+					const matches = line.match(BANNED_PATTERN);
+					if (matches) {
+						violations.push(
+							`${relPath}:${index + 1} — ${[...new Set(matches)].join(", ")}`,
+						);
+					}
+				});
+			}
+		}
+
+		expect(
+			violations,
+			`Raw gray-* utilities found. Replace them with editorial tokens ` +
+				`(text-primary-content / text-secondary-content / text-muted, ` +
+				`bg-[var(--surface-*)], border-[var(--surface-border)]):\n` +
+				violations.join("\n"),
+		).toEqual([]);
+	});
+});

--- a/projects/rawkode.academy/website/src/utils/article-types.ts
+++ b/projects/rawkode.academy/website/src/utils/article-types.ts
@@ -55,8 +55,8 @@ export const typeBadgeConfig = {
 		icon: "M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z", // Newspaper icon
 	},
 	"case-study": {
-		bg: "bg-gray-100 dark:bg-gray-200",
-		text: "text-gray-800 dark:text-gray-900",
+		bg: "bg-[var(--surface-card-muted)]",
+		text: "text-primary-content",
 		label: "Case Study",
 		icon: "M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z", // Chart/document icon
 	},

--- a/projects/rawkode.academy/website/src/utils/view-transition-name.ts
+++ b/projects/rawkode.academy/website/src/utils/view-transition-name.ts
@@ -1,0 +1,11 @@
+/**
+ * Cross-document view-transition names. The same name rendered on two pages
+ * (e.g. a video thumbnail on /watch and the player frame on /watch/[slug])
+ * makes the browser morph one into the other during navigation.
+ *
+ * Names must be valid CSS custom-idents and unique per page: the prefix
+ * guards against slugs starting with a digit, and the replace strips
+ * anything a slug shouldn't contain anyway.
+ */
+export const videoTransitionName = (slug: string): string =>
+	`vt-video-${slug.replace(/[^a-zA-Z0-9_-]/g, "-")}`;

--- a/projects/rawkode.academy/website/src/wrappers/page.astro
+++ b/projects/rawkode.academy/website/src/wrappers/page.astro
@@ -26,7 +26,7 @@ const headProps = { ...(frontmatter ?? {}), ...directProps };
 		<slot name="extra-head" slot="extra-head" />
 	</DefaultHead>
 
-	<body class="h-full w-full mx-auto max-w-screen-3xl text-gray-900 dark:text-gray-100">
+	<body class="h-full w-full mx-auto max-w-screen-3xl text-primary-content">
 		<slot name="layout">
 			<DefaultLayout>
 				<slot />

--- a/projects/rawkode.academy/website/uno.config.ts
+++ b/projects/rawkode.academy/website/uno.config.ts
@@ -32,6 +32,19 @@ export default defineConfig({
 		"client:visible",
 		"client:only",
 		"client:media",
+		// Raw Tailwind gray utilities are banned: they drift from the warm
+		// paper/ink editorial palette (worst in dark mode, where gray-900's
+		// cool hue clashes with the ink-dark ground). Use the semantic
+		// tokens instead — text-primary-content / text-secondary-content /
+		// text-muted, bg-[var(--surface-*)], border-[var(--surface-border)].
+		// src/tests/design-tokens.test.ts fails CI with the offending files.
+		[
+			/(?:^|:)(?:bg|text|border|divide|ring|outline|decoration|from|to|via|fill|stroke|placeholder|caret|accent|shadow)-gray-\d+(?:\/\d+)?$/,
+			{
+				message:
+					"gray-* utilities are banned — use the editorial tokens (text-*-content, var(--surface-*))",
+			},
+		],
 	],
 	theme: {
 		colors: {


### PR DESCRIPTION
Implements the five approved design-system / theme / UX improvements from the website audit.

## 1. Editorial token migration + enforcement
- Replaces ~370 raw Tailwind `gray-*` utilities across 45 files with the semantic editorial vocabulary (`text-*-content`, `var(--surface-*)`, `var(--editorial-*)`). Raw grays are cool-hued and drifted from the warm paper/ink palette — worst in dark mode, where `gray-900` clashed with the ink-dark ground.
- New tokens: `--surface-skeleton` (bone colour for the `Skeleton*` family) and theme-invariant `--terminal-*` chrome for terminals/WebContainers, which must stay dark in light mode.
- Enforcement: `uno.config.ts` blocklists `gray-*` colour utilities, and a new `design-tokens.test.ts` fails CI listing offending `file:line`.
- Decorative gray/blue/purple gradient washes flattened to flat surfaces; image-legibility overlays kept.

## 2. Cross-document view transitions
- `@view-transition { navigation: auto }` — **native MPA transitions, not `ClientRouter`**: full page loads still happen, so the site's many per-page inline scripts, analytics, and auth flows are untouched, and unsupporting browsers simply navigate.
- Topbar and sidebar are pinned with their own `view-transition-name` so persistent chrome reads as static.
- Video stills on `/watch` (featured hero + grid) share a per-slug name with the watch page's player frame: the thumbnail you click morphs into the player.
- `prefers-reduced-motion` disables navigation transitions entirely (plus an explicit `::view-transition-*` animation kill as belt and braces).

## 3. /read pagination + shared pager primitive
- `/read` previously rendered the entire article archive on one page; it now pages at 12/page (`?page=N`) with the featured article fronting page 1 only, `rel=prev/next`, `noindex` on deep pages, and author resolution limited to the visible slice.
- New `PagerStrip.astro` primitive; `/watch` swaps its inline footer pager for it.
- `/courses` deliberately left unpaginated — it prerenders a single-digit course library.

## 4. EmptyState primitive
- New `EmptyState.vue` (+ Storybook story): the "loaded, but nothing here" counterpart to the `Skeleton*` loading family. Serif italic title, optional body, mono uppercase action links.
- Adopted by `/read` (filter + pagination misses), `/search` zero results, `/courses` empty library, video comments (Discord CTA), and the resources tab.

## 5. Typography & a11y polish
- `text-wrap: balance` on the h1–h3 base ramp (`.prose` headings inherit), eliminating one-word orphan lines under the serif italic display headings.
- Watch page: screen-reader heading for the technologies section and an `h2` landmark for the comments/transcript/resources tab region.

Docs: `website/CLAUDE.md` updated with the new tokens, primitives, the gray-* ban, and view-transition conventions.

## Verification
- `astro check`: 0 errors (matches baseline)
- `vitest`: 127/127 passing (incl. the new token guard)
- `astro build`: completes; verified `@view-transition`, reduced-motion opt-out, and chrome pins survive minification in the built output
- Repo-wide grep: zero `gray-*` colour utilities remain in `src/` + `.storybook/`

Note: fresh-clone `bun install` currently fails at HEAD because `website/package.json` references workspace packages that aren't in the repo (`ski-*`, `email-preferences`); I stubbed them locally and did not commit anything related. Worth a follow-up.

https://claude.ai/code/session_01Ga3yMCqgvFv1UVrfzNmy5F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga3yMCqgvFv1UVrfzNmy5F)_