### PR TITLE
fix(rawkode.academy/website): trigger production deploy on env.cue changes

### DIFF
--- a/projects/rawkode.academy/website/env.cue
+++ b/projects/rawkode.academy/website/env.cue
@@ -87,8 +87,11 @@ tasks: {
 				"-lc",
 				"bun run build && bun x wrangler deploy --config ./dist/server/wrangler.json",
 			]
+			// env.cue drives build-time vars (e.g. DISABLE_GAME_AUTH); include it so
+			// an env-only change marks this deploy affected (else CI skips it).
 			inputs: [
 				"astro.config.mts",
+				"env.cue",
 				"package.json",
 				"public/**",
 				"src/**",


### PR DESCRIPTION
Follow-up to #1258. The login-gate fix merged but the live site stayed ungated because the default pipeline runs `deploy.main`, whose `inputs` didn't list `env.cue` — so cuenv reported "No affected tasks" and skipped the redeploy. (The PR *preview* deployed because `deploy.preview` depends on the `build` task, which #1258 gave an `env.cue` input; `deploy.main` has no such dependency.)

This adds `env.cue` to `deploy.main.inputs` so an env-only change actually redeploys. On merge, this commit changes `env.cue` **and** `deploy.main` now lists it → affected → real production deploy → `DISABLE_GAME_AUTH=false` ships → games require login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)