### PR TITLE
fix(rawkode.academy/website): CNIcon newsletter status reads EMAIL_PREFERENCES

### DIFF
--- a/projects/rawkode.academy/website/src/components/games/guess-the-logo/ResultsView.vue
+++ b/projects/rawkode.academy/website/src/components/games/guess-the-logo/ResultsView.vue
@@ -81,10 +81,10 @@ async function subscribeNewsletter(): Promise<void> {
 onMounted(async () => {
 	if (!props.isSignedIn) return;
 	try {
-		const res = await fetch("/api/subscriptions/check?audienceId=cnicon");
+		const res = await fetch("/api/games/cnicon/newsletter-status");
 		if (!res.ok) return;
-		const data = (await res.json()) as { isSubscribed?: boolean };
-		if (data.isSubscribed) {
+		const data = (await res.json()) as { subscribed?: boolean };
+		if (data.subscribed) {
 			newsletterState.value = "done";
 		}
 	} catch {

--- a/projects/rawkode.academy/website/src/pages/api/games/cnicon/newsletter-status.ts
+++ b/projects/rawkode.academy/website/src/pages/api/games/cnicon/newsletter-status.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { createLearnerId } from "@/actions/newsletter";
+
+const AUDIENCE = "cnicon";
+
+/**
+ * GET /api/games/cnicon/newsletter-status
+ * Whether the signed-in learner is subscribed to the CNIcon newsletter.
+ * Checks EMAIL_PREFERENCES (where newsletter.subscribe writes), not Resend —
+ * the subscription is stored under the learner id + audience "cnicon".
+ */
+export const GET: APIRoute = async ({ locals }) => {
+	const user = locals.user;
+
+	if (!user) {
+		return new Response(JSON.stringify({ subscribed: false }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	try {
+		const prefs = await env.EMAIL_PREFERENCES.getPreferences(
+			createLearnerId(user.id),
+			"newsletter",
+			AUDIENCE,
+		);
+
+		return new Response(JSON.stringify({ subscribed: prefs.length > 0 }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	} catch (error) {
+		console.error("Failed to check newsletter status:", error);
+		return new Response(JSON.stringify({ subscribed: false }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+};


### PR DESCRIPTION
The results newsletter box reset to "Notify me" after subscribing + reloading. The mount check used `/api/subscriptions/check` (Resend-by-email), but `newsletter.subscribe` stores the preference in **EMAIL_PREFERENCES** (D1) under `learner:{id}` + audience `cnicon` — so the Resend lookup never matched.

Adds `/api/games/cnicon/newsletter-status` checking `EMAIL_PREFERENCES.getPreferences(learnerId, "newsletter", "cnicon")` (same source the settings page reads) and points the box's on-mount check at it. Website-only — no service deploy needed. `astro check` clean.