### PR TITLE
feat(rawkode.academy/website): ship high-value SEO improvements

### DIFF
--- a/projects/rawkode.academy/website/src/components/command-palette/styles.css
+++ b/projects/rawkode.academy/website/src/components/command-palette/styles.css
@@ -258,8 +258,15 @@
 		padding: 4.75rem 0.75rem 0;
 	}
 
+	/* Pin to both edges instead of the desktop centering math — keeping
+	   `left: 50%` + its negative margin while forcing `width: 100%` pushed
+	   the right edge 1rem past the viewport. */
 	.command-palette-container {
-		width: 100%;
+		top: 4.75rem;
+		left: 0.75rem;
+		right: 0.75rem;
+		margin-left: 0;
+		width: auto;
 	}
 
 	.command-palette-header {
@@ -272,7 +279,9 @@
 	}
 
 	.command-palette-list {
-		max-height: calc(100vh - 10rem);
+		/* dvh tracks the visible viewport on mobile Safari, where the URL
+		   bar makes 100vh taller than what's actually on screen. */
+		max-height: calc(100dvh - 10rem);
 	}
 
 	.command-palette-item-title {

--- a/projects/rawkode.academy/website/src/components/video/VideoGridItem.astro
+++ b/projects/rawkode.academy/website/src/components/video/VideoGridItem.astro
@@ -11,7 +11,6 @@ interface Props {
 	thumbnailUrl?: string | undefined;
 	author?: string | undefined;
 	date?: string | undefined;
-	viewerCount?: number | undefined;
 	/** Cross-document view-transition name. The same name on the watch
 	 * page's player frame morphs this still into the player on click. */
 	vtName?: string | undefined;
@@ -26,7 +25,6 @@ const {
 	thumbnailUrl,
 	author,
 	date,
-	viewerCount,
 	vtName,
 } = Astro.props as Props;
 ---
@@ -54,11 +52,7 @@ const {
 		<h3 class="video-grid-item__title">{title}</h3>
 		<div class="video-grid-item__footer">
 			{author && <MLabel>{author}</MLabel>}
-			<MLabel>
-				{[date, viewerCount !== undefined ? `${viewerCount.toLocaleString()} views` : null]
-					.filter(Boolean)
-					.join(" · ")}
-			</MLabel>
+			{date && <MLabel>{date}</MLabel>}
 		</div>
 	</div>
 </a>

--- a/projects/rawkode.academy/website/src/components/video/VideoHero.astro
+++ b/projects/rawkode.academy/website/src/components/video/VideoHero.astro
@@ -13,7 +13,6 @@ interface Props {
 	description: string;
 	author?: string | undefined;
 	date?: string | undefined;
-	viewerCount?: number | undefined;
 	primaryCtaLabel?: string | undefined;
 	secondaryCtaLabel?: string | undefined;
 	/** Cross-document view-transition name. The same name on the watch
@@ -32,7 +31,6 @@ const {
 	description,
 	author,
 	date,
-	viewerCount,
 	primaryCtaLabel,
 	secondaryCtaLabel,
 	vtName,
@@ -46,9 +44,6 @@ const metaParts = [
 	duration,
 	date,
 	author,
-	viewerCount !== undefined
-		? `${viewerCount.toLocaleString()} ${live ? "watching" : "views"}`
-		: null,
 ].filter(Boolean);
 ---
 

--- a/projects/rawkode.academy/website/src/lib/article-markdown.ts
+++ b/projects/rawkode.academy/website/src/lib/article-markdown.ts
@@ -1,0 +1,68 @@
+import type { CollectionEntry } from "astro:content";
+
+const DEFAULT_SITE_URL = "https://rawkode.academy";
+
+// MDX bodies open with ESM import lines for embedded islands; they're
+// noise in a plain-markdown rendition, so drop the leading import block.
+function stripLeadingMdxImports(body: string): string {
+	const lines = body.split("\n");
+	let index = 0;
+	while (index < lines.length) {
+		const line = (lines[index] ?? "").trim();
+		if (line === "" || /^import\s.+from\s+["'][^"']+["'];?$/.test(line)) {
+			index++;
+			continue;
+		}
+		break;
+	}
+	return lines.slice(index).join("\n").trim();
+}
+
+export function articleCanonicalUrl(
+	article: CollectionEntry<"articles">,
+	site: URL | undefined,
+): string {
+	return new URL(`/read/${article.id}`, site ?? DEFAULT_SITE_URL).href;
+}
+
+export function articleMarkdownUrl(
+	article: CollectionEntry<"articles">,
+	site: URL | undefined,
+): string {
+	return new URL(`/read/${article.id}.md`, site ?? DEFAULT_SITE_URL).href;
+}
+
+export function articleToMarkdown(
+	article: CollectionEntry<"articles">,
+	authors: CollectionEntry<"people">[],
+	site: URL | undefined,
+): string {
+	const lines: string[] = [
+		`# ${article.data.title}`,
+		"",
+		`> ${article.data.description}`,
+		"",
+		`- Canonical: ${articleCanonicalUrl(article, site)}`,
+		`- Published: ${article.data.publishedAt.toISOString().slice(0, 10)}`,
+	];
+
+	if (article.data.updatedAt) {
+		lines.push(
+			`- Updated: ${article.data.updatedAt.toISOString().slice(0, 10)}`,
+		);
+	}
+
+	if (authors.length > 0) {
+		lines.push(
+			`- Authors: ${authors.map((author) => author.data.name).join(", ")}`,
+		);
+	}
+
+	if ((article.data.technologies ?? []).length > 0) {
+		lines.push(`- Technologies: ${article.data.technologies.join(", ")}`);
+	}
+
+	lines.push("", stripLeadingMdxImports(article.body ?? ""), "");
+
+	return lines.join("\n");
+}

--- a/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/courses/[...slug].astro
@@ -9,6 +9,7 @@ import {
 import CourseModules from "@/components/courses/CourseModules.astro";
 import CourseSignupFormCompact from "@/components/courses/CourseSignupFormCompact.astro";
 import CourseDetailHero from "@/components/courses/CourseDetailHero.vue";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 import CourseJsonLd from "@/components/html/course-jsonld.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
@@ -118,6 +119,14 @@ function getResourceHref(
 			authors={authors}
 		/>
 	)}
+	<BreadcrumbJsonLd
+		slot="extra-head"
+		elements={[
+			{ title: "Home", link: "/" },
+			{ title: "Courses", link: "/courses" },
+			{ title: course.data.title, link: `/courses/${course.id}` },
+		]}
+	/>
 	
 	<!-- Hero Section with Signup Form -->
 	<CourseDetailHero

--- a/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
+++ b/projects/rawkode.academy/website/src/pages/learning-paths/[slug].astro
@@ -13,6 +13,7 @@ import EditorialButton from "@/components/ui/EditorialButton.vue";
 import MLabel from "@/components/ui/MLabel.vue";
 import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
 import LearningPathJsonLd from "@/components/html/learning-path-jsonld.astro";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 
 export const prerender = true;
 
@@ -103,6 +104,14 @@ const pageDescription = learningPath.data.description;
 		learningPath={learningPath}
 		authors={authors}
 		technologyLabels={technologyLabels}
+	/>
+	<BreadcrumbJsonLd
+		slot="extra-head"
+		elements={[
+			{ title: "Home", link: "/" },
+			{ title: "Learning Paths", link: "/learning-paths" },
+			{ title: learningPath.data.title, link: `/learning-paths/${learningPath.id}` },
+		]}
 	/>
 
 	<div class="path-detail">

--- a/projects/rawkode.academy/website/src/pages/llms-full.txt.ts
+++ b/projects/rawkode.academy/website/src/pages/llms-full.txt.ts
@@ -1,0 +1,34 @@
+import { getCollection, getEntries } from "astro:content";
+import type { APIContext } from "astro";
+import { articleToMarkdown } from "@/lib/article-markdown";
+import { SITE_DESCRIPTION } from "@/lib/site";
+
+export const prerender = true;
+
+export async function GET({ site }: APIContext) {
+	const articles = (
+		await getCollection("articles", ({ data }) => !data.draft)
+	).sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+
+	const documents = await Promise.all(
+		articles.map(async (article) => {
+			const authors = await getEntries(article.data.authors);
+			return articleToMarkdown(article, authors, site);
+		}),
+	);
+
+	const body = [
+		"# Rawkode Academy — Full Article Corpus",
+		"",
+		`> ${SITE_DESCRIPTION}`,
+		"",
+		documents.join("\n\n---\n\n"),
+		"",
+	].join("\n");
+
+	return new Response(body, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/llms.txt.ts
+++ b/projects/rawkode.academy/website/src/pages/llms.txt.ts
@@ -1,0 +1,86 @@
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+import { articleMarkdownUrl } from "@/lib/article-markdown";
+import { getPublishedVideos } from "@/lib/content";
+import { SITE_DESCRIPTION } from "@/lib/site";
+
+export const prerender = true;
+
+const DEFAULT_SITE_URL = "https://rawkode.academy";
+const SUMMARY_MAX_LENGTH = 160;
+
+function summarize(text: string): string {
+	const normalized = text
+		.replace(/\\n/g, " ")
+		.replace(/[*_`#]+/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (normalized.length <= SUMMARY_MAX_LENGTH) return normalized;
+	const truncated = normalized.slice(0, SUMMARY_MAX_LENGTH);
+	const lastSpace = truncated.lastIndexOf(" ");
+	return `${truncated.slice(0, lastSpace > 80 ? lastSpace : SUMMARY_MAX_LENGTH)}…`;
+}
+
+export async function GET({ site }: APIContext) {
+	const base = site ?? new URL(DEFAULT_SITE_URL);
+	const absolute = (path: string) => new URL(path, base).href;
+
+	const articles = (
+		await getCollection("articles", ({ data }) => !data.draft)
+	).sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+	const videos = await getPublishedVideos();
+	const courses = await getCollection("courses");
+	const learningPaths = await getCollection("learningPaths");
+
+	const lines: string[] = [
+		"# Rawkode Academy",
+		"",
+		`> ${SITE_DESCRIPTION}`,
+		"",
+		"Article links below point at plain-markdown renditions; the canonical",
+		"HTML pages live at the same path without the `.md` suffix. Video links",
+		"point at markdown documents containing the description, chapters, and",
+		"full transcript of each session.",
+		"",
+		"## Articles",
+		"",
+		...articles.map(
+			(article) =>
+				`- [${article.data.title}](${articleMarkdownUrl(article, base)}): ${summarize(article.data.description)}`,
+		),
+		"",
+		"## Courses",
+		"",
+		...courses.map(
+			(course) =>
+				`- [${course.data.title}](${absolute(`/courses/${course.id}`)}): ${summarize(course.data.description)}`,
+		),
+		"",
+		"## Learning Paths",
+		"",
+		...learningPaths.map(
+			(path) =>
+				`- [${path.data.title}](${absolute(`/learning-paths/${path.id}`)}): ${summarize(path.data.description)}`,
+		),
+		"",
+		"## Videos",
+		"",
+		...videos.map(
+			(video) =>
+				`- [${video.data.title}](${absolute(`/watch/${video.data.slug}.md`)}): ${summarize(video.data.description)}`,
+		),
+		"",
+		"## Optional",
+		"",
+		`- [Full article corpus as a single document](${absolute("/llms-full.txt")})`,
+		`- [All-content RSS feed](${absolute("/api/feeds/all.xml")})`,
+		`- [Sitemap index](${absolute("/sitemap-index.xml")})`,
+		"",
+	];
+
+	return new Response(lines.join("\n"), {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/news/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/news/[...slug].astro
@@ -7,6 +7,7 @@ import {
 } from "astro:content";
 import ArticleHeader from "@/components/read/ArticleHeader.astro";
 import ArticleByline from "@/components/read/ArticleByline.astro";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 import NewsJsonLd from "@/components/html/news-jsonld.astro";
 import RelatedNews from "@/components/news/RelatedNews.astro";
 import NewsletterCTA from "@/components/newsletter/NewsletterCTA.astro";
@@ -109,6 +110,13 @@ const categoryTrail = tags[0]?.label;
 >
 	<Fragment slot="extra-head">
 		<NewsJsonLd article={article} authors={authors} />
+		<BreadcrumbJsonLd
+			elements={[
+				{ title: "Home", link: "/" },
+				{ title: "News", link: "/news" },
+				{ title: article.data.title, link: `/news/${article.id}` },
+			]}
+		/>
 		<link
 			rel="alternate"
 			type="application/rss+xml"

--- a/projects/rawkode.academy/website/src/pages/read/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/read/[...slug].astro
@@ -12,6 +12,7 @@ import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 import Page from "@/wrappers/page.astro";
 
 import ArticleJsonLd from "@/components/html/article-jsonld.astro";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 import { buildHowToJsonLd } from "@/lib/howto-jsonld";
 
 import RelatedArticles from "@/components/articles/RelatedArticles.astro";
@@ -185,11 +186,25 @@ const subtitle = article.data.openGraph?.subtitle || article.data.subtitle;
 	articleTags={tags.map((tag) => tag.label)}
 	{...(howToJsonLd ? { jsonLd: howToJsonLd } : {})}
 >
-	{imageUrl ? (
-		<ArticleJsonLd slot="extra-head" article={article} authors={authors} imageUrl={imageUrl} />
-	) : (
-		<ArticleJsonLd slot="extra-head" article={article} authors={authors} />
-	)}
+	{/*
+		A single slotted element with a conditional spread — a ternary holding
+		two `slot="extra-head"` branches makes Astro drop every slotted
+		sibling that follows it (the feed links below never reached the head).
+	*/}
+	<ArticleJsonLd
+		slot="extra-head"
+		article={article}
+		authors={authors}
+		{...(imageUrl ? { imageUrl } : {})}
+	/>
+	<BreadcrumbJsonLd
+		slot="extra-head"
+		elements={[
+			{ title: "Home", link: "/" },
+			{ title: "Read", link: "/read" },
+			{ title: article.data.title, link: `/read/${article.id}` },
+		]}
+	/>
 	<link slot="extra-head" rel="alternate" type="application/rss+xml" title="Rawkode Academy - Articles (RSS)" href="/api/feeds/articles.xml" />
 	<link slot="extra-head" rel="alternate" type="application/atom+xml" title="Rawkode Academy - Articles (Atom)" href="/api/feeds/articles.atom" />
 	<link slot="extra-head" rel="alternate" type="application/feed+json" title="Rawkode Academy - Articles (JSON Feed)" href="/api/feeds/articles.json" />

--- a/projects/rawkode.academy/website/src/pages/read/[slug].md.ts
+++ b/projects/rawkode.academy/website/src/pages/read/[slug].md.ts
@@ -1,0 +1,29 @@
+import { getCollection, getEntries } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import type { APIContext, GetStaticPaths } from "astro";
+import { articleToMarkdown } from "@/lib/article-markdown";
+
+export const prerender = true;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+	const articles = await getCollection("articles", ({ data }) => !data.draft);
+	return articles.map((article) => ({
+		params: { slug: article.id },
+		props: { article },
+	}));
+};
+
+type Props = {
+	article: CollectionEntry<"articles">;
+};
+
+export async function GET({ props, site }: APIContext) {
+	const { article } = props as Props;
+	const authors = await getEntries(article.data.authors);
+
+	return new Response(articleToMarkdown(article, authors, site), {
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+		},
+	});
+}

--- a/projects/rawkode.academy/website/src/pages/read/index.astro
+++ b/projects/rawkode.academy/website/src/pages/read/index.astro
@@ -232,9 +232,11 @@ const activeFilterSummary = [
 	.filter(Boolean)
 	.join(" · ");
 
-const pageTitle = "Field Notes — Articles from Rawkode Academy";
+// SERP title leads with what people search for; the "Field Notes"
+// editorial branding stays on the visible masthead.
+const pageTitle = "Cloud Native & Kubernetes Articles";
 const pageDescription =
-	"Long-form essays, tutorials, and field reports on cloud native engineering — Kubernetes, eBPF, containers, supply chain.";
+	"Long-form articles, tutorials, and field reports on cloud native engineering — Kubernetes, eBPF, containers, supply chain — from Rawkode Academy.";
 ---
 
 <Page title={pageTitle} description={pageDescription} pageType="CollectionPage">

--- a/projects/rawkode.academy/website/src/pages/series/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/series/[...slug].astro
@@ -2,6 +2,7 @@
 import { getImage } from "astro:assets";
 import { type CollectionEntry, getCollection, render } from "astro:content";
 import SeriesArticles from "@/components/articles/series/SeriesArticles.astro";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 import Page from "@/wrappers/page.astro";
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
@@ -50,6 +51,14 @@ const imageUrl = await computeImageUrl(series);
 	description={`${series.data.title} - a multi-part article series from Rawkode Academy covering hands-on cloud native and Kubernetes engineering.`}
 	image={{ image: imageUrl }}
 >
+	<BreadcrumbJsonLd
+		slot="extra-head"
+		elements={[
+			{ title: "Home", link: "/" },
+			{ title: "Series", link: "/series" },
+			{ title: series.data.title, link: `/series/${series.id}` },
+		]}
+	/>
 	<div class="mx-auto max-w-3xl content-px py-12">
 		<h1>
 			{series.data.title}

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, getEntry } from "astro:content";
+import BreadcrumbJsonLd from "@/components/breadcrumb/BreadcrumbJsonLd.astro";
 import VideoMetadata from "@/components/html/video-metadata.astro";
 import VideoPlayer from "@/components/video/player.vue";
 import LiveStreamGate from "@/components/video/LiveStreamGate.vue";
@@ -275,6 +276,52 @@ const watchVideoSeoText = await buildWatchVideoSeoText({
 	chapters: chapterSource,
 });
 
+// Full transcript, grouped under chapter headings, server-rendered so the
+// spoken content is crawlable in the initial HTML (the interactive
+// transcript tab hydrates separately and only ever existed client-side).
+type TranscriptSection = {
+	title: string | null;
+	startTime: number | null;
+	paragraphs: { startSeconds: number; text: string }[];
+};
+
+const transcriptSections: TranscriptSection[] = (() => {
+	const paragraphs = watchVideoSeoText.transcriptParagraphs ?? [];
+	if (paragraphs.length === 0) return [];
+	if (chapterSource.length === 0) {
+		return [{ title: null, startTime: null, paragraphs }];
+	}
+
+	const sortedChapters = [...chapterSource].sort(
+		(a, b) => a.startTime - b.startTime,
+	);
+	const leading: TranscriptSection = {
+		title: null,
+		startTime: null,
+		paragraphs: [],
+	};
+	const sections: TranscriptSection[] = sortedChapters.map((chapter) => ({
+		title: chapter.title,
+		startTime: chapter.startTime,
+		paragraphs: [],
+	}));
+
+	for (const paragraph of paragraphs) {
+		let sectionIndex = -1;
+		for (let i = 0; i < sortedChapters.length; i++) {
+			const chapter = sortedChapters[i];
+			if (chapter && paragraph.startSeconds >= chapter.startTime) {
+				sectionIndex = i;
+			}
+		}
+		(sections[sectionIndex] ?? leading).paragraphs.push(paragraph);
+	}
+
+	return [leading, ...sections].filter(
+		(section) => section.paragraphs.length > 0,
+	);
+})();
+
 const user = Astro.locals.user;
 const isAuthenticated = !!user;
 
@@ -370,6 +417,17 @@ const watchStatusLabel = isUpcomingLive
 		creators={creatorRefs}
 		guests={guestRefs}
 		partOfSeries={partOfSeriesRef}
+	/>
+	<BreadcrumbJsonLd
+		slot="extra-head"
+		elements={[
+			{ title: "Home", link: "/" },
+			{ title: "Watch", link: "/watch" },
+			...(showEntry
+				? [{ title: showEntry.data.name, link: `/shows/${showEntry.id}` }]
+				: []),
+			{ title: video.data.title, link: `/watch/${video.data.slug}` },
+		]}
 	/>
 	<link slot="extra-head" rel="alternate" type="application/rss+xml" title="Rawkode Academy - Videos (RSS)" href="/api/feeds/videos.xml" />
 	<link slot="extra-head" rel="alternate" type="application/atom+xml" title="Rawkode Academy - Videos (Atom)" href="/api/feeds/videos.atom" />
@@ -571,6 +629,59 @@ const watchStatusLabel = isUpcomingLive
 							</li>
 						))}
 					</ol>
+				</section>
+			)}
+
+			{transcriptSections.length > 0 && (
+				<section
+					class="watch-detail__transcript"
+					aria-labelledby="watch-detail-transcript-heading"
+				>
+					<MLabel tone="spruce">Transcript</MLabel>
+					<h2
+						id="watch-detail-transcript-heading"
+						class="watch-detail__transcript-title"
+					>
+						Full transcript
+					</h2>
+					<p class="watch-detail__transcript-note">
+						Generated from the English captions. Timestamps jump the player to
+						that moment.
+					</p>
+					<details class="watch-detail__transcript-details">
+						<summary>Read the full transcript</summary>
+						<div class="watch-detail__transcript-body">
+							{transcriptSections.map((section) => (
+								<section class="watch-detail__transcript-section">
+									{section.title !== null && section.startTime !== null && (
+										<h3 class="watch-detail__transcript-chapter">
+											<a
+												href={`?t=${section.startTime}`}
+												data-chapter-link={String(section.startTime)}
+											>
+												<span class="watch-detail__transcript-time">
+													{formatTimestamp(section.startTime)}
+												</span>
+												{section.title}
+											</a>
+										</h3>
+									)}
+									{section.paragraphs.map((paragraph) => (
+										<p class="watch-detail__transcript-paragraph">
+											<a
+												class="watch-detail__transcript-time"
+												href={`?t=${paragraph.startSeconds}`}
+												data-chapter-link={String(paragraph.startSeconds)}
+											>
+												{formatTimestamp(paragraph.startSeconds)}
+											</a>{" "}
+											{paragraph.text}
+										</p>
+									))}
+								</section>
+							))}
+						</div>
+					</details>
 				</section>
 			)}
 
@@ -1207,6 +1318,101 @@ const watchStatusLabel = isUpcomingLive
 		font-size: 0.95rem;
 		line-height: 1.4;
 		transition: color var(--duration-base) var(--ease-standard);
+	}
+
+	.watch-detail__transcript {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-block-gap);
+		padding-top: var(--space-section-gap);
+		border-top: 1px solid var(--editorial-hairline);
+	}
+
+	.watch-detail__transcript-title {
+		font-family: var(--font-instrument-serif), serif;
+		font-style: italic;
+		font-weight: 400;
+		font-size: 1.75rem;
+		line-height: 1.05;
+		letter-spacing: -0.02em;
+		color: var(--editorial-ink);
+		margin: 0;
+	}
+
+	.watch-detail__transcript-note {
+		max-width: 48rem;
+		margin: 0;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: 0.875rem;
+		line-height: 1.5;
+		color: var(--editorial-ink-mute);
+	}
+
+	.watch-detail__transcript-details {
+		max-width: 48rem;
+		border-top: 1px solid var(--editorial-hairline);
+	}
+
+	.watch-detail__transcript-details summary {
+		cursor: pointer;
+		padding: 0.625rem 0;
+		font-family: var(--font-jetbrains-mono), monospace;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--editorial-spruce);
+	}
+
+	.watch-detail__transcript-details summary:hover {
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.35em;
+	}
+
+	.watch-detail__transcript-body {
+		padding: 0.5rem 0 0.75rem;
+	}
+
+	.watch-detail__transcript-chapter {
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--editorial-ink);
+		margin: 1.75rem 0 0.75rem;
+	}
+
+	.watch-detail__transcript-chapter a {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.875rem;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.watch-detail__transcript-chapter a:hover {
+		color: var(--editorial-spruce);
+	}
+
+	.watch-detail__transcript-paragraph {
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: 0.95rem;
+		line-height: 1.6;
+		color: var(--editorial-ink-soft);
+		margin: 0 0 1rem;
+	}
+
+	.watch-detail__transcript-time {
+		font-family: var(--font-jetbrains-mono), monospace;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--editorial-ink-mute);
+		font-variant-numeric: tabular-nums;
+		text-decoration: none;
+	}
+
+	a.watch-detail__transcript-time:hover {
+		color: var(--editorial-spruce);
 	}
 
 	.watch-detail__tech {

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -1547,6 +1547,18 @@ const watchStatusLabel = isUpcomingLive
 				"player";
 		}
 
+		/* Single-column layout: the player is already as wide as it can get,
+		   so the expand/shrink toggle is meaningless — and its full-frame
+		   checkbox overlay would swallow the first tap meant for the player. */
+		.watch-detail__player-wrap {
+			max-width: 100%;
+		}
+
+		.watch-detail__player-state,
+		.watch-detail__player-toggle {
+			display: none;
+		}
+
 		.watch-detail__summary {
 			display: flex;
 			flex-direction: column;

--- a/projects/rawkode.academy/website/src/pages/watch/[slug].md.ts
+++ b/projects/rawkode.academy/website/src/pages/watch/[slug].md.ts
@@ -1,0 +1,89 @@
+import type { APIContext } from "astro";
+import { getPublishedVideos } from "@/lib/content";
+import { buildWatchVideoSeoText } from "@/utils/watch-video-seo";
+
+export const prerender = false;
+
+const DEFAULT_SITE_URL = "https://rawkode.academy";
+
+function formatTimestamp(seconds: number): string {
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	const s = Math.floor(seconds % 60);
+	return h > 0
+		? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+		: `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export async function GET({ params, site }: APIContext) {
+	const videos = await getPublishedVideos();
+	const video = videos.find((v) => v.data.slug === params.slug);
+
+	if (!video) {
+		return new Response(null, { status: 404 });
+	}
+
+	const canonicalUrl = new URL(
+		`/watch/${video.data.slug}`,
+		site ?? DEFAULT_SITE_URL,
+	).href;
+	const captionUrl = `https://content.rawkode.academy/videos/${video.data.id}/captions/en.vtt`;
+	const description = video.data.description.replace(/\\n/g, "\n").trim();
+
+	type Chapter = { startTime: number; title: string };
+	const chapters: Chapter[] = Array.isArray(video.data.chapters)
+		? (video.data.chapters as Chapter[]).map((chapter) => ({
+				title: chapter.title,
+				startTime: Math.max(0, Math.floor(chapter?.startTime ?? 0)),
+			}))
+		: [];
+
+	const seoText = await buildWatchVideoSeoText({
+		captionUrl,
+		description,
+		chapters,
+	});
+
+	const lines: string[] = [
+		`# ${video.data.title}`,
+		"",
+		`- Canonical: ${canonicalUrl}`,
+		`- Published: ${new Date(video.data.publishedAt).toISOString().slice(0, 10)}`,
+	];
+
+	if (typeof video.data.duration === "number" && video.data.duration > 0) {
+		lines.push(`- Duration: ${formatTimestamp(video.data.duration)}`);
+	}
+
+	lines.push("", "## Description", "", description);
+
+	if (chapters.length > 0) {
+		lines.push("", "## Chapters", "");
+		for (const chapter of chapters) {
+			lines.push(`- ${formatTimestamp(chapter.startTime)} ${chapter.title}`);
+		}
+	}
+
+	const transcriptParagraphs = seoText.transcriptParagraphs ?? [];
+	if (transcriptParagraphs.length > 0) {
+		lines.push("", "## Transcript", "");
+		for (const paragraph of transcriptParagraphs) {
+			lines.push(
+				`[${formatTimestamp(paragraph.startSeconds)}] ${paragraph.text}`,
+				"",
+			);
+		}
+	}
+
+	lines.push("");
+
+	return new Response(lines.join("\n"), {
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+			"Cache-Control":
+				"public, max-age=600, s-maxage=7200, stale-while-revalidate=172800",
+			"CDN-Cache-Control": "public, max-age=7200",
+			"Cache-Tag": `video-${video.data.slug}, video-markdown`,
+		},
+	});
+}

--- a/projects/rawkode.academy/website/src/tests/seo.test.ts
+++ b/projects/rawkode.academy/website/src/tests/seo.test.ts
@@ -8,6 +8,8 @@ import {
 	buildTranscriptExcerpt,
 	groupTranscriptParagraphs,
 	parseWebVTT,
+	transcriptParagraphsToText,
+	vttTimestampToSeconds,
 } from "@/utils/video-transcript";
 import {
 	buildVideoSummaryParagraphs,
@@ -542,7 +544,45 @@ Search engines should see this text.`;
 		expect(state.transcriptExcerpt).toContain(
 			"Search engines should see this text.",
 		);
+		expect(state.transcriptParagraphs?.[0]?.startSeconds).toBe(0);
+		expect(
+			state.transcriptParagraphs?.map((paragraph) => paragraph.text).join(" "),
+		).toContain("Search engines should see this text.");
 		expect(fetchImpl).toHaveBeenCalledTimes(1);
+	});
+
+	it("converts VTT timestamps and full paragraphs for server rendering", () => {
+		expect(vttTimestampToSeconds("00:00:00.000")).toBe(0);
+		expect(vttTimestampToSeconds("00:01:30.500")).toBe(90);
+		expect(vttTimestampToSeconds("01:02:03.000")).toBe(3723);
+		expect(vttTimestampToSeconds("garbage")).toBe(0);
+
+		const paragraphs = transcriptParagraphsToText([
+			[
+				{
+					start: "00:00:05.000",
+					end: "00:00:08.000",
+					text: "First cue.",
+				},
+				{
+					start: "00:00:08.000",
+					end: "00:00:11.000",
+					text: "Second cue.",
+				},
+			],
+			[
+				{
+					start: "00:10:00.000",
+					end: "00:10:04.000",
+					text: "Later cue.",
+				},
+			],
+		]);
+
+		expect(paragraphs).toEqual([
+			{ startSeconds: 5, text: "First cue. Second cue." },
+			{ startSeconds: 600, text: "Later cue." },
+		]);
 	});
 
 	it("falls back to a server-rendered summary when captions are unavailable", async () => {

--- a/projects/rawkode.academy/website/src/utils/video-transcript.ts
+++ b/projects/rawkode.academy/website/src/utils/video-transcript.ts
@@ -100,6 +100,33 @@ export function groupTranscriptParagraphs(
 	return paragraphs;
 }
 
+export function vttTimestampToSeconds(timestamp: string): number {
+	const match = timestamp.match(/^(\d{2}):(\d{2}):(\d{2})\.(\d{3})$/);
+	if (!match) {
+		return 0;
+	}
+	const [, hours, minutes, seconds] = match;
+	return Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+}
+
+export interface TranscriptParagraphText {
+	startSeconds: number;
+	text: string;
+}
+
+export function transcriptParagraphsToText(
+	paragraphs: TranscriptParagraph[],
+): TranscriptParagraphText[] {
+	return paragraphs
+		.map((paragraph) => ({
+			startSeconds: vttTimestampToSeconds(
+				paragraph[0]?.start ?? "00:00:00.000",
+			),
+			text: transcriptParagraphToText(paragraph),
+		}))
+		.filter((paragraph) => paragraph.text.length > 0);
+}
+
 export function transcriptParagraphToText(
 	paragraph: TranscriptParagraph,
 ): string {

--- a/projects/rawkode.academy/website/src/utils/watch-video-seo.ts
+++ b/projects/rawkode.academy/website/src/utils/watch-video-seo.ts
@@ -3,6 +3,8 @@ import {
 	groupTranscriptParagraphs,
 	parseWebVTT,
 	transcriptParagraphToText,
+	transcriptParagraphsToText,
+	type TranscriptParagraphText,
 } from "@/utils/video-transcript";
 
 export type WatchVideoSeoTextSource = "transcript" | "summary" | "none";
@@ -13,6 +15,7 @@ export interface WatchVideoSeoTextState {
 	previewDescription: string;
 	previewParagraphs: string[];
 	transcriptExcerpt?: string;
+	transcriptParagraphs?: TranscriptParagraphText[];
 }
 
 type ChapterLike = {
@@ -135,6 +138,8 @@ export async function buildWatchVideoSeoText({
 					previewDescription: TRANSCRIPT_PREVIEW_DESCRIPTION,
 					previewParagraphs,
 					transcriptExcerpt: buildTranscriptExcerpt(transcriptParagraphs),
+					transcriptParagraphs:
+						transcriptParagraphsToText(transcriptParagraphs),
 				};
 			}
 		}


### PR DESCRIPTION
- Render full video transcripts as crawlable HTML on watch pages,
  grouped under chapter headings with seekable timestamp links; the
  spoken content (often 50k+ chars per video) was previously only a
  1,600-char excerpt in JSON-LD
- Emit BreadcrumbList JSON-LD on article, video, course, learning
  path, series, and news detail pages (component existed but was only
  wired into show pages)
- Fix article pages dropping slotted head elements: a ternary holding
  two slot="extra-head" branches silently discarded the feed links
  that followed it
- Add /llms.txt, /llms-full.txt, and plain-markdown renditions of
  every article (/read/<slug>.md) and video (/watch/<slug>.md, with
  description, chapters, and transcript) for AI answer engines
- Replace the keyword-weak "Field Notes" SERP title on /read with
  "Cloud Native & Kubernetes Articles"
- Remove unused view-count props from VideoHero and VideoGridItem

https://claude.ai/code/session_01N6LzHHwDBaRZ9xErVmKfZi