### PR TITLE
fix(rawkode.academy/website): blank CNIcon results page after finishing

### DIFF
--- a/projects/rawkode.academy/website/src/components/games/guess-the-logo/ResultsView.vue
+++ b/projects/rawkode.academy/website/src/components/games/guess-the-logo/ResultsView.vue
@@ -27,7 +27,7 @@ interface PlayerStats {
 	};
 	bestScore: number;
 	perfectWeeks: number;
-	correctLogos: string[];
+	correctCount: number;
 	wins: number;
 	podiums: number;
 	bestRank: number;
@@ -201,19 +201,19 @@ function progressHint(id: string): string | null {
 		// Completion (pool-relative)
 		case "surveyor": {
 			const pct = props.poolSize > 0
-				? Math.round((s.correctLogos.length / props.poolSize) * 100)
+				? Math.round((s.correctCount / props.poolSize) * 100)
 				: 0;
 			return `${pct}% of pool (need 25%)`;
 		}
 		case "cartographer": {
 			const pct = props.poolSize > 0
-				? Math.round((s.correctLogos.length / props.poolSize) * 100)
+				? Math.round((s.correctCount / props.poolSize) * 100)
 				: 0;
 			return `${pct}% of pool (need 50%)`;
 		}
 		case "completionist": {
 			const pct = props.poolSize > 0
-				? Math.round((s.correctLogos.length / props.poolSize) * 100)
+				? Math.round((s.correctCount / props.poolSize) * 100)
 				: 0;
 			return `${pct}% of pool`;
 		}


### PR DESCRIPTION
**Blank page after answering all logos.** ResultsView's `progressHint` accessed `stats.correctLogos.length`, but the read-model `playerStats` query (and the client `PlayerStats`) only expose `correctCount` — `stats.correctLogos` was `undefined`, so `.length` threw during render and the results screen rendered blank.

Fix: use `correctCount` in the three completion progress hints and align ResultsView's local `PlayerStats` interface. The full `correctLogos` array remains server-side for `evaluateAchievements`. `astro check` clean.