### PR TITLE
Rawkode Academy News - June 18, 2026

### DIFF
--- a/content/news/2026-06-18-prometheus-pytorch-remp-capsule-langchain4j-pulse/index.mdx
+++ b/content/news/2026-06-18-prometheus-pytorch-remp-capsule-langchain4j-pulse/index.mdx
@@ -1,0 +1,74 @@
+---
+title: "Prometheus, PyTorch, Capsule, LangChain4j, ReMP, and PULSE land security and AI-infra updates"
+description: "Prometheus and PyTorch shipped security and correctness fixes, while fresh advisories and systems papers targeted Kubernetes multi-tenancy, vector-store filters, and GPU scheduling."
+publishedAt: 2026-06-18
+authors:
+  - rawkode
+technologies:
+  - prometheus
+  - kubernetes
+  - ai-infrastructure
+  - security
+---
+
+Six fresh items landed in the last 24 hours across observability, Kubernetes multi-tenancy, AI framework security, GPU correctness, LLM serving, and distributed training.
+
+## Prometheus v3.5.4 fixes STACKIT SD secret exposure
+
+Prometheus published v3.5.4 on June 17 with multiple security fixes. The release fixes a STACKIT service-discovery issue where secrets could be exposed in plaintext through the `/-/config` endpoint, bumps `golang.org/x/net` and OpenTelemetry dependencies for reported CVEs, and updates UI dependencies with security advisories.
+
+The release also starts publishing Prometheus container images to GitHub Container Registry, giving operators another official image source. For teams using STACKIT SD, this is an upgrade target rather than routine dependency churn.
+
+**Source:** [Prometheus v3.5.4 release](https://github.com/prometheus/prometheus/releases/tag/v3.5.4) - June 17, 2026
+
+---
+
+## PyTorch 2.12.1 fixes B100 and B200 correctness regressions
+
+PyTorch released 2.12.1 on June 18 as a bug-fix release for regressions and silent correctness issues. The release updates Triton to 3.7.1 to fix nondeterministic `FLASH_ATTN` output on NVIDIA B200 GPUs and an illegal-memory-access issue in the Triton `convolution2d_bwd_weight` kernel on B100 and B200 GPUs.
+
+It also fixes `fill_` on byte-dtype views with misaligned storage offsets and removes CPython 3.13t from the binary build matrix. The practical signal is clear: teams validating PyTorch 2.12 on Blackwell-class GPUs should treat 2.12.1 as the safer baseline.
+
+**Source:** [PyTorch 2.12.1 release](https://github.com/pytorch/pytorch/releases/tag/v2.12.1) - June 18, 2026
+
+---
+
+## Capsule discloses a namespaces/finalize admission bypass
+
+The Capsule project published GHSA-gwxr-7h77-7777 on June 17 for an incomplete fix to CVE-2026-30963. Capsule v0.13.2 used `namespace/finalize` instead of Kubernetes' plural `namespaces/finalize` in webhook rules, so the intended finalize-subresource defense did not match real API requests.
+
+The advisory says a user with `namespaces/finalize` RBAC could bypass the webhook through a raw finalize request and change a tenant label, carrying the same threat model as the earlier CVE. The affected range is `>= 0.13.0, < 0.13.6`, with Capsule 0.13.6 listed as the first patched version.
+
+**Source:** [Capsule GHSA-gwxr-7h77-7777 advisory](https://github.com/projectcapsule/capsule/security/advisories/GHSA-gwxr-7h77-7777) - June 17, 2026
+
+---
+
+## LangChain4j patches SQL injection in pgvector and MariaDB filters
+
+LangChain4j published GHSA-2mfg-cc43-9pcj on June 17 for SQL injection in the `langchain4j-pgvector` and `langchain4j-mariadb` embedding stores. The issue is in metadata filters: crafted filter keys, and in MariaDB some string values, could be concatenated into SQL for search and `removeAll(Filter)` paths without adequate escaping.
+
+The advisory calls out the risk for applications that allow attacker-influenced metadata filter keys, including LLM-generated filters, to reach those stores. Fixed package lines include `1.16.3-beta26`, `1.11.8-beta19`, `1.5.1-beta11`, and `1.2.1-beta8`; hard-coded allow-listed filter keys are the stated workaround.
+
+**Source:** [LangChain4j GHSA-2mfg-cc43-9pcj advisory](https://github.com/langchain4j/langchain4j/security/advisories/GHSA-2mfg-cc43-9pcj) - June 17, 2026
+
+---
+
+## ReMP targets runtime model-parallelism changes for LLM serving
+
+An arXiv paper published on June 17 describes ReMP, a framework for changing tensor-parallel and pipeline-parallel topology in running LLM serving systems. The paper argues that current serving stacks usually treat TP and PP layout as static, so topology changes require restarting service instances, dropping KV cache state, and recomputing work.
+
+ReMP decouples the parallelism topology from runtime state, migrates KV cache across TP and PP changes, and implements online reconfiguration. The authors report most topology switches finishing in 1-7 seconds across 7B to 70B models, with improvements in TTFT, TPOT, and output throughput under dynamic workloads.
+
+**Source:** [arXiv 2606.18741](https://arxiv.org/abs/2606.18741) - June 17, 2026
+
+---
+
+## PULSE makes skip locality a pipeline-parallel training constraint
+
+An arXiv paper published on June 17 describes PULSE, an automatic pipeline-parallel training strategy for large diffusion models. The core problem is that UNet-style encoder-decoder structures and skip connections can force skip activations and gradients across pipeline boundaries, making peer-to-peer communication a bottleneck.
+
+PULSE colocates skip-connected encoder-decoder layers, caches skip activations locally for backpropagation, and combines a dynamic-programming partitioner, ILP schedule synthesis, and hybrid-parallelism tuning. The authors report up to 89% less communication volume and up to 2.3x higher training throughput on communication-bound hardware.
+
+**Source:** [arXiv 2606.19163](https://arxiv.org/abs/2606.19163) - June 17, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest covers six fresh, source-backed items from the last 24 hours: Prometheus security fixes, PyTorch Blackwell correctness fixes, Kubernetes multi-tenancy and AI framework advisories, and two AI/HPC systems papers on serving reconfiguration and diffusion training parallelism. The final set favors actionable security/runtime changes and technically specific systems work over conference, product, or thin release material.

## Run metadata

- Run time: `2026-06-18 07:02 Europe/London`
- Coverage window: `2026-06-17 07:02:04 BST` to `2026-06-18 07:02:04 BST`
- Source URLs inspected: `116`
- Candidates longlisted: `18`
- Candidates shortlisted: `8`
- Segments shipped: `6`
- Time horizon: last 24 hours only

## Segments

- Prometheus v3.5.4 fixes STACKIT SD secret exposure - operators using STACKIT SD get a concrete secret-exposure fix plus CVE-driven dependency updates.
- PyTorch 2.12.1 fixes B100 and B200 correctness regressions - teams validating PyTorch 2.12 on Blackwell GPUs get fixes for nondeterministic output and illegal memory access.
- Capsule discloses a namespaces/finalize admission bypass - Capsule multi-tenant clusters have an actionable upgrade target for a webhook rule typo that leaves a finalize-subresource bypass.
- LangChain4j patches SQL injection in pgvector and MariaDB filters - AI applications that pass dynamic metadata filters into embedding stores need patched package lines or allow-listed filter keys.
- ReMP targets runtime model-parallelism changes for LLM serving - the paper gives a concrete topology-reconfiguration design for TP/PP serving layouts without full restarts.
- PULSE makes skip locality a pipeline-parallel training constraint - the paper turns diffusion-model skip locality into a first-class distributed-training placement constraint.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Prometheus v3.5.4 was published June 17 and fixes STACKIT SD plaintext secret exposure via `/-/config`. | https://github.com/prometheus/prometheus/releases/tag/v3.5.4 release notes | ✅ |
| Prometheus v3.5.4 bumps `golang.org/x/net`, OpenTelemetry, and UI dependencies for security advisories, and publishes images to GHCR. | https://github.com/prometheus/prometheus/releases/tag/v3.5.4 release notes | ✅ |
| PyTorch 2.12.1 was published June 18 and fixes nondeterministic `FLASH_ATTN` output on NVIDIA B200 GPUs. | https://github.com/pytorch/pytorch/releases/tag/v2.12.1 release notes | ✅ |
| PyTorch 2.12.1 fixes illegal memory access in Triton `convolution2d_bwd_weight` on B100/B200 via Triton 3.7.1. | https://github.com/pytorch/pytorch/releases/tag/v2.12.1 release notes | ✅ |
| Capsule GHSA-gwxr-7h77-7777 was published June 17 and describes `namespace/finalize` vs `namespaces/finalize` webhook mismatch. | https://github.com/projectcapsule/capsule/security/advisories/GHSA-gwxr-7h77-7777 advisory summary/details | ✅ |
| Capsule affected range is `>= 0.13.0, < 0.13.6`, with 0.13.6 first patched. | https://github.com/projectcapsule/capsule/security/advisories/GHSA-gwxr-7h77-7777 vulnerability metadata | ✅ |
| LangChain4j GHSA-2mfg-cc43-9pcj was published June 17 for SQL injection in `langchain4j-pgvector` and `langchain4j-mariadb`. | https://github.com/langchain4j/langchain4j/security/advisories/GHSA-2mfg-cc43-9pcj advisory summary/details | ✅ |
| LangChain4j patched package lines include `1.16.3-beta26`, `1.11.8-beta19`, `1.5.1-beta11`, and `1.2.1-beta8`. | https://github.com/langchain4j/langchain4j/security/advisories/GHSA-2mfg-cc43-9pcj vulnerability metadata | ✅ |
| arXiv 2606.18741 was published June 17 and describes ReMP for online TP/PP topology reconfiguration with KV-cache migration. | https://arxiv.org/abs/2606.18741 abstract/metadata | ✅ |
| ReMP authors report most topology switches complete within 1-7 seconds across 7B to 70B models. | https://arxiv.org/abs/2606.18741 abstract | ✅ |
| arXiv 2606.19163 was published June 17 and describes PULSE for skip-locality-aware pipeline-parallel diffusion training. | https://arxiv.org/abs/2606.19163 abstract/metadata | ✅ |
| PULSE authors report 89% less communication volume and up to 2.3x higher throughput on communication-bound hardware. | https://arxiv.org/abs/2606.19163 abstract | ✅ |

## Items considered and dropped

- Helm v4.2.2 - fresh, but the release is a narrow revert of a v4.2.1 WaitForDelete fix and weaker than the shipped items.
- Zitadel v3.4.12 - fresh v3-line auth validation fixes, but weaker than Capsule/LangChain4j advisories and partly overlapped yesterday's v4.15.2 story.
- FlashInfer v0.6.13rc2 and nightly-v0.6.13-20260617 - fresh, but release bodies lacked technical detail beyond changelog/nightly metadata.
- TurboServe arXiv paper - fresh and technically relevant, but cut in favor of ReMP and PULSE for broader serving/training coverage.
- Gitea advisory cluster - fresh and security-relevant, but less directly aligned with this digest than Kubernetes multi-tenancy and AI embedding-store advisories.
- Cloudflare Agents SDK / Flue post - fresh and technical, but too vendor/product shaped for this issue.
- CNCF Flipkart case study, India report, CARE certification update, and agentic AI blog - fresh, but primarily conference/report/certification/commentary material.
- Headlamp Helm 0.43.0 chart - fresh chart wrapper around a release outside the window.
- Langflow and Open WebUI advisories - fresh, but weaker scope fit than LangChain4j for infrastructure practitioners.
- Kubernetes, Kueue, OTel, Cilium, Envoy, Istio, Trivy, Kyverno, Argo CD, Flux, Crossplane, Wasmtime, Rook, KubeVirt, Knative, Tekton, and other routine release feeds - latest primary artifacts were outside the strict 24-hour window or already handled in prior digests.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `18`
- Segments shipped: `6`
- Any unresolved framing concerns: none
- Any vendor-attributed claims: PyTorch release claims and arXiv paper measurements are attributed to their source authors; no vendor benchmark segment shipped.
- Validation: `git diff --check`, banned-word scan, heading/source-count sanity, source-link HTTP checks, and source readbacks passed. Full site build was not run because this was a content-only change and no Bun/dependency command was needed.