### PR TITLE
fix(rawkode.academy/website): deliver partnership applications via rawkode.email

### DIFF
--- a/projects/rawkode.academy/website/src/actions/partnership.ts
+++ b/projects/rawkode.academy/website/src/actions/partnership.ts
@@ -4,7 +4,10 @@ import { EmailMessage } from "cloudflare:email";
 import { env } from "cloudflare:workers";
 import { applicationPaths } from "@/lib/partnerships";
 
-const FROM_ADDRESS = "partnerships@rawkode.academy";
+// Sender must be on a domain onboarded to Cloudflare Email Routing.
+// rawkode.academy's MX points at Google Workspace, so we send from
+// rawkode.email and deliver to the verified destination address below.
+const FROM_ADDRESS = "partnerships@rawkode.email";
 const TO_ADDRESS = "david@rawkode.academy";
 
 /** Strip CR/LF so user input can never inject extra MIME headers. */
@@ -47,11 +50,17 @@ export const partnership = {
 				.min(1, "Please describe your current adoption challenge")
 				.max(5000),
 			links: z.string().trim().max(2000).optional(),
-			// Honeypot: real users never fill this in.
-			website: z.string().optional(),
+			// Honeypot: real users never fill this in. Named so browser
+			// autofill heuristics (which match "website", "url", etc.)
+			// don't populate it for real applicants.
+			comments: z.string().optional(),
 		}),
 		handler: async (input) => {
-			if (input.website) {
+			if (input.comments) {
+				console.warn("Partnership application dropped by honeypot", {
+					email: input.email,
+					company: input.company,
+				});
 				return { success: true };
 			}
 
@@ -84,7 +93,7 @@ export const partnership = {
 				`To: <${TO_ADDRESS}>`,
 				`Reply-To: <${sanitizeHeader(input.email)}>`,
 				`Subject: ${subject}`,
-				`Message-ID: <${crypto.randomUUID()}@rawkode.academy>`,
+				`Message-ID: <${crypto.randomUUID()}@rawkode.email>`,
 				`Date: ${new Date().toUTCString()}`,
 				"MIME-Version: 1.0",
 				'Content-Type: text/plain; charset="utf-8"',

--- a/projects/rawkode.academy/website/src/actions/partnership.ts
+++ b/projects/rawkode.academy/website/src/actions/partnership.ts
@@ -50,20 +50,8 @@ export const partnership = {
 				.min(1, "Please describe your current adoption challenge")
 				.max(5000),
 			links: z.string().trim().max(2000).optional(),
-			// Honeypot: real users never fill this in. Named so browser
-			// autofill heuristics (which match "website", "url", etc.)
-			// don't populate it for real applicants.
-			comments: z.string().optional(),
 		}),
 		handler: async (input) => {
-			if (input.comments) {
-				console.warn("Partnership application dropped by honeypot", {
-					email: input.email,
-					company: input.company,
-				});
-				return { success: true };
-			}
-
 			const subject = encodeHeader(
 				`Partnership application: ${input.path} - ${input.company}`.slice(
 					0,

--- a/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
+++ b/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
@@ -91,19 +91,6 @@
 			<small v-if="fieldErrors.links" class="application-form__field-error">{{ fieldErrors.links }}</small>
 		</label>
 
-		<div class="application-form__trap" aria-hidden="true">
-			<label>
-				Comments
-				<input
-					v-model="honeypot"
-					type="text"
-					name="comments"
-					tabindex="-1"
-					autocomplete="off"
-				/>
-			</label>
-		</div>
-
 		<button type="submit" class="editorial-button" :disabled="loading">
 			{{ loading ? "Sending application..." : "Submit application" }}
 		</button>
@@ -125,8 +112,6 @@ const path = ref<ApplicationPath>("Not sure yet");
 const targetDevelopers = ref("");
 const challenge = ref("");
 const links = ref("");
-// Honeypot — named "comments" because autofill fills fields named "website".
-const honeypot = ref("");
 
 const loading = ref(false);
 const submitted = ref(false);
@@ -169,7 +154,6 @@ async function submit() {
 			targetDevelopers: targetDevelopers.value,
 			challenge: challenge.value,
 			...(links.value.trim() ? { links: links.value } : {}),
-			...(honeypot.value ? { comments: honeypot.value } : {}),
 		});
 
 		if (result.error) {
@@ -286,14 +270,6 @@ async function submit() {
 	font-size: 0.92rem;
 	line-height: 1.5;
 	padding: 0.75rem 1rem;
-}
-
-.application-form__trap {
-	position: absolute;
-	left: -9999px;
-	width: 1px;
-	height: 1px;
-	overflow: hidden;
 }
 
 .application-form button:disabled {

--- a/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
+++ b/projects/rawkode.academy/website/src/components/organizations/PartnershipApplicationForm.vue
@@ -93,11 +93,11 @@
 
 		<div class="application-form__trap" aria-hidden="true">
 			<label>
-				Website
+				Comments
 				<input
-					v-model="website"
+					v-model="honeypot"
 					type="text"
-					name="website"
+					name="comments"
 					tabindex="-1"
 					autocomplete="off"
 				/>
@@ -125,7 +125,8 @@ const path = ref<ApplicationPath>("Not sure yet");
 const targetDevelopers = ref("");
 const challenge = ref("");
 const links = ref("");
-const website = ref("");
+// Honeypot — named "comments" because autofill fills fields named "website".
+const honeypot = ref("");
 
 const loading = ref(false);
 const submitted = ref(false);
@@ -168,7 +169,7 @@ async function submit() {
 			targetDevelopers: targetDevelopers.value,
 			challenge: challenge.value,
 			...(links.value.trim() ? { links: links.value } : {}),
-			...(website.value ? { website: website.value } : {}),
+			...(honeypot.value ? { comments: honeypot.value } : {}),
 		});
 
 		if (result.error) {


### PR DESCRIPTION
## Problem

Partnership applications showed "Application received" but never arrived. Two independent causes:

1. **Undeliverable sender domain.** The action sent from `partnerships@rawkode.academy` via the Cloudflare `send_email` binding, but that binding requires the sender to be on a domain onboarded to Cloudflare Email Routing — and `rawkode.academy`'s MX points at Google Workspace, so it never can be.
2. **Honeypot eating real submissions.** The hidden anti-spam field was named/labelled `website`, which browser autofill recognises and fills (ignoring `autocomplete="off"`). Tripped submissions were silently discarded behind the same success screen.

Confirmed: zero emails from `partnerships@rawkode.academy` ever reached the destination inbox, including spam/trash.

## Fix

- Send from `partnerships@rawkode.email` (zone onboarded to Email Routing), still delivering to `david@rawkode.academy` with the applicant's address as `Reply-To`.
- Remove the honeypot entirely from the form and the action input schema — spam handling moves out of the form.

## Validation

- 128/128 vitest tests pass; `astro check` reports 0 errors.
- Deploy prerequisite: `david@rawkode.academy` must be a verified destination address in Cloudflare Email Routing.

https://claude.ai/code/session_01Naa1ssBvpcAjQuffUEWQqh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Naa1ssBvpcAjQuffUEWQqh)_