### PR TITLE
Rawkode Academy News - June 15, 2026

### DIFF
--- a/content/news/2026-06-15-sig-storage-apko-llama-cpp/index.mdx
+++ b/content/news/2026-06-15-sig-storage-apko-llama-cpp/index.mdx
@@ -1,0 +1,48 @@
+---
+title: "Kubernetes SIG Storage, apko, and llama.cpp ship storage and runtime updates"
+description: "Kubernetes published SIG Storage roadmap details, while apko and llama.cpp shipped concrete packaging and inference fixes."
+publishedAt: 2026-06-15
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - storage
+  - security
+  - ai-infrastructure
+---
+
+Today's digest covers Kubernetes storage roadmap detail, apko image-build correctness fixes, and a narrow llama.cpp update for Cohere2MoE model support.
+
+## Kubernetes SIG Storage points at COSI, CBT, and volume-health work
+
+Kubernetes published a SIG Storage spotlight on June 15 with roadmap detail from Xing Yang, a SIG Storage co-chair. The post is not a feature release, but it gives platform teams a concrete update on where Kubernetes storage APIs are moving after the v1.36 cycle.
+
+The Data Protection WG work highlighted in the post includes VolumeGroupSnapshot moving to GA in Kubernetes v1.36 and CSI Changed Block Tracking moving to beta. It also says the Container Object Storage Interface is moving to `v1alpha2`, with a future beta promotion planned, and calls out Volume Health work aimed at moving beyond non-persistent events toward remediation-oriented status. The same post asks for feedback on Mutable PV Affinity, introduced as alpha in Kubernetes v1.35, for cases such as shifting volumes between zones or storage classes.
+
+For operators running stateful and AI workloads on Kubernetes, the signal is that storage standardization is moving beyond volume provisioning into backup efficiency, object bucket claims, locality, and health-aware recovery.
+
+**Source:** [Kubernetes](https://kubernetes.io/blog/2026/06/15/sig-storage-spotlight-2026/) - June 15, 2026
+
+---
+
+## apko v1.2.17 fixes solver ordering and image permission bits
+
+Chainguard released apko v1.2.17 on June 15 with fixes that affect image reproducibility and filesystem semantics. The release includes a [solver change](https://github.com/chainguard-dev/apko/pull/2271) so apko follows apk-tools provider comparison ordering, avoiding a case where an older package build with a higher provider priority could outrank a newer build.
+
+The same release [preserves setuid, setgid, and sticky bits](https://github.com/chainguard-dev/apko/pull/2274) declared through `paths` mutations, fixing published layers that silently dropped special permission bits. It also changes [`expandapk` to materialize uncompressed `.dat.tar` cache files atomically](https://github.com/chainguard-dev/apko/pull/2269), so concurrent builds sharing a cache directory do not read a partial package payload.
+
+This is a small release, but the failure modes are operationally concrete: wrong package selection, incorrect layer permissions, and cache races during parallel image builds.
+
+**Source:** [apko](https://github.com/chainguard-dev/apko/releases/tag/v1.2.17) - June 15, 2026
+
+---
+
+## llama.cpp adds Cohere2MoE parsing across June 14 builds
+
+llama.cpp published four builds on June 14, ending with b9637. The sequence added [Cohere2MoE vocabulary handling for TINY_AYA](https://github.com/ggml-org/llama.cpp/releases/tag/b9630), a [dedicated Cohere2MoE chat parser](https://github.com/ggml-org/llama.cpp/releases/tag/b9637), [Jinja `count`, `d`, and `e` filter aliases](https://github.com/ggml-org/llama.cpp/releases/tag/b9632), and a [CLI fix for copying preserved tokens](https://github.com/ggml-org/llama.cpp/releases/tag/b9631).
+
+The most operator-facing change is the dedicated Cohere2MoE parser: the linked PR says the generic autoparser path was not sufficient for that template and points users at `models/templates/Cohere2-MoE.jinja`. Teams packaging llama.cpp-based inference images or local serving binaries for Cohere/North Code-style templates should pick up the newer build before debugging prompt-template behavior downstream.
+
+**Source:** [llama.cpp](https://github.com/ggml-org/llama.cpp/releases/tag/b9637) - June 14, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest ships three items that survived the 24-hour freshness and substance gate: Kubernetes SIG Storage roadmap detail for storage APIs, apko image-build correctness fixes, and llama.cpp Cohere2MoE parsing updates. Thin chart/nightly/dependency-only releases and repo-update-only candidates were dropped.

## Run metadata

- Run time: `2026-06-15 07:02 Europe/London`
- Coverage window: `2026-06-14 07:02 BST` to `2026-06-15 07:02 BST`
- Source URLs inspected: `195`
- Candidates longlisted: `11`
- Candidates shortlisted: `5`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- Kubernetes SIG Storage points at COSI, CBT, and volume-health work - SIG Storage is pushing data-protection and object-storage APIs beyond CSI provisioning.
- apko v1.2.17 fixes solver ordering and image permission bits - Packaging teams can hit wrong package resolution, lost special bits, and cache races.
- llama.cpp adds Cohere2MoE parsing across June 14 builds - Cohere2MoE prompt-template handling now has a dedicated parser instead of generic autoparsing.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Kubernetes SIG Storage spotlight was published on June 15, 2026 | https://kubernetes.io/blog/2026/06/15/sig-storage-spotlight-2026/ header/feed | yes |
| SIG Storage post highlights VolumeGroupSnapshot GA in v1.36, CBT beta in v1.36, COSI `v1alpha2`, Volume Health remediation work, and Mutable PV Affinity feedback | https://kubernetes.io/blog/2026/06/15/sig-storage-spotlight-2026/ sections "Current work and roadmap" and "Looking ahead" | yes |
| apko v1.2.17 was published on 2026-06-15T01:12:48Z | https://github.com/chainguard-dev/apko/releases/tag/v1.2.17 release metadata | yes |
| apko solver now follows apk-tools provider comparison ordering | https://github.com/chainguard-dev/apko/pull/2271 | yes |
| apko preserves setuid, setgid, and sticky bits in `paths` mutations | https://github.com/chainguard-dev/apko/pull/2274 | yes |
| apko materializes uncompressed `.dat.tar` cache files atomically | https://github.com/chainguard-dev/apko/pull/2269 | yes |
| llama.cpp b9630, b9631, b9632, and b9637 were published on June 14 inside the coverage window | https://github.com/ggml-org/llama.cpp/releases/tag/b9630, https://github.com/ggml-org/llama.cpp/releases/tag/b9631, https://github.com/ggml-org/llama.cpp/releases/tag/b9632, https://github.com/ggml-org/llama.cpp/releases/tag/b9637 | yes |
| llama.cpp b9637 adds a dedicated Cohere2MoE chat parser and the PR notes the generic autoparser path was insufficient | https://github.com/ggml-org/llama.cpp/releases/tag/b9637 and https://github.com/ggml-org/llama.cpp/pull/24615 | yes |

## Items considered and dropped

- vLLM v0.23.0 - Fresh release metadata appeared in the window, but the same version is already covered by the June 13 digest in this checkout.
- Kubernetes vertical-pod-autoscaler chart 0.10.0 - Fresh timestamp, but the release body had no technical substance beyond the chart description.
- FlashInfer nightly v0.6.13-20260614 - Fresh automated nightly with no changelog detail.
- chainguard-dev/melange v0.53.2 - Fresh release, but dependency-only.
- llm-d and llm-d-router repository updates - Pushed during the window, but no release, tag, changelog, or material primary artifact.
- OpenInfer, OpenInference, and Beta9 repository updates - Pushed during the window, but no fresh release/tag artifact; OpenInfer and Beta9 were already covered in the prior run.
- NVIDIA, Cloudflare, AWS, CNCF, GitLab, Docker, and Google Cloud feed items - Latest canonical publish dates were outside the window or lacked a stronger primary artifact.
- arXiv systems and AI-infrastructure searches - No matching submissions returned for the coverage window.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `11`
- Segments shipped: `3`
- Any unresolved framing concerns: Kubernetes SIG Storage is a roadmap/profile post rather than a feature release; the segment says that explicitly.
- Any vendor-attributed claims: apko claims are from project release notes and linked PRs, not a marketing post.
