### PR TITLE
Rawkode Academy News - June 13, 2026

### DIFF
--- a/content/news/2026-06-13-vllm-sglang-kubernetes-kueue-helm/index.mdx
+++ b/content/news/2026-06-13-vllm-sglang-kubernetes-kueue-helm/index.mdx
@@ -1,0 +1,72 @@
+---
+title: "vLLM, SGLang, Kubernetes, Kueue, and Helm ship runtime fixes"
+description: "vLLM and SGLang released AI serving updates, while Kubernetes, Kueue, and Helm shipped scheduler, queueing, and release-management fixes."
+publishedAt: 2026-06-13
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - ai-infrastructure
+---
+
+Five fresh releases landed in the last 24 hours across AI serving, Kubernetes scheduling, workload queueing, and Helm release management.
+
+## vLLM v0.23.0 expands Model Runner V2 and KV-cache offload
+
+vLLM published v0.23.0 on June 12 with 408 commits across model support, serving internals, distributed execution, and hardware backends. Model Runner V2 is now selected by default for Llama and Mistral dense models, after previously landing for Qwen3.
+
+The release adds an object-store secondary tier to the KV-cache offloading framework, enables HMA by default for capable connectors, and adds per-request offloading policy through the `on_new_request` lifecycle hook. It also moves vLLM toward Transformers v5, deprecates v4 support, expands the experimental Rust frontend with streaming `generate`, dynamic LoRA, `/version`, and `/server_info` endpoints, and continues DeepSeek-V4 work across attention, RoPE, sparse MLA metadata, EPLB, and XPU decode paths.
+
+For operators running mixed model fleets, the practical change is broader default coverage for the newer execution path plus more explicit cache-tiering controls for disaggregated serving.
+
+**Source:** [vLLM v0.23.0 release](https://github.com/vllm-project/vllm/releases/tag/v0.23.0) - June 12, 2026
+
+---
+
+## SGLang v0.5.13 makes Spec V2 the default speculative path
+
+SGLang released v0.5.13 on June 13 with runtime changes across speculative decoding, scheduler overhead, CUDA graph capture, hybrid-model cache offload, and DeepSeek V4 serving. The main serving change is that Spec V2 is now the default speculative-decoding path, with tree drafting across Triton, FA3, MLA, and AITER backends, including `page_size > 1` and Mamba or hybrid-linear models.
+
+The release deprecates Spec V1, moves EAGLE and MTP onto the unified V2 worker, and adds faster top-k equals 1 drafting. It also extends Piecewise and Breakable CUDA Graph coverage to DSA models, Kimi-K2.5, and DeepSeek V4; enables HiCache by default for hybrid SWA and Mamba models through UnifiedTree; and adds DeepSeek V4 context-parallel serving, sparse FlashMLA, FP4 indexer support, SM120 support, and DeepEP waterfill load balancing.
+
+This matters for inference teams because speculative decode, CUDA graph capture, and hierarchical KV-cache offload are becoming default-path behavior rather than optional tuning around the core server.
+
+**Source:** [SGLang v0.5.13 release](https://github.com/sgl-project/sglang/releases/tag/v0.5.13) - June 13, 2026
+
+---
+
+## Kubernetes ships June patch releases with DRA and storage fixes
+
+Kubernetes published [v1.36.2](https://github.com/kubernetes/kubernetes/releases/tag/v1.36.2), [v1.35.6](https://github.com/kubernetes/kubernetes/releases/tag/v1.35.6), [v1.34.9](https://github.com/kubernetes/kubernetes/releases/tag/v1.34.9), and [v1.33.13](https://github.com/kubernetes/kubernetes/releases/tag/v1.33.13) on June 12. The v1.36.2 changelog includes DRA scheduler fixes for mutually exclusive device partitions, Pods stuck Pending when multi-node and per-node claims are mixed, and a kube-scheduler panic when `allocationMode: All` selects a device using shared counters.
+
+The backports also include endpoint-controller panic fixes for Services with empty `IPFamilies`, CSI republish handling so kubelet does not delete the mount directory after a failed `NodePublishVolume` call, and a 1.34+ regression fix for Secret API objects containing binary non-UTF-8 data in container environment values. Kubernetes v1.36.2 is also built with Go 1.26.4.
+
+For clusters testing DRA or CSI republish behavior, this patch set is more than routine version churn: it fixes scheduler and kubelet failure modes that can directly affect workload placement and volume contents.
+
+**Source:** [Kubernetes releases](https://github.com/kubernetes/kubernetes/releases) - June 12, 2026
+
+---
+
+## Kueue v0.18.1 and v0.17.5 repair DRA, TAS, and queue status behavior
+
+Kueue published [v0.18.1](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1) and [v0.17.5](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.5) on June 12. The v0.18.1 release fixes pending DRA Workloads not being requeued when a `DeviceClass` is deleted or its `extendedResourceName` changes, rejects partitionable-device `sources` config when the related feature gate is disabled, and avoids hot reconcile loops for deterministic DRA resolution failures.
+
+Both supported lines include fixes for regular Workloads being rejected when `ElasticJobsViaWorkloadSlicesWithTAS` is enabled, LocalQueue status updates failing when a referenced ClusterQueue has more than 16 flavors, and TAS topology assignment errors being treated as `Fit` instead of `NoFit`. The releases also correct unset borrowing and lending limits in metrics to report `+Inf`, matching unconstrained behavior instead of reporting zero.
+
+Batch platform teams using Kueue for accelerator queues should treat this as a scheduler correctness release, especially if DRA or topology-aware scheduling is enabled.
+
+**Source:** [Kueue v0.18.1 release](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1) - June 12, 2026
+
+---
+
+## Helm v4.2.1 and v3.21.1 patch CLI and SDK edge cases
+
+Helm released [v4.2.1](https://github.com/helm/helm/releases/tag/v4.2.1) and [v3.21.1](https://github.com/helm/helm/releases/tag/v3.21.1) on June 12. Helm 4.2.1 fixes a data race in `FailingKubeClient.RecordedWaitOptions`, success messages that were written to stderr instead of stdout, false warnings when resolving version range constraints, and a `WaitForDelete` race where the status observer could cancel the watch too early.
+
+Helm 3.21.1 fixes a nil REST client getter panic in ClientOnly CRD install flows, keeps registry credentials during plain-HTTP fallback with `oras-go` v2.6.1, and moves the v3 line to Go 1.26. Both v4.2.1 and v3.21.1 bump `golang.org/x/net` to v0.55.0 to address GO-2026-5026.
+
+The release is most relevant to teams embedding Helm as an SDK or depending on deterministic CLI output in automation.
+
+**Source:** [Helm v4.2.1 release](https://github.com/helm/helm/releases/tag/v4.2.1) - June 12, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest covers five fresh operator-facing releases from the last 24 hours: vLLM and SGLang serving/runtime updates, Kubernetes and Kueue scheduler and queueing fixes, and Helm CLI/SDK patch releases. Each item shipped because the primary artifact was fresh, technically specific, and useful to cloud native or AI infrastructure practitioners.

## Run metadata

- Run time: `2026-06-13 07:01 Europe/London`
- Coverage window: `2026-06-12 07:01 Europe/London` to `2026-06-13 07:01 Europe/London`
- Source URLs inspected: `61`
- Candidates longlisted: `8`
- Candidates shortlisted: `5`
- Segments shipped: `5`
- Time horizon: last 24 hours only

## Segments

- vLLM v0.23.0 expands Model Runner V2 and KV-cache offload - broader default MRv2 coverage and explicit cache-tiering controls for disaggregated serving.
- SGLang v0.5.13 makes Spec V2 the default speculative path - speculative decoding, CUDA graph capture, and HiCache move further into default serving paths.
- Kubernetes ships June patch releases with DRA and storage fixes - supported releases fix DRA scheduling, endpoint-controller, CSI republish, and Secret env regressions.
- Kueue v0.18.1 and v0.17.5 repair DRA, TAS, and queue status behavior - queue admission, topology assignment, and metrics correctness fixes affect accelerator scheduling.
- Helm v4.2.1 and v3.21.1 patch CLI and SDK edge cases - release-management automation gets stdout, version constraint, race, panic, and dependency fixes.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| vLLM v0.23.0 was published on June 12, 2026. | https://github.com/vllm-project/vllm/releases/tag/v0.23.0 release timestamp | ✅ |
| vLLM v0.23.0 contains 408 commits from 200 contributors and makes MRv2 default for Llama and Mistral dense models. | https://github.com/vllm-project/vllm/releases/tag/v0.23.0 Highlights | ✅ |
| vLLM v0.23.0 adds object-store secondary KV-cache offload, HMA defaulting, and per-request offload policy via `on_new_request`. | https://github.com/vllm-project/vllm/releases/tag/v0.23.0 Highlights and Large Scale Serving sections | ✅ |
| SGLang v0.5.13 was published on June 13, 2026. | https://github.com/sgl-project/sglang/releases/tag/v0.5.13 release timestamp | ✅ |
| SGLang v0.5.13 makes Spec V2 the default speculative-decoding path and deprecates Spec V1. | https://github.com/sgl-project/sglang/releases/tag/v0.5.13 Highlights and Speculative Decoding sections | ✅ |
| SGLang v0.5.13 extends PCG/BCG coverage and enables HiCache for hybrid SWA/Mamba models by default. | https://github.com/sgl-project/sglang/releases/tag/v0.5.13 Highlights, Piecewise & Breakable CUDA Graph, HiCache sections | ✅ |
| Kubernetes v1.36.2, v1.35.6, v1.34.9, and v1.33.13 were published on June 12, 2026. | https://github.com/kubernetes/kubernetes/releases release timestamps | ✅ |
| Kubernetes v1.36.2 fixes DRA scheduler double-allocation, Pending multi-node/per-node claims, and a scheduler panic with `allocationMode: All`. | https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-1.36.md v1.36.2 changelog | ✅ |
| Kubernetes backports include endpoint-controller, CSI republish, and 1.34+ binary Secret env regression fixes in the applicable release lines. | Kubernetes CHANGELOG-1.36.md, CHANGELOG-1.35.md, CHANGELOG-1.34.md, and CHANGELOG-1.33.md v1.36.2/v1.35.6/v1.34.9/v1.33.13 sections | ✅ |
| Kueue v0.18.1 and v0.17.5 were published on June 12, 2026. | https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1 and https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.5 release timestamps | ✅ |
| Kueue v0.18.1 fixes DRA requeueing on `DeviceClass` changes, feature-gate validation, and deterministic DRA hot reconcile loops. | https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1 Bug or Regression section | ✅ |
| Kueue v0.18.1/v0.17.5 fix LocalQueue flavor limits, TAS `Fit`/`NoFit` handling, and unset borrowing/lending metrics. | https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1 and https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.5 Bug or Regression sections | ✅ |
| Helm v4.2.1 and v3.21.1 were published on June 12, 2026. | https://github.com/helm/helm/releases/tag/v4.2.1 and https://github.com/helm/helm/releases/tag/v3.21.1 release timestamps | ✅ |
| Helm v4.2.1 fixes the FailingKubeClient data race, stdout/stderr success messages, version range warnings, and WaitForDelete race. | https://github.com/helm/helm/releases/tag/v4.2.1 Notable Changes and Changelog | ✅ |
| Helm v3.21.1 fixes ClientOnly CRD install panic, plain-HTTP registry credential fallback, Go 1.26, and `golang.org/x/net` GO-2026-5026 dependency bump. | https://github.com/helm/helm/releases/tag/v3.21.1 Notable Changes and Changelog | ✅ |

## Items considered and dropped

- Dapr Runtime v1.16.16-rc.1 - fresh but only an RC for one downgrade fix; stable v1.16.15 source was outside the window.
- CNCF CI/CD dependency-locking post - fresh and useful, but an evergreen how-to rather than daily news.
- Cloudflare Security Insights scaling post - fresh engineering writeup, but less directly relevant than the five release artifacts and would tilt the issue toward vendor case-study coverage.
- arXiv AI/HPC systems papers - relevant papers found were submitted before the 24-hour window.
- Argo CD, Flux, Crossplane, Backstage, Gateway API, cert-manager, cosign, SPIRE, Kyverno, Prometheus, OpenTelemetry, containerd, CRI-O, etcd, Cluster API, Triton, PyTorch, Ray, Kubeflow Trainer, Dragonfly, Knative, OPA, wasmCloud, and nerdctl - latest primary release artifacts were outside the 24-hour window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 8 longlisted fresh candidates, plus stale-source sweeps across the usual release feeds
- Segments shipped: 5
- Any unresolved framing concerns: none
- Any vendor-attributed claims: none
- Local publishing note: linked-worktree `HEAD.lock` and `index.lock` permissions blocked local branch/commit creation, so the branch and commit were created through the GitHub connector after content validation.
- Reviewer request note: CODEOWNERS resolves this path to `@rawkode`; GitHub rejected requesting review from the pull request author.
