### PR TITLE
feat(rawkode.academy/website): sidebar categories + article prose/code-block overhaul

### DIFF
--- a/content/articles/cgroups-chaos-control/index.mdx
+++ b/content/articles/cgroups-chaos-control/index.mdx
@@ -71,7 +71,9 @@ This design is elegant. What went wrong is what always goes wrong in systems tha
 
 ## Try It Yourself
 
-> **Tested on:** Ubuntu 25.10, kernel 7.0.5, systemd 257, runc 1.3.4. Anything cgroupsv2 with these or newer should behave identically.
+<Aside variant="info">
+	**Tested on:** Ubuntu 25.10, kernel 7.0.5, systemd 257, runc 1.3.4. Anything cgroupsv2 with these or newer should behave identically.
+</Aside>
 
 The cleanest way to *feel* how cgroups work is to create one, cap it, and watch the kernel enforce the cap. Do this on a disposable Linux VM or lab host, not a production node. Any cgroupsv2 system will do.
 

--- a/projects/rawkode.academy/website/astro.config.mts
+++ b/projects/rawkode.academy/website/astro.config.mts
@@ -141,16 +141,16 @@ export default defineConfig({
 		// that never ships in dist. Inlining avoids the broken file reference.
 		...(d2Available ? [d2({ inline: true })] : []),
 		expressiveCode({
-			// Editorial palette: Ayu Light for the paper scheme, Catppuccin
-			// Mocha for the dark scheme. First entry is the default.
-			themes: ["catppuccin-mocha", "ayu-light"],
-			themeCssRoot: ":root",
-			themeCssSelector: (theme) =>
-				theme.name === "ayu-light" ? ":root:not(.dark)" : "html.dark",
+			// Code blocks are "screen within the page" surfaces: like the
+			// --terminal-* tokens they stay dark in both colour schemes, so
+			// shell frames, output blocks, and editor frames all read as the
+			// same material instead of flipping between light and dark chrome.
+			themes: ["catppuccin-mocha"],
 			styleOverrides: {
 				borderRadius: "var(--radius-sm)",
-				borderColor: "var(--editorial-hairline-strong)",
+				borderColor: "var(--terminal-border)",
 				borderWidth: "1px",
+				codeBackground: "var(--terminal-bg)",
 				codeFontFamily:
 					"var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, monospace",
 				codeFontSize: "13px",
@@ -160,12 +160,13 @@ export default defineConfig({
 					editorActiveTabBorderColor: "transparent",
 					editorActiveTabIndicatorBottomColor: "transparent",
 					editorActiveTabIndicatorTopColor: "var(--editorial-spruce)",
-					editorTabBarBackground: "oklch(0.18 0.012 280)",
-					editorTabBarBorderBottomColor: "oklch(1 0 0 / 0.08)",
+					editorBackground: "var(--terminal-bg)",
+					editorTabBarBackground: "var(--terminal-surface)",
+					editorTabBarBorderBottomColor: "var(--terminal-border)",
 					frameBoxShadowCssValue: "none",
-					terminalBackground: "oklch(0.14 0.012 280)",
-					terminalTitlebarBackground: "oklch(0.18 0.012 280)",
-					terminalTitlebarBorderBottomColor: "oklch(1 0 0 / 0.08)",
+					terminalBackground: "var(--terminal-bg)",
+					terminalTitlebarBackground: "var(--terminal-surface)",
+					terminalTitlebarBorderBottomColor: "var(--terminal-border)",
 					terminalTitlebarDotsForeground: "oklch(1 0 0 / 0.18)",
 				},
 			},

--- a/projects/rawkode.academy/website/src/components/Aside.astro
+++ b/projects/rawkode.academy/website/src/components/Aside.astro
@@ -18,89 +18,81 @@ const iconPaths: Record<Props["variant"], string> = {
 ---
 
 <div class={`aside aside--${variant}`}>
-	<div class="aside__rail" aria-hidden="true"></div>
-	<div class="aside__icon" aria-hidden="true">
-		<svg
-			class="h-4 w-4"
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke-width="1.5"
-			stroke="currentColor"
-		>
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				d={iconPaths[variant]}></path>
-		</svg>
+	<div class="aside__header" aria-hidden="true">
+		<span class="aside__icon">
+			<svg
+				class="h-4 w-4"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d={iconPaths[variant]}></path>
+			</svg>
+		</span>
+		<span class="aside__label">{variant}</span>
 	</div>
 	<div class="aside__body">
-		<span class="aside__label">{variant}</span>
 		<slot />
 	</div>
 </div>
 
 <style>
+	/* Icon + mono label form a header row; the body spans the full
+	   width below it so narrow viewports don't lose ~50px of measure
+	   to an icon gutter. Variant colour rides on a background tint and
+	   the header, not a side-stripe rail. */
 	.aside {
-		display: grid;
-		grid-template-columns: 4px 28px 1fr;
-		gap: 0.875rem;
-		align-items: start;
-		padding: 0.875rem 1rem;
-		margin: 1.25rem 0;
+		padding: 1rem 1.125rem;
+		margin: 1.75rem 0;
 		background: var(--editorial-paper-deep);
 		border: 1px solid var(--editorial-hairline);
 		border-radius: var(--radius-sm);
 		color: var(--editorial-ink);
 	}
 
-	.aside__rail {
-		width: 2px;
-		align-self: stretch;
-		justify-self: start;
-		background: var(--editorial-ink-mute);
-		margin-left: -1rem;
-		margin-block: -0.875rem;
+	.aside--tip { background: color-mix(in oklab, var(--editorial-spruce) 6%, var(--editorial-paper-deep)); }
+	.aside--caution { background: color-mix(in oklab, var(--editorial-amber) 8%, var(--editorial-paper-deep)); }
+	.aside--danger { background: color-mix(in oklab, var(--editorial-rust) 8%, var(--editorial-paper-deep)); }
+
+	.aside__header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.5rem;
+		color: var(--editorial-ink);
 	}
 
-	.aside--tip .aside__rail { background: var(--editorial-spruce); }
-	.aside--caution .aside__rail { background: var(--editorial-amber); }
-	.aside--danger .aside__rail { background: var(--editorial-rust); }
-	.aside--info .aside__rail { background: var(--editorial-ink); }
+	.aside--tip .aside__header { color: var(--editorial-spruce); }
+	.aside--caution .aside__header { color: var(--editorial-amber-text); }
+	.aside--danger .aside__header { color: var(--editorial-rust); }
 
 	.aside__icon {
-		width: 28px;
-		height: 28px;
+		width: 16px;
+		height: 16px;
 		display: grid;
 		place-items: center;
-		color: var(--editorial-ink);
-		margin-top: 0.1rem;
+		flex-shrink: 0;
 	}
-
-	.aside--tip .aside__icon { color: var(--editorial-spruce); }
-	.aside--caution .aside__icon { color: var(--editorial-amber-text); }
-	.aside--danger .aside__icon { color: var(--editorial-rust); }
 
 	.aside__body {
 		min-width: 0;
 		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.95rem;
-		line-height: 1.5;
+		font-size: 0.9375rem;
+		line-height: 1.6;
 	}
 
 	.aside__label {
-		display: block;
 		font-family: var(--font-jetbrains-mono), monospace;
 		font-size: 0.65rem;
 		font-weight: 500;
 		text-transform: uppercase;
 		letter-spacing: 0.14em;
-		color: var(--editorial-ink-mute);
-		margin-bottom: 0.35rem;
+		color: inherit;
 	}
-
-	.aside--tip .aside__label { color: var(--editorial-spruce); }
-	.aside--caution .aside__label { color: var(--editorial-amber-text); }
-	.aside--danger .aside__label { color: var(--editorial-rust); }
 
 	.aside :global(p) {
 		margin: 0;

--- a/projects/rawkode.academy/website/src/components/Aside.astro
+++ b/projects/rawkode.academy/website/src/components/Aside.astro
@@ -18,8 +18,8 @@ const iconPaths: Record<Props["variant"], string> = {
 ---
 
 <div class={`aside aside--${variant}`}>
-	<div class="aside__header" aria-hidden="true">
-		<span class="aside__icon">
+	<div class="aside__header">
+		<span class="aside__icon" aria-hidden="true">
 			<svg
 				class="h-4 w-4"
 				fill="none"

--- a/projects/rawkode.academy/website/src/components/AsideWrapper.tsx
+++ b/projects/rawkode.academy/website/src/components/AsideWrapper.tsx
@@ -23,14 +23,13 @@ const AsideWrapper: React.FC<AsideProps> = ({ variant, children }) => {
 
 	return (
 		<div className={`ed-aside ed-aside--${variant}`}>
-			<div className="ed-aside__rail" aria-hidden="true" />
-			<div className="ed-aside__icon" aria-hidden="true">
-				<IconComponent className="h-4 w-4" />
-			</div>
-			<div className="ed-aside__body">
+			<div className="ed-aside__header">
+				<span className="ed-aside__icon" aria-hidden="true">
+					<IconComponent className="h-4 w-4" />
+				</span>
 				<span className="ed-aside__label">{variant}</span>
-				{children}
 			</div>
+			<div className="ed-aside__body">{children}</div>
 		</div>
 	);
 };

--- a/projects/rawkode.academy/website/src/components/read/ArticleTOC.astro
+++ b/projects/rawkode.academy/website/src/components/read/ArticleTOC.astro
@@ -11,8 +11,7 @@ const { headings, tools = [] } = Astro.props as Props;
 
 const sections = headings
 	.filter((h) => h.depth === 2)
-	.map((h, i) => ({
-		num: `§${String(i + 1).padStart(2, "0")}`,
+	.map((h) => ({
 		slug: h.slug,
 		text: h.text,
 	}));
@@ -28,7 +27,6 @@ const sections = headings
 					href={`#${s.slug}`}
 					data-toc-slug={s.slug}
 				>
-					<span class="article-toc__num">{s.num}</span>
 					<span class="article-toc__text">{s.text}</span>
 				</a>
 			))}
@@ -117,27 +115,12 @@ const sections = headings
 		border-top-color: var(--editorial-ink);
 	}
 
-	.article-toc__num {
-		min-width: 2rem;
-		font-family: var(--font-jetbrains-mono), monospace;
-		font-size: 0.6875rem;
-		font-weight: 500;
-		letter-spacing: 0.14em;
-		color: var(--editorial-ink-mute);
-		text-transform: uppercase;
-	}
-
 	.article-toc__text {
 		font-family: var(--font-inter-tight), sans-serif;
 		font-size: 0.875rem;
 		font-weight: 400;
 		line-height: 1.35;
 		color: var(--editorial-ink-soft);
-	}
-
-	.article-toc__link:hover .article-toc__num,
-	.article-toc__link--active .article-toc__num {
-		color: var(--editorial-spruce);
 	}
 
 	.article-toc__link:hover .article-toc__text,

--- a/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
+++ b/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
@@ -11,7 +11,13 @@ interface NavLink {
 	iconPath: string;
 }
 
-const navItems: NavLink[] = [
+interface NavGroup {
+	label: string;
+	links: NavLink[];
+	comingSoon?: boolean;
+}
+
+const learnItems: NavLink[] = [
 	{
 		name: "News",
 		href: "/news",
@@ -68,6 +74,21 @@ const navItems: NavLink[] = [
 	},
 ];
 
+const workItems: NavLink[] = [
+	{
+		name: "Partnerships",
+		href: "/organizations/partnerships",
+		iconPath:
+			"M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0M12 12.75h.008v.008H12v-.008Z",
+	},
+];
+
+const navGroups: NavGroup[] = [
+	{ label: "Learn", links: learnItems },
+	{ label: "Work", links: workItems },
+	{ label: "Play", links: [], comingSoon: true },
+];
+
 const currentPath = Astro.url.pathname;
 
 function isCurrentPath(itemPath: string): boolean {
@@ -85,39 +106,63 @@ function isCurrentPath(itemPath: string): boolean {
 
 <aside id="site-sidebar" class="ed-sidebar" aria-label="Sidebar navigation">
 	<nav class="ed-sidebar__nav">
-		<ul class="ed-sidebar__list">
-			{
-				navItems.map((item) => {
-					const active = isCurrentPath(item.href);
-					return (
-						<li class="ed-sidebar__item">
-							<a
-								href={item.href}
-								class:list={["ed-nav-item", active && "ed-nav-item--active"]}
-								aria-current={active ? "page" : undefined}
-								data-nav-name={item.name}
-							>
-								<svg
-									class="ed-nav-item__icon"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke-width="1.6"
-									stroke="currentColor"
-									aria-hidden="true"
-								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										d={item.iconPath}
-									/>
-								</svg>
-								<span class="ed-nav-item__label">{item.name}</span>
-							</a>
-						</li>
-					);
-				})
-			}
-		</ul>
+		{
+			navGroups.map((group) => {
+				const labelId = `sidebar-group-${group.label.toLowerCase()}`;
+				return (
+					<section
+						class:list={[
+							"ed-sidebar__group",
+							group.links.length === 0 && "ed-sidebar__group--empty",
+						]}
+						aria-labelledby={labelId}
+					>
+						<span class="ed-sidebar__group-label" id={labelId}>
+							{group.label}
+						</span>
+						{group.comingSoon && (
+							<span class="ed-sidebar__soon">Coming soon</span>
+						)}
+						{group.links.length > 0 && (
+							<ul class="ed-sidebar__list">
+								{group.links.map((item) => {
+									const active = isCurrentPath(item.href);
+									return (
+										<li class="ed-sidebar__item">
+											<a
+												href={item.href}
+												class:list={[
+													"ed-nav-item",
+													active && "ed-nav-item--active",
+												]}
+												aria-current={active ? "page" : undefined}
+												data-nav-name={item.name}
+											>
+												<svg
+													class="ed-nav-item__icon"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke-width="1.6"
+													stroke="currentColor"
+													aria-hidden="true"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														d={item.iconPath}
+													/>
+												</svg>
+												<span class="ed-nav-item__label">{item.name}</span>
+											</a>
+										</li>
+									);
+								})}
+							</ul>
+						)}
+					</section>
+				);
+			})
+		}
 	</nav>
 
 	<div
@@ -494,6 +539,46 @@ function isCurrentPath(itemPath: string): boolean {
 	}
 	.ed-sidebar__nav::-webkit-scrollbar-thumb {
 		background: var(--editorial-hairline-strong);
+	}
+
+	.ed-sidebar__group {
+		padding-bottom: 0.625rem;
+	}
+
+	.ed-sidebar__group + .ed-sidebar__group {
+		border-top: 1px solid var(--editorial-hairline);
+		padding-top: 0.375rem;
+	}
+
+	.ed-sidebar__group-label {
+		display: block;
+		padding: 0.5rem 1rem 0.375rem;
+		font-family: var(--font-jetbrains-mono), monospace;
+		font-size: 0.65rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		color: var(--editorial-ink-mute);
+	}
+
+	.ed-sidebar__soon {
+		display: block;
+		padding: 0 1rem 0.5rem;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-size: 0.8125rem;
+		color: var(--editorial-ink-mute);
+	}
+
+	/* Collapsed rail: group names can't render, so groups read as
+	   hairline-separated icon clusters. An empty group has nothing to
+	   show at all. */
+	.ed-sidebar--collapsed .ed-sidebar__group-label,
+	.ed-sidebar--collapsed .ed-sidebar__soon {
+		display: none;
+	}
+
+	.ed-sidebar--collapsed .ed-sidebar__group--empty {
+		display: none;
 	}
 
 	.ed-sidebar__list {

--- a/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
+++ b/projects/rawkode.academy/website/src/components/sidebar/Sidebar.astro
@@ -136,6 +136,7 @@ function isCurrentPath(itemPath: string): boolean {
 													active && "ed-nav-item--active",
 												]}
 												aria-current={active ? "page" : undefined}
+												aria-label={item.name}
 												data-nav-name={item.name}
 											>
 												<svg

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -517,64 +517,56 @@ html.dark {
 		outline-offset: 2px;
 	}
 
-	/* Editorial aside callout — used by React AsideWrapper in MDX. */
+	/* Editorial aside callout — used by React AsideWrapper in MDX.
+	   Icon + mono label form a header row; the body spans the full
+	   width below it so narrow viewports don't lose ~50px of measure
+	   to an icon gutter. Variant colour rides on a background tint and
+	   the header, not a side-stripe rail. */
 	.ed-aside {
-		display: grid;
-		grid-template-columns: 4px 28px 1fr;
-		gap: 0.875rem;
-		align-items: start;
-		padding: 0.875rem 1rem;
-		margin: 1.25rem 0;
+		padding: 1rem 1.125rem;
+		margin: 1.75rem 0;
 		background: var(--editorial-paper-deep);
 		border: 1px solid var(--editorial-hairline);
 		border-radius: var(--radius-sm);
 		color: var(--editorial-ink);
 	}
 
-	.ed-aside__rail {
-		width: 2px;
-		align-self: stretch;
-		background: var(--editorial-ink-mute);
-		margin-left: -1rem;
-		margin-block: -0.875rem;
-	}
+	.ed-aside--tip     { background: color-mix(in oklab, var(--editorial-spruce) 6%, var(--editorial-paper-deep)); }
+	.ed-aside--caution { background: color-mix(in oklab, var(--editorial-amber) 8%, var(--editorial-paper-deep)); }
+	.ed-aside--danger  { background: color-mix(in oklab, var(--editorial-rust) 8%, var(--editorial-paper-deep)); }
 
-	.ed-aside--tip .ed-aside__rail     { background: var(--editorial-spruce); }
-	.ed-aside--caution .ed-aside__rail { background: var(--editorial-amber); }
-	.ed-aside--danger .ed-aside__rail  { background: var(--editorial-rust); }
-	.ed-aside--info .ed-aside__rail    { background: var(--editorial-ink); }
-
-	.ed-aside__icon {
-		width: 28px; height: 28px;
-		display: grid; place-items: center;
-		margin-top: 0.1rem;
+	.ed-aside__header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.5rem;
 		color: var(--editorial-ink);
 	}
-	.ed-aside--tip .ed-aside__icon     { color: var(--editorial-spruce); }
-	.ed-aside--caution .ed-aside__icon { color: var(--editorial-amber-text); }
-	.ed-aside--danger .ed-aside__icon  { color: var(--editorial-rust); }
+	.ed-aside--tip .ed-aside__header     { color: var(--editorial-spruce); }
+	.ed-aside--caution .ed-aside__header { color: var(--editorial-amber-text); }
+	.ed-aside--danger .ed-aside__header  { color: var(--editorial-rust); }
+
+	.ed-aside__icon {
+		width: 16px; height: 16px;
+		display: grid; place-items: center;
+		flex-shrink: 0;
+	}
 
 	.ed-aside__body {
 		min-width: 0;
 		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.95rem;
-		line-height: 1.5;
+		font-size: 0.9375rem;
+		line-height: 1.6;
 	}
 
 	.ed-aside__label {
-		display: block;
 		font-family: var(--font-jetbrains-mono), monospace;
 		font-size: 0.65rem;
 		font-weight: 500;
 		text-transform: uppercase;
 		letter-spacing: 0.14em;
-		color: var(--editorial-ink-mute);
-		margin-bottom: 0.35rem;
+		color: inherit;
 	}
-	.ed-aside--tip .ed-aside__label     { color: var(--editorial-spruce); }
-	.ed-aside--caution .ed-aside__label { color: var(--editorial-amber-text); }
-	.ed-aside--danger .ed-aside__label  { color: var(--editorial-rust); }
-	.ed-aside--info .ed-aside__label    { color: var(--editorial-ink); }
 
 	.ed-aside p { margin: 0; }
 	.ed-aside p + p { margin-top: 0.5rem; }
@@ -589,85 +581,27 @@ html.dark {
 	.ed-aside a:hover { text-decoration-color: currentColor; }
 
 	/* ════════════════════════════════════════════════════════════════
-	   Article body — Instrument Serif paragraphs on /read/[slug] pages.
-	   The general `.prose` rules below still use Inter Tight for body
-	   on changelog / ADRs / etc.; `.article-prose` opts long-form
-	   articles into the serif reading body per the read-pages design. */
-	.article-prose {
-		font-family: var(--font-instrument-serif), "Iowan Old Style", Georgia, serif;
-		font-size: 1.125rem;
-		line-height: 1.55;
-		color: var(--editorial-ink-soft);
-	}
-
+	   Article body — long-form articles on /read/[slug] read through the
+	   standard `.prose` ramp (Inter Tight body, serif italic display
+	   headings). Instrument Serif is a display face; per the Display
+	   Scarcity Rule it carries headings and ledes, not running text. */
 	.article-prose > p:first-of-type {
-		font-family: var(--font-instrument-serif), "Iowan Old Style", Georgia, serif;
-		font-size: 1.375rem;
-		line-height: 1.45;
-		color: var(--editorial-ink);
+		font-size: 1.3125rem;
+		line-height: 1.5;
 	}
 
-	.article-prose p,
-	.article-prose li {
-		font-family: var(--font-instrument-serif), "Iowan Old Style", Georgia, serif;
-	}
-
-	.article-prose strong,
-	.article-prose b,
-	.article-prose em,
-	.article-prose i {
-		font-family: inherit;
-	}
-
-	/* Section headings inside articles: the chat described them as
-	   "§NN ·" mono kicker beside a serif italic h2. Render h2/h3 with
-	   the section-mark prefix using a CSS counter so MDX stays clean. */
-	.article-prose {
-		counter-reset: article-section;
-	}
-
+	/* Articles breathe a little more between sections than the compact
+	   changelog / ADR prose. */
 	.article-prose h2 {
-		counter-increment: article-section;
-		display: grid;
-		grid-template-columns: auto 1fr;
-		column-gap: 0.875rem;
-		align-items: baseline;
 		margin-top: 3rem;
 		margin-bottom: 1.125rem;
 	}
 
-	.article-prose h2::before {
-		content: "§" counter(article-section, decimal-leading-zero);
-		font-family: var(--font-jetbrains-mono), monospace;
-		font-style: normal;
-		font-size: 0.6875rem;
-		font-weight: 500;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: var(--editorial-spruce);
-		line-height: 1.4;
-		grid-column: 1;
-	}
-
-	.article-prose h2 > * {
-		grid-column: 2;
-	}
-
-	/* When prose links wrap a heading (MDX autolink), keep the
-	   inner heading aligned with the section mark. */
-	.article-prose h2 :global(a) {
+	/* When prose links wrap a heading (MDX autolink), keep headings
+	   looking like headings. */
+	.article-prose :is(h2, h3, h4) a {
 		text-decoration: none;
 		color: inherit;
-	}
-
-	@media (max-width: 720px) {
-		.article-prose h2 {
-			grid-template-columns: 1fr;
-			row-gap: 0.25rem;
-		}
-		.article-prose h2::before {
-			grid-column: 1;
-		}
 	}
 
 	/* ════════════════════════════════════════════════════════════════
@@ -924,6 +858,22 @@ html.dark {
 		margin-bottom: 1.5rem;
 	}
 
+	/* On phones the article gutter is 1.25rem a side and code is the
+	   widest content on the page — let blocks bleed to the viewport
+	   edges to claw that measure back. */
+	@media (max-width: 720px) {
+		.article-prose .expressive-code {
+			margin-inline: -1.25rem;
+		}
+
+		.article-prose .expressive-code .frame,
+		.article-prose .expressive-code .frame pre,
+		.article-prose .expressive-code .frame .header {
+			border-radius: 0;
+			border-inline-width: 0;
+		}
+	}
+
 	/* Images — paperDeep frame, 2px hairline, no shadow. */
 	.prose img {
 		border: 1px solid var(--surface-border);
@@ -1162,4 +1112,120 @@ html.dark {
 	background: transparent;
 	border: 0;
 	overflow-wrap: normal;
+}
+
+/* Tables already scroll horizontally on narrow viewports; never break
+   a `cpu.cfs_quota_us`-style identifier mid-token inside one. (Unlayered
+   like the `.prose code` rule above, which it has to out-cascade.) */
+.prose table code {
+	overflow-wrap: normal;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Prose rhythm — unlayered restatements.
+
+   The UnoCSS preflight reset is injected unlayered, so it out-cascades
+   everything in @layer base/components regardless of specificity:
+   `h1..h6 { font-size: inherit }`, `h1..h6, p, blockquote, hr, pre
+   { margin: 0 }` and `ol, ul { padding: 0 }` were silently flattening
+   the entire prose ramp (body-sized headings, zero paragraph spacing,
+   bullets hanging outside the text column). Every size/spacing rule
+   the reset clobbers is restated here, unlayered, mirroring the
+   `.prose code` rules above.
+   ════════════════════════════════════════════════════════════════ */
+.prose h1 {
+	font-size: clamp(2.25rem, 5vw, 3.5rem);
+	font-weight: 400;
+	margin: 2.5rem 0 1.25rem;
+}
+
+.prose h2 {
+	font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+	font-weight: 400;
+	margin: 2.25rem 0 1rem;
+}
+
+.prose h3 {
+	font-size: clamp(1.25rem, 2.5vw, 1.5rem);
+	font-weight: 500;
+	margin: 2rem 0 0.875rem;
+}
+
+.prose h4 {
+	font-size: clamp(1.125rem, 2vw, 1.25rem);
+	font-weight: 500;
+	margin: 1.75rem 0 0.75rem;
+}
+
+.article-prose h2 {
+	margin-top: 3rem;
+	margin-bottom: 1.125rem;
+}
+
+.prose p {
+	margin-bottom: 1.5rem;
+}
+
+.prose ul {
+	margin-bottom: 1.5rem;
+	padding-left: 2rem;
+}
+
+.prose ol {
+	margin-bottom: 1.5rem;
+	padding-left: 2.5rem;
+}
+
+.prose :is(ul, ol) > li {
+	padding-left: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.prose li > p {
+	margin: 0.5rem 0;
+}
+
+.prose li > p:first-child {
+	margin-top: 0;
+}
+
+.prose li > p:last-child {
+	margin-bottom: 0;
+}
+
+.prose li > :is(ul, ol) {
+	margin-block: 0.625rem;
+}
+
+.prose blockquote {
+	margin: 2rem 0;
+}
+
+.prose blockquote p {
+	margin-bottom: 0;
+}
+
+.prose blockquote p:not(:last-child) {
+	margin-bottom: 0.75rem;
+}
+
+.prose img {
+	margin: 2rem 0;
+}
+
+.prose pre {
+	margin-bottom: 1.5rem;
+}
+
+.prose hr {
+	border: none;
+	margin: 3rem auto;
+}
+
+.prose > *:first-child {
+	margin-top: 0;
+}
+
+.prose > *:last-child {
+	margin-bottom: 0;
 }


### PR DESCRIPTION
## Sidebar categories

The sidebar nav is now grouped into three sections with mono kicker labels and hairline separators:

- **Learn** — all existing destinations (News, Videos, Articles, Technology Matrix, Courses, Learning Paths, Shows, Technologies, People)
- **Work** — Partnerships
- **Play** — "Coming soon", no links yet

The collapsed desktop rail keeps the hairline separators between groups and hides the empty Play group; the mobile drawer shows the full grouped list.

## Article prose & code-block overhaul (verified on the cgroups article)

Root cause of most of the weirdness: the **unlayered UnoCSS preflight reset out-cascades everything in `@layer base/components`**, so the `.prose` ramp was silently flattened — headings collapsed to body size (`h2 { font-size: inherit }`), paragraph/list/blockquote/hr margins were zeroed, and list padding vanished. The affected size/spacing rules are now restated unlayered, following the existing unlayered `.prose code` pattern in `global.css`.

On top of that:

- **Body type**: long-form articles now read through the standard Inter Tight prose body instead of Instrument Serif running text (serif stays on display headings, per the Display Scarcity Rule in DESIGN.md).
- **Code blocks**: single Catppuccin Mocha theme on the `--terminal-*` tokens, so shell, output, and editor frames are all the same theme-invariant dark "screen" in both colour schemes (previously light-mode pages mixed dark terminal frames with white editor frames). Blocks bleed full-width on phones to reclaim measure.
- **Asides**: icon + mono label now form a header row with the body at full width below (no more ~50px icon gutter on mobile), with a variant-tinted background instead of a colored side-stripe rail.
- **`§NN` section marks** removed from article headings and the TOC.
- **Tables** no longer break identifiers like `cpu.cfs_quota_us` mid-token; they rely on the existing horizontal scroll.
- The cgroups "Tested on" note is now an info `<Aside>` instead of a blockquote that rendered as a serif pull-quote.

Verified in headless Chromium at 390px and 1280px, light and dark schemes: sidebar states (expanded/collapsed/mobile drawer), headings, lists, tables, asides, and code blocks. `bun run test`: 128 passed.

https://claude.ai/code/session_01MrwzfXgHiz3FPY283FiFfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrwzfXgHiz3FPY283FiFfx)_