### PR TITLE
Rawkode Academy News - June 16, 2026

### DIFF
--- a/content/news/2026-06-16-moe-kernels-kvcache-serving-heterogeneous-gpu/index.mdx
+++ b/content/news/2026-06-16-moe-kernels-kvcache-serving-heterogeneous-gpu/index.mdx
@@ -4,9 +4,7 @@ description: "NVIDIA shipped fused mixture-of-experts training kernels in Transf
 publishedAt: 2026-06-16
 authors:
   - rawkode
-technologies:
-  - ai-infrastructure
-  - hpc
+technologies: []
 ---
 
 Four fresh items from the last 24 hours, all in AI and HPC infrastructure: new mixture-of-experts training kernels shipping in NVIDIA's stack, plus three systems papers on KV-cache management, disaggregated serving, and heterogeneous-GPU training.

--- a/content/news/2026-06-16-moe-kernels-kvcache-serving-heterogeneous-gpu/index.mdx
+++ b/content/news/2026-06-16-moe-kernels-kvcache-serving-heterogeneous-gpu/index.mdx
@@ -1,0 +1,60 @@
+---
+title: "MoE training kernels ship while fresh research targets KV-cache, disaggregated serving, and heterogeneous GPUs"
+description: "NVIDIA shipped fused mixture-of-experts training kernels in Transformer Engine and Megatron Core, alongside new systems research on KV-cache management for coding agents, SLO-aware disaggregated serving, and heterogeneous-GPU training planning."
+publishedAt: 2026-06-16
+authors:
+  - rawkode
+technologies:
+  - ai-infrastructure
+  - hpc
+---
+
+Four fresh items from the last 24 hours, all in AI and HPC infrastructure: new mixture-of-experts training kernels shipping in NVIDIA's stack, plus three systems papers on KV-cache management, disaggregated serving, and heterogeneous-GPU training.
+
+## NVIDIA ships fused MoE training kernels in Transformer Engine and Megatron Core
+
+NVIDIA published an engineering writeup on June 15 describing three CuTe DSL kernels that fuse grouped GEMM, activation, and quantization for mixture-of-experts training.
+
+The kernels fold GLU activations (SwiGLU, GeGLU, sReLU) into GEMM epilogues by repacking weights so input and gate tensors are read together, removing intermediate tensor traffic. They track tokens-per-group in GPU memory to enable sync-free MoE execution under full-iteration CUDA Graphs, and fuse MXFP8 and NVFP4 quantization directly into the GEMM. NVIDIA reports a 1.3x forward-pass and up to 2.1x backward-pass speedup, an 8% end-to-end gain on DeepSeek-V3, and a 93% end-to-end gain on GPT-OSS pre-training. The kernels are exposed through cuDNN Frontend v1.23.0+, Transformer Engine v2.15+, and Megatron Core 26.04-alpha.rc2+.
+
+For teams pre-training MoE models, this is shipping today through named library versions rather than a research preview, though the end-to-end figures are vendor-reported.
+
+**Source:** [NVIDIA Developer Blog](https://developer.nvidia.com/blog/boosting-moe-training-throughput-with-advanced-fusion-kernels/) - June 15, 2026
+
+---
+
+## CacheWise tunes KV-cache management for LLM coding agents
+
+A paper submitted to arXiv on June 15 introduces CacheWise, a set of KV-cache policies built from real coding-agent traces rather than chat workloads and implemented in vLLM.
+
+The authors collected coding-assistant traces and found that sessions repeatedly reuse large prefixes and sustain KV-cache pressure that general-purpose serving handles inefficiently. CacheWise adds prefix-aware scheduling that recognizes repeated context, plus reuse-aware eviction informed by metadata predicted from tool calls. Built into vLLM and evaluated on the collected traces, the authors report 2x to 2.6x fewer KV-cache evictions and up to 3.5x faster agent-session completion.
+
+Agentic coding traffic has different cache locality than chat, and the paper argues scheduling and eviction tuned to that pattern materially change serving cost.
+
+**Source:** [arXiv: CacheWise](https://arxiv.org/abs/2606.16824) - June 15, 2026
+
+---
+
+## Tropical proposes SLO-aware multiplexing for disaggregated LLM serving
+
+Also submitted on June 15, Tropical treats the choice between disaggregated and colocated LLM serving as a multiplexing problem rather than a fixed deployment topology.
+
+Disaggregated serving isolates prefill and decode on separate workers to avoid interference but pays queuing delay; colocated serving cuts queuing but suffers prefill-decode interference. Tropical schedules work to balance queuing time against interference per request. The authors report serving up to 2.09x more requests within a 90% SLO, a 9x P90 time-to-first-token improvement over disaggregated serving for a 15% time-per-output-token reduction, and a 2.8x P90 time-per-output-token improvement over colocated serving at equivalent TTFT.
+
+For teams tuning prefill/decode splits, the result argues the disaggregation decision should be dynamic and SLO-driven.
+
+**Source:** [arXiv: Tropical](https://arxiv.org/abs/2606.16264) - June 15, 2026
+
+---
+
+## Tangram adapts homogeneous LLM parallelizers to mixed-GPU clusters
+
+A June 15 arXiv paper presents Tangram, which lets parallelizers designed for uniform hardware plan training across heterogeneous GPU fleets.
+
+Tangram exploits "homogeneous GPU islands" — groups of identical GPUs acquired together — and the common pattern of partitioning a model before parallelizing, composing model slices and islands into work-balanced pipelines through a narrow enumeration API plus pruning for scalability. Rather than redesign parallelizers, it decouples parallelization planning from hardware heterogeneity. Against the heterogeneous parallelizers Metis and Sailor, the authors report up to 2.3x higher training throughput.
+
+Operators rarely run a single GPU SKU, and Tangram targets the planning gap that forms when a training job spans mixed accelerator generations.
+
+**Source:** [arXiv: Tangram](https://arxiv.org/abs/2606.16907) - June 15, 2026
+
+---


### PR DESCRIPTION
## Summary

A four-segment digest covering the AI/HPC infrastructure items that landed in the last 24 hours. The cloud-native, platform-engineering, and CNCF release surfaces were quiet in the window (latest stable releases for Kubernetes, Cilium, Istio, Argo CD, Flux, Prometheus, OpenTelemetry Collector, Crossplane, Backstage, Kyverno, cert-manager, Kueue, containerd, and etcd all predate June 15), so the signal this run is concentrated in AI training and inference. The lead item is shipping today — NVIDIA's fused MoE training kernels in Transformer Engine and Megatron Core — followed by three systems papers with concrete, reproducible mechanisms and reported numbers.

## Run metadata

- Run time: `2026-06-16 06:00 Europe/London`
- Coverage window: `2026-06-15T05:00Z` to `2026-06-16T05:00Z`
- Source URLs inspected: `~30`
- Candidates longlisted: `11`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- NVIDIA ships fused MoE training kernels in Transformer Engine and Megatron Core - deployable now via named cuDNN/TE/Megatron versions, with fused activation + quantization and sync-free CUDA Graph execution.
- CacheWise tunes KV-cache management for LLM coding agents - prefix-aware scheduling and reuse-aware eviction built into vLLM, derived from real coding-agent traces.
- Tropical proposes SLO-aware multiplexing for disaggregated LLM serving - makes the prefill/decode disaggregation decision dynamic and SLO-driven rather than a fixed topology.
- Tangram adapts homogeneous LLM parallelizers to mixed-GPU clusters - plans training across heterogeneous accelerator generations via "homogeneous GPU islands."

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Three CuTe DSL kernels fuse grouped GEMM + activation + quantization; sync-free MoE under full-iteration CUDA Graphs; 1.3x fwd / up to 2.1x bwd; 8% e2e DeepSeek-V3; 93% e2e GPT-OSS pre-training; cuDNN Frontend v1.23.0+, TE v2.15+, Megatron Core 26.04-alpha.rc2+ | [developer.nvidia.com](https://developer.nvidia.com/blog/boosting-moe-training-throughput-with-advanced-fusion-kernels/) (post body, June 15) | ✅ |
| CacheWise: prefix-aware scheduling + reuse-aware eviction from tool-call metadata; implemented in vLLM; 2–2.6x fewer KV-cache evictions; up to 3.5x faster session completion; submitted June 15 | [arXiv:2606.16824](https://arxiv.org/abs/2606.16824) (abstract) | ✅ |
| Tropical: SLO-aware multiplexing balancing queuing vs interference; up to 2.09x more requests within 90% SLO; 9x P90 TTFT vs disaggregated for 15% TPOT reduction; 2.8x P90 TPOT vs colocated at equal TTFT; submitted June 15 | [arXiv:2606.16264](https://arxiv.org/abs/2606.16264) (abstract) | ✅ |
| Tangram: "homogeneous GPU islands" + slice/island enumeration API + pruning; up to 2.3x training throughput vs Metis and Sailor; submitted June 15 | [arXiv:2606.16907](https://arxiv.org/abs/2606.16907) (abstract) | ✅ |

## Items considered and dropped

- SMEPilot (arXiv:2606.16332, June 15) - strong and verified (per-operator routing across Arm SME/CPU, up to 3.94x), but CPU/edge inference is the most niche fit for a GPU/cluster-focused audience; held to keep the digest tight and avoid paper overload.
- SGLang v0.5.13.post1 (June 15) - post-release patch; release notes failed to load and the change set is trivial, so substance could not be verified.
- Linkerd edge-26.6.2 (June 16) - rolling dev-channel edge release, not a stable milestone.
- CNCF "Improving Arm64 support with OCI credits" (June 15) - member program/positioning post, no technical artifact.
- Kubernetes "Spotlight on SIG Storage" (June 15) - community interview, not a release or change.
- NVIDIA BioNeMo LoRA fine-tuning (June 15) - product/domain (computational biology) walkthrough, outside core infra scope.
- vLLM v0.23.1rc0 (June 15, 02:35Z) - release candidate with a CI/Dockerfile-doc fix; trivial and just before the window start.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 11
- Segments shipped: 4
- Vendor-attributed claims: NVIDIA's end-to-end MoE figures (8% DeepSeek-V3, 93% GPT-OSS) are vendor-reported and attributed inline; the kernel mechanisms are corroborated by their shipping library versions.
- Note: one arXiv ID surfaced during discovery (2606.15135, listed as "SwiftCache") resolved to an unrelated paper on verification and was discarded rather than cited.
- This digest is single-pillar (AI/HPC) by necessity — the cloud-native/platform release surfaces produced nothing fresh in the window, and no padding was added to diversify.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjS1PXHSMn7vnSfoaz7E6s)_