### PR TITLE
Rawkode Academy News - June 16, 2026

### DIFF
--- a/content/news/2026-06-16-dapr-wasmtime-trivy-tekton/index.mdx
+++ b/content/news/2026-06-16-dapr-wasmtime-trivy-tekton/index.mdx
@@ -1,0 +1,62 @@
+---
+title: "Dapr, Wasmtime, Trivy, and Tekton ship runtime and security fixes"
+description: "Dapr repaired workflow reload and timer failure modes while Wasmtime and Trivy shipped security fixes for WASIp1 hosts and OCI artifact downloads."
+publishedAt: 2026-06-16
+authors:
+  - rawkode
+technologies:
+  - dapr
+  - webassembly
+  - security
+  - tekton
+---
+
+Four fresh releases landed in the last 24 hours across workflow runtimes, WebAssembly hosts, supply-chain scanning, and CI/CD controllers.
+
+## Dapr 1.18.1 fixes workflow reload, timer, and concurrency failures
+
+Dapr published [v1.18.1](https://github.com/dapr/dapr/releases/tag/v1.18.1) on June 16 and [v1.16.16](https://github.com/dapr/dapr/releases/tag/v1.16.16) on June 15. The 1.18.1 release fixes leaked workflow event-timer reminders, workflow sidecars that stayed unavailable after a configuration reload, no-op Kubernetes operator resyncs that restarted sidecars, and `ContinueAsNew` child-workflow completions that could leave parents stuck in `RUNNING`.
+
+The same release regenerates the Helm chart `Configuration` CRD so workflow and activity concurrency-limit fields are preserved when Dapr is installed from the chart. The 1.16.16 backport fixes Sentry certificate signing when an issuer key type does not match the CSR signature algorithm, and avoids immutable scheduler StatefulSet storage changes during Helm downgrades from 1.17 or 1.18.
+
+For operators, the practical change is fewer workflow failure modes that required pod restarts, manual Helm overrides, or waiting for leaked reminders to be swept at workflow completion.
+
+**Source:** [Dapr v1.18.1 release](https://github.com/dapr/dapr/releases/tag/v1.18.1) and [Dapr v1.16.16 release](https://github.com/dapr/dapr/releases/tag/v1.16.16) - June 16 and June 15, 2026
+
+---
+
+## Wasmtime patches a WASIp1 fd_renumber host-resource leak
+
+Wasmtime published [v45.0.2](https://github.com/bytecodealliance/wasmtime/releases/tag/v45.0.2), [v44.0.3](https://github.com/bytecodealliance/wasmtime/releases/tag/v44.0.3), [v36.0.11](https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.11), and [v24.0.10](https://github.com/bytecodealliance/wasmtime/releases/tag/v24.0.10) on June 15. Each patch fixes [GHSA-3p27-qvp9-27qf](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-3p27-qvp9-27qf), a low-severity leak in the native WASIp1 `fd_renumber` implementation.
+
+The advisory says the bug updates Wasmtime's WASIp1 descriptor table without updating the underlying host descriptor table, so a guest can repeatedly call `fd_renumber` and exhaust host resources or file descriptors until the corresponding `Store` is destroyed. Hosts are affected when they load core Wasm modules, expose `fd_renumber`, and allow the guest to acquire a file descriptor such as by opening a file.
+
+There is no workaround listed; runtimes exposing WASIp1 file access should update to a patched line.
+
+**Source:** [Wasmtime security advisory](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-3p27-qvp9-27qf) - June 15, 2026
+
+---
+
+## Trivy 0.71.1 closes path traversal in downloaded OCI artifacts
+
+Aqua released [Trivy v0.71.1](https://github.com/aquasecurity/trivy/releases/tag/v0.71.1) on June 15 with a fix for [GHSA-mcj4-mphf-j9ff](https://github.com/aquasecurity/trivy/security/advisories/GHSA-mcj4-mphf-j9ff), a high-severity path traversal in downloaded OCI artifacts. The advisory says Trivy used the `org.opencontainers.image.title` annotation from an artifact manifest as a destination filename without validation.
+
+The affected paths are overridden OCI artifact sources such as `--db-repository`, `TRIVY_DB_REPOSITORY`, Java DB repositories, checks bundle repositories, and repositories passed to `trivy module install`. Trivy's default Aqua-operated repositories are not affected, but a hostile mirror or copied command pointing at an attacker-controlled artifact could write outside the intended destination as the user running Trivy.
+
+The release validates artifact filenames as local relative paths and also constrains VEX document loading to the repository cache directory. If you cannot upgrade immediately, the advisory says not to fetch Trivy databases, bundles, or modules from untrusted OCI repositories.
+
+**Source:** [Trivy v0.71.1 release](https://github.com/aquasecurity/trivy/releases/tag/v0.71.1) and [Trivy security advisory](https://github.com/aquasecurity/trivy/security/advisories/GHSA-mcj4-mphf-j9ff) - June 15, 2026
+
+---
+
+## Tekton Pipeline backports resolver validation and cross-architecture fixes
+
+Tekton Pipeline published [v1.9.4](https://github.com/tektoncd/pipeline/releases/tag/v1.9.4), [v1.6.3](https://github.com/tektoncd/pipeline/releases/tag/v1.6.3), and [v1.3.5](https://github.com/tektoncd/pipeline/releases/tag/v1.3.5) on June 15. The patch train includes resolver-framework validation so non-Tekton objects and arbitrary data fail resolution instead of being accepted.
+
+The v1.9.4 and v1.6.3 releases also fix entrypoint command lookup when controller and worker nodes run different CPU architectures, where the controller platform could leak into `TEKTON_PLATFORM_COMMANDS` and produce missing-command errors on workers. Both releases bump `google.golang.org/grpc` for CVE-2026-33186, while v1.9.4 adds clearer status and warning events when completed tasks are missing referenced results.
+
+Custom resolver users should read the upgrade notes before rolling forward, because the release notes call out an action-required change for Resolver API use outside the supported Tekton object set.
+
+**Source:** [Tekton Pipeline v1.9.4 release](https://github.com/tektoncd/pipeline/releases/tag/v1.9.4), [v1.6.3 release](https://github.com/tektoncd/pipeline/releases/tag/v1.6.3), and [v1.3.5 release](https://github.com/tektoncd/pipeline/releases/tag/v1.3.5) - June 15, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest ships four fresh, primary-sourced items from the last 24 hours: Dapr workflow/runtime fixes, Wasmtime WASIp1 security patches, Trivy OCI artifact path-traversal hardening, and Tekton Pipeline backports for resolver validation plus cross-architecture execution fixes. These made the cut because each has a direct operational consequence for platform or infrastructure teams and a verifiable primary source inside the run window.

## Run metadata

- Run time: `2026-06-16 07:02 Europe/London`
- Coverage window: `2026-06-15 07:02 Europe/London` to `2026-06-16 07:02 Europe/London`
- Source URLs inspected: `114`
- Candidates longlisted: `10`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- Dapr 1.18.1 fixes workflow reload, timer, and concurrency failures - operational workflow fixes across sidecar reload, timer reminders, ContinueAsNew, Helm CRD drift, and downgrade handling.
- Wasmtime patches a WASIp1 fd_renumber host-resource leak - maintained Wasmtime lines patched a host file-descriptor/resource leak with no listed workaround.
- Trivy 0.71.1 closes path traversal in downloaded OCI artifacts - scanner users overriding OCI database or bundle sources need the patched release or trusted repositories.
- Tekton Pipeline backports resolver validation and cross-architecture fixes - CI/CD operators get resolver hardening, cross-arch command lookup fixes, and gRPC CVE updates across supported lines.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Dapr v1.18.1 was published on June 16, 2026. | https://github.com/dapr/dapr/releases/tag/v1.18.1 release metadata | ✅ |
| Dapr v1.18.1 fixes workflow timer reminder leaks, sidecars stuck after reload, no-op operator resync restarts, ContinueAsNew child workflow hangs, and Helm chart workflow concurrency CRD drift. | https://github.com/dapr/dapr/releases/tag/v1.18.1 release sections | ✅ |
| Dapr v1.16.16 was published on June 15, 2026 and fixes Sentry CSR/issuer key mismatch plus Helm scheduler StatefulSet downgrade storage size. | https://github.com/dapr/dapr/releases/tag/v1.16.16 release sections | ✅ |
| Wasmtime v45.0.2, v44.0.3, v36.0.11, and v24.0.10 were published on June 15, 2026. | https://github.com/bytecodealliance/wasmtime/releases/tag/v45.0.2 and linked release tags | ✅ |
| GHSA-3p27-qvp9-27qf is a low-severity WASIp1 fd_renumber leak that can exhaust host resources or file descriptors; there is no workaround listed. | https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-3p27-qvp9-27qf advisory Impact, Patches, Workarounds | ✅ |
| Trivy v0.71.1 was published on June 15, 2026 and fixes GHSA-mcj4-mphf-j9ff. | https://github.com/aquasecurity/trivy/releases/tag/v0.71.1 release notes | ✅ |
| GHSA-mcj4-mphf-j9ff is a high-severity path traversal via crafted OCI artifact metadata; default Aqua-operated repositories are not affected, and 0.71.1 is patched. | https://github.com/aquasecurity/trivy/security/advisories/GHSA-mcj4-mphf-j9ff advisory Summary, Affected configurations, Patches | ✅ |
| Trivy v0.71.1 validates artifact filenames as local relative paths and constrains VEX loading to the repository directory. | https://github.com/aquasecurity/trivy/commit/a72d9a4d997c25fbb6534e231b4e206c9b202b31 and https://github.com/aquasecurity/trivy/commit/a62cbe40a240d3a3f568401b8a5f86e14114e371 commits | ✅ |
| Tekton Pipeline v1.9.4, v1.6.3, and v1.3.5 were published on June 15, 2026. | https://github.com/tektoncd/pipeline/releases/tag/v1.9.4, https://github.com/tektoncd/pipeline/releases/tag/v1.6.3, https://github.com/tektoncd/pipeline/releases/tag/v1.3.5 release metadata | ✅ |
| Tekton Pipeline release notes include resolver validation for non-Tekton/arbitrary data and action-required custom resolver guidance. | https://github.com/tektoncd/pipeline/releases/tag/v1.9.4 Fixes section | ✅ |
| Tekton Pipeline v1.9.4 and v1.6.3 fix cross-architecture entrypoint command lookup and bump gRPC for CVE-2026-33186. | https://github.com/tektoncd/pipeline/releases/tag/v1.9.4 and https://github.com/tektoncd/pipeline/releases/tag/v1.6.3 Fixes sections | ✅ |

## Items considered and dropped

- CNCF Arm64 support in CNCF projects with OCI credits - fresh and useful, but mostly vendor-program shaped and not a new project release or governance change.
- llama.cpp b9661/b9660 build train - fresh automated build notes, but individual changes were too narrow compared with stronger security/runtime items.
- FlashInfer nightly v0.6.13-20260615 - automated nightly with no substantive release notes.
- melange v0.53.3 - single QEMU DNS fix, too narrow for this digest.
- vLLM v0.23.0 - outside this run's actual 24-hour window and already treated as a duplicate in the prior automation memory.
- apko v1.2.17 - outside this run's actual 24-hour window and already shipped in the June 15 digest.
- Cloudflare Ensemble AI talent post - fresh but an acquisition/talent item without a technical artifact.
- NVIDIA BioNeMo LoRA post - fresh tutorial, but vendor-specific and bio-model focused rather than cloud-native or AI infrastructure news.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `10`
- Segments shipped: `4`
- Any unresolved framing concerns: none
- Any vendor-attributed claims: Trivy segment cites Aqua project release/advisory but no uncorroborated vendor benchmark or performance claim
- Validation: `git diff --check`, banned-word scan, heading/source-count sanity, and source-link 200 checks passed
