### PR TITLE
fix(rawkode.academy/website): require login for games in production

### DIFF
--- a/projects/rawkode.academy/website/env.cue
+++ b/projects/rawkode.academy/website/env.cue
@@ -11,8 +11,13 @@ hooks: onEnter: devenv: schema.#Devenv
 
 let _t = tasks
 env: {
-	GRAPHQL_ENDPOINT:  "https://api.rawkode.academy/"
+	GRAPHQL_ENDPOINT: "https://api.rawkode.academy/"
+	// Bypass the game login gate in local dev only. Production MUST require
+	// login (games read Astro.locals.user); the production override forces it off.
 	DISABLE_GAME_AUTH: true
+	environment: production: {
+		DISABLE_GAME_AUTH: false
+	}
 }
 
 ci: pipelines: {
@@ -58,8 +63,11 @@ tasks: {
 		command:  "bun"
 		args: ["run", "build"]
 
+		// env.cue is included so build-time env changes (e.g. DISABLE_GAME_AUTH)
+		// mark the build/deploy affected; otherwise CI would skip the redeploy.
 		inputs: [
 			"astro.config.mts",
+			"env.cue",
 			"package.json",
 			"public/**",
 			"src/**",


### PR DESCRIPTION
## Problem
`DISABLE_GAME_AUTH: true` was set **globally** in `website/env.cue`, so it shipped to the production build. The game page does `disableAuth = DISABLE_GAME_AUTH === "true"` and `canPlay = !!user || disableAuth` — with `disableAuth` true, the login gate was bypassed (Guess the Logo and the SKI game were both playable logged-out).

## Fix
- Scope the bypass to **local dev only** via a production override: `environment: production: { DISABLE_GAME_AUTH: false }`. Production now requires `Astro.locals.user`; logged-out visitors get the sign-in CTA. CUE eval confirms base→`true` (dev), production→`false`.
- Add `env.cue` to the `build` task inputs so build-time env changes mark the website affected — otherwise cuenv change-detection skips the redeploy.

## Verification after merge
The website redeploys (env.cue is now an affected input); logged-out → sign-in CTA, logged-in → game. I'll confirm on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)