### PR TITLE
Rawkode Academy News - June 13, 2026

### DIFF
--- a/content/news/2026-06-13-vllm-sglang-gateway-api-kueue/index.mdx
+++ b/content/news/2026-06-13-vllm-sglang-gateway-api-kueue/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "vLLM 0.23, SGLang 0.5.13, and Gateway API 1.6-rc.1 ship serving and routing changes"
-description: "vLLM 0.23.0 makes Model Runner V2 the default for Llama and Mistral and deprecates Transformers v4, SGLang 0.5.13 promotes Spec V2 to the default speculative-decoding path, and Gateway API 1.6.0-rc.1 graduates TCPRoute and UDPRoute to GA."
+title: "vLLM 0.23, SGLang 0.5.13, Gateway API 1.6.0-rc.1, and Kueue 0.18.1 ship serving, routing, and scheduling changes"
+description: "vLLM 0.23.0 makes Model Runner V2 the default for Llama and Mistral and deprecates Transformers v4, SGLang 0.5.13 promotes Spec V2 to the default speculative-decoding path, Gateway API 1.6.0-rc.1 graduates TCPRoute and UDPRoute to GA, and Kueue 0.18.1 fixes DRA requeueing and topology-aware quota handling."
 publishedAt: 2026-06-13
 authors:
   - rawkode

--- a/content/news/2026-06-13-vllm-sglang-gateway-api-kueue/index.mdx
+++ b/content/news/2026-06-13-vllm-sglang-gateway-api-kueue/index.mdx
@@ -1,0 +1,59 @@
+---
+title: "vLLM 0.23, SGLang 0.5.13, and Gateway API 1.6-rc.1 ship serving and routing changes"
+description: "vLLM 0.23.0 makes Model Runner V2 the default for Llama and Mistral and deprecates Transformers v4, SGLang 0.5.13 promotes Spec V2 to the default speculative-decoding path, and Gateway API 1.6.0-rc.1 graduates TCPRoute and UDPRoute to GA."
+publishedAt: 2026-06-13
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+---
+
+Four releases landed in the last 24 hours across LLM serving, L4 routing, and batch scheduling.
+
+## vLLM 0.23.0 defaults Model Runner V2 for dense models and deprecates Transformers v4
+
+vLLM published v0.23.0 on June 12, with 408 commits from 200 contributors. The release makes Model Runner V2 the default path for Llama and Mistral dense models, adding FlashInfer sampling, breakable CUDA graphs, and pipeline-parallel bubble elimination on that path.
+
+The breaking-class change is the deprecation of Transformers v4 support, with the project moving model loading onto Transformers v5. The release also lands a multi-tier KV cache offloading framework with an object-store secondary tier and per-request policies, continues DeepSeek-V4 hardening with decoupled sparse MLA metadata and TRTLLM attention kernels, and extends the experimental Rust frontend with streaming generate, dynamic LoRA, and new tool parsers.
+
+For operators tracking vLLM images, the concrete action items are the Transformers v5 migration and Model Runner V2 becoming the default for two of the most common dense-model families.
+
+**Source:** [vLLM v0.23.0 release](https://github.com/vllm-project/vllm/releases/tag/v0.23.0) - June 12, 2026
+
+---
+
+## SGLang 0.5.13 promotes Spec V2 to the default speculative-decoding path
+
+SGLang released v0.5.13 on June 13. Spec V2 is now the default speculative-decoding path and supports tree drafting (topk > 1); Spec V1 is deprecated, and EAGLE and MTP models are migrated onto a unified V2 worker.
+
+The release reduces per-step scheduler overhead through unified async value passing, extends Piecewise and Breakable CUDA Graph coverage to DSA models, Kimi-K2.5, and DeepSeek V4, and enables HiCache by default for hybrid SWA/Mamba models. DeepSeek V4 support gains context parallelism with MTP, fused MoE kernels, sparse attention kernels, and SM120 GPU support. The release bumps transformers to 5.8.1, flashinfer to 0.6.12, and sgl-kernel to 0.4.3.
+
+Teams running EAGLE or MTP speculative decoding should plan the move off the deprecated V1 worker before it is removed.
+
+**Source:** [SGLang v0.5.13 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.13) - June 13, 2026
+
+---
+
+## Gateway API 1.6.0-rc.1 graduates TCPRoute and UDPRoute to GA
+
+The Gateway API project cut v1.6.0-rc.1 on June 12. Both TCPRoute and UDPRoute graduate to GA on the v1 API version, with the v1alpha2 versions of each now deprecated.
+
+The release candidate also moves the CORS filter into the standard channel, raises the allowed Certificate Authority references from 8 to 16, lifts TLSRoute to 4096 hostnames and rules, and allows BackendTLSPolicy to apply alongside other route types. HTTPRoute retry validation now requires unique retry codes and at least one attempt.
+
+This is a release candidate rather than a final tag, but it sets the v1 contract that platform teams exposing raw L4 services through Gateway API will standardize on once 1.6.0 ships.
+
+**Source:** [Gateway API v1.6.0-rc.1 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0-rc.1) - June 12, 2026
+
+---
+
+## Kueue 0.18.1 fixes DRA extended-resource requeueing and topology quota handling
+
+Kueue published the v0.18.1 patch on June 12. It fixes a bug where pending Workloads using DRA extended resources were not requeued when their DeviceClass was deleted or its `extendedResourceName` changed, and adds validation that rejects `deviceClassMappings` when the `KueueDRAIntegrationPartitionableDevices` feature gate is disabled.
+
+On the scheduling side, Topology-Aware Scheduling no longer ignores excluded or transformed resources during node capacity tracking, and Workloads with failed topology assignments are now classified as NoFit rather than Fit, preventing them from holding quota reservations they cannot use. The release also raises the LocalQueue status flavor limit from 16 to 64 to match ClusterQueue.
+
+For GPU and accelerator queues built on DRA, the requeue and NoFit fixes change how stuck Workloads recover and how reserved quota is accounted.
+
+**Source:** [Kueue v0.18.1 release](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1) - June 12, 2026
+
+---


### PR DESCRIPTION
## Summary

Four releases landed inside the June 12–13 window across LLM serving, L4 routing, and batch scheduling. vLLM 0.23.0 and SGLang 0.5.13 both shipped major serving changes (Model Runner V2 default for dense models / Transformers v4 deprecation; Spec V2 as the default speculative-decoding path), Gateway API 1.6.0-rc.1 graduates TCPRoute and UDPRoute to GA, and Kueue 0.18.1 fixes DRA extended-resource requeueing and topology-aware quota handling. Each segment cites a Tier 1 primary release and was verified against its Atom feed timestamp.

## Run metadata

- Run time: `2026-06-13 06:00 Europe/London`
- Coverage window: `2026-06-12 06:00 Europe/London` to `2026-06-13 06:00 Europe/London`
- Source URLs inspected: `~35`
- Candidates longlisted: `10`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- vLLM 0.23.0 — Model Runner V2 becomes the default for Llama/Mistral dense models and Transformers v4 is deprecated, so image bumps now require a v5 migration.
- SGLang 0.5.13 — Spec V2 becomes the default speculative-decoding path and V1 is deprecated, forcing EAGLE/MTP users onto the unified V2 worker.
- Gateway API 1.6.0-rc.1 — TCPRoute and UDPRoute graduate to GA on v1, setting the contract platform teams exposing raw L4 services will standardize on.
- Kueue 0.18.1 — DRA extended-resource requeue and topology NoFit-classification fixes change how stuck accelerator Workloads recover and how reserved quota is accounted.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| vLLM v0.23.0 published 2026-06-12T23:33:08Z | github.com/vllm-project/vllm releases.atom `<updated>` for v0.23.0 | ✅ |
| Model Runner V2 default for Llama/Mistral dense; Transformers v4 deprecated | vLLM v0.23.0 release notes | ✅ |
| SGLang v0.5.13 published 2026-06-13T00:17Z | github.com/sgl-project/sglang releases.atom + release notes | ✅ |
| Spec V2 default path, V1 deprecated, EAGLE/MTP on unified V2 worker | SGLang v0.5.13 release notes | ✅ |
| Gateway API v1.6.0-rc.1 published 2026-06-12T16:28:01Z | github.com/kubernetes-sigs/gateway-api releases.atom entry `<updated>` (confirmed twice) | ✅ |
| TCPRoute and UDPRoute graduate to GA (v1; v1alpha2 deprecated); CORS filter in standard channel; CA refs 8→16 | Gateway API v1.6.0-rc.1 release notes | ✅ |
| Kueue v0.18.1 published 2026-06-12T12:18:21Z | github.com/kubernetes-sigs/kueue releases.atom `<updated>` | ✅ |
| DRA extended-resource requeue fix; TAS NoFit classification; LocalQueue flavor limit 16→64 | Kueue v0.18.1 release notes | ✅ |

## Items considered and dropped

- NVIDIA `nccl4py-v0.3.1` (2026-06-11T18:46Z) — outside the 24h window.
- Envoy v1.38.2 / v1.37.4 / v1.36.8 / v1.35.12 patch wave (2026-06-11) — outside the 24h window.
- Dapr 1.18 "Verifiable Execution" CNCF project post (2026-06-11) — outside the 24h window.
- arXiv June 12 systems papers (Maestro cross-cluster multi-agent scheduling; Eidola multi-GPU traffic modeling; GF-DiT) — research papers, not release news; dropped to avoid a paper/take roundup.
- Kueue v0.17.5 (2026-06-12) — same fixes backported to the 0.17 line; redundant with v0.18.1.
- CNCF "Securing CI/CD for an open source project" member post (2026-06-12) — positioning, no technical artifact.
- Wasmtime `dev` rolling tag (2026-06-12) — CI commit on a non-release rolling tag.

## Reviewer notes

- Stages completed: Discovery → Triage → Draft → Adversarial Review → Fact-check → Edit Pass → Final Review
- Total candidates considered: 10
- Segments shipped: 4
- Note on timestamps: GitHub tag-page rendering misreported the year ("2024") for several releases; all freshness decisions were made against the authoritative `releases.atom` `<updated>` timestamps, which consistently showed 2026.
- Two of four segments are LLM-serving releases (vLLM, SGLang) — distinct projects and distinct technical changes, balanced by one networking and one scheduling segment.
- Gateway API 1.6.0-rc.1 is a release candidate; the segment frames the GA graduations as the v1 contract landing once 1.6.0 ships, not as a final tag.
- Any vendor-attributed claims: none — all four are OSS project releases cited to their own release notes.

https://claude.ai/code/session_011ZJjyUzqmJByexVCks3Kv9

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZJjyUzqmJByexVCks3Kv9)_