### PR TITLE
Rawkode Academy News - June 19, 2026

### DIFF
--- a/content/news/2026-06-19-containerd-cves-opentofu-argocd-kuberay/index.mdx
+++ b/content/news/2026-06-19-containerd-cves-opentofu-argocd-kuberay/index.mdx
@@ -8,8 +8,7 @@ technologies:
   - containerd
   - opentofu
   - kubernetes
-  - security
-  - ai-infrastructure
+  - argo
 ---
 
 Four security and correctness patches landed across the cloud native stack on June 18: a coordinated containerd CVE wave, an OpenTofu file-read fix, Argo CD RBAC and diff regressions, and a KubeRay cleanup deadlock under Kueue.

--- a/content/news/2026-06-19-containerd-cves-opentofu-argocd-kuberay/index.mdx
+++ b/content/news/2026-06-19-containerd-cves-opentofu-argocd-kuberay/index.mdx
@@ -1,0 +1,63 @@
+---
+title: "containerd, OpenTofu, Argo CD, and KubeRay ship security and correctness fixes"
+description: "containerd patched five CRI CVEs across every supported branch, while OpenTofu, Argo CD, and KubeRay fixed a git file-read flaw, RBAC and diff regressions, and a RayService cleanup deadlock."
+publishedAt: 2026-06-19
+authors:
+  - rawkode
+technologies:
+  - containerd
+  - opentofu
+  - kubernetes
+  - security
+  - ai-infrastructure
+---
+
+Four security and correctness patches landed across the cloud native stack on June 18: a coordinated containerd CVE wave, an OpenTofu file-read fix, Argo CD RBAC and diff regressions, and a KubeRay cleanup deadlock under Kueue.
+
+## containerd patches five CRI vulnerabilities across all supported branches
+
+containerd shipped [v2.3.2](https://github.com/containerd/containerd/releases/tag/v2.3.2), v2.2.5, v2.1.9, v2.0.10, and v1.7.33 on June 18, fixing five CVEs in the CRI plugin, three of them rated critical.
+
+The most severe, CVE-2026-53488 ([GHSA-xhf5-7wjv-pqxp](https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp)), lets `LABEL` metadata from a pulled image config reach host-level command execution when a plugin consumes container labels, so an untrusted image pull alone can trigger it. The other critical advisories cover CDI annotation smuggling during CRI checkpoint restore (GHSA-33vj-92qq-66hc) and local image tag poisoning via CRI checkpoint import (GHSA-cvxm-645q-p574); a high-severity symlink-following bug allows arbitrary host file reads during checkpoint restore (GHSA-rgh6-rfwx-v388), and a moderate parsing flaw enables an image-triggered DoS (GHSA-jpcc-p29g-p8mq). The patched releases also bump runc to v1.4.3 and `golang.org/x/crypto` to v0.53.0.
+
+Several of these are reachable from the image-pull or CRI checkpoint/restore paths rather than requiring an already-compromised workload, so clusters pulling third-party images should patch rather than wait for the next routine bump.
+
+**Source:** [containerd security advisories](https://github.com/containerd/containerd/security/advisories) - June 18, 2026
+
+---
+
+## OpenTofu fixes arbitrary file read via malicious git URLs
+
+OpenTofu released [v1.12.3](https://github.com/opentofu/opentofu/releases/tag/v1.12.3) and a companion v1.11.10 on June 18. v1.12.3 fixes GHSA-q7j3-v8qv-22vq, where previous releases in the v1.12 series could read an arbitrary file on the host during certain git operations via a maliciously crafted URL.
+
+The same release fixes handling of `TF_ENCRYPTION` values containing only whitespace, corrects deprecation-mark processing for values from `lifecycle.enabled`, and repairs `tofu console -lock=false`.
+
+This matters for CI systems that run `tofu init` or module fetches against modules sourced from untrusted or user-supplied git URLs, where the file-read path is reachable without operator interaction.
+
+**Source:** [OpenTofu v1.12.3 release](https://github.com/opentofu/opentofu/releases/tag/v1.12.3) - June 18, 2026
+
+---
+
+## Argo CD patches RBAC and diff regressions in 3.4.4 and 3.3.12
+
+Argo CD shipped [v3.4.4](https://github.com/argoproj/argo-cd/releases/tag/v3.4.4) and v3.3.12 on June 18, both bug-fix releases.
+
+v3.4.4 fixes an RBAC regression affecting project-scoped resources in multi-namespace (apps-in-any-namespace) configurations, and a separate regression that caused diffs to error on newly created objects. It also adds locking to the cluster informer for thread safety, excludes live status from normalization, and repairs dex passwords containing dollar signs and cross-generator Values templates in ApplicationSet.
+
+The RBAC and diff regressions affect access control and sync correctness in multi-tenant GitOps setups, so operators on the 3.4 or 3.3 lines should pick up the patch.
+
+**Source:** [Argo CD v3.4.4 release](https://github.com/argoproj/argo-cd/releases/tag/v3.4.4) - June 18, 2026
+
+---
+
+## KubeRay v1.6.2 fixes RayService cleanup deadlock under Kueue
+
+KubeRay released [v1.6.2](https://github.com/ray-project/kuberay/releases/tag/v1.6.2) on June 18 with two fixes for Ray clusters managed alongside Kueue.
+
+The release fixes a bug (#4807) where the Redis cleanup job would never execute when using RayService with Kueue, and adds a timeout (#4836) that enforces removal of Ray cluster finalizers so deletion is not blocked indefinitely when that cleanup job fails to run.
+
+Teams running Ray Serve on Kubernetes with Kueue could previously see RayService deletions hang on stuck finalizers; this release unblocks cluster teardown.
+
+**Source:** [KubeRay v1.6.2 release](https://github.com/ray-project/kuberay/releases/tag/v1.6.2) - June 18, 2026
+
+---


### PR DESCRIPTION
## Summary

June 18 was effectively a security and correctness patch day across the cloud native stack. This digest ships four segments: a coordinated containerd CVE wave (five CVEs, three critical, across every supported branch), an OpenTofu fix for arbitrary file reads via malicious git URLs, Argo CD RBAC and diff regressions, and a KubeRay fix for a RayService cleanup deadlock under Kueue. Triton 3.7.1 (also June 18) was dropped as too thin for the audience. The arXiv LLM-serving papers surfaced during discovery were dropped on the freshness gate (submitted June 16–17, outside the 24h window).

## Run metadata

- Run time: `2026-06-19 06:00 Europe/London`
- Coverage window: `2026-06-18 06:00 Europe/London` to `2026-06-19 06:00 Europe/London`
- Source URLs inspected: `~34`
- Candidates longlisted: `7`
- Candidates shortlisted: `5`
- Segments shipped: `4`
- Time horizon: last 24 hours only

## Segments

- containerd patches five CRI vulnerabilities across all supported branches - critical image-pull and checkpoint/restore CVEs reachable without a compromised workload
- OpenTofu fixes arbitrary file read via malicious git URLs - reachable from CI fetching untrusted module URLs
- Argo CD patches RBAC and diff regressions in 3.4.4 and 3.3.12 - access control and sync correctness in multi-tenant GitOps
- KubeRay v1.6.2 fixes RayService cleanup deadlock under Kueue - unblocks Ray cluster teardown stuck on finalizers

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| containerd shipped v2.3.2/v2.2.5/v2.1.9/v2.0.10/v1.7.33 on 2026-06-18 | github.com/containerd/containerd/releases.atom (timestamps 2026-06-18T23:xxZ) | ✅ |
| Five CVEs, three critical, in the CRI plugin | github.com/containerd/containerd/security/advisories (5 advisories dated June 18) | ✅ |
| CVE-2026-53488: image-config LABEL → host-root command execution | GHSA-xhf5-7wjv-pqxp advisory page | ✅ |
| Patched releases bump runc to v1.4.3, x/crypto to v0.53.0 | github.com/containerd/containerd/releases/tag/v2.3.2 | ✅ |
| OpenTofu v1.12.3 / v1.11.10 released 2026-06-18 | github.com/opentofu/opentofu/releases.atom (2026-06-18T15:21Z) | ✅ |
| GHSA-q7j3-v8qv-22vq: arbitrary file read via crafted git URL in v1.12 series | github.com/opentofu/opentofu/releases/tag/v1.12.3 | ✅ |
| Argo CD v3.4.4 / v3.3.12 released 2026-06-18 | github.com/argoproj/argo-cd/releases.atom (2026-06-18T09:40Z) | ✅ |
| RBAC regression for project-scoped resources in multi-namespace; diff erroring on new objects | github.com/argoproj/argo-cd/releases/tag/v3.4.4 | ✅ |
| KubeRay v1.6.2 released 2026-06-18 | github.com/ray-project/kuberay/releases.atom (2026-06-18T14:39Z) | ✅ |
| Redis cleanup never runs with RayService+Kueue (#4807); finalizer timeout (#4836) | github.com/ray-project/kuberay/releases/tag/v1.6.2 | ✅ |

## Items considered and dropped

- Triton 3.7.1 (June 18) - patch fixing only two regressions (async read deps, LLVM InstCombine); too thin for the audience
- "Beyond Prediction: Tail-Aware Scheduling for LLM Inference" (arXiv 2606.18431) - submitted June 16, outside the 24h window
- "ShuntServe: Cost-Efficient LLM Serving on Heterogeneous Spot GPU Clusters" (arXiv) - submitted June 17, outside the 24h window
- CNCF KubeCon India announcements (Flipkart case study, Udemy partnership, SlashData report, new members, China conferences) - event/marketing PR, no technical artifact
- Wasmtime "dev" rolling tag (June 19) - not a real release
- Many checked projects had no in-window release: Kubernetes, Cilium, Istio, vLLM, SGLang, Kyverno, Prometheus, OTel Collector, Envoy, SPIRE, cert-manager, Flux, runc, etcd, Crossplane, Backstage, Gateway API, NCCL, Dynamo, Volcano, Karpenter, CRI-O, KubeVirt, Dapr, Ray, NVIDIA GPU Operator, Harbor, Falco, Loki, Tetragon, llm-d

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: 7
- Segments shipped: 4
- containerd CVE→GHSA mapping: only CVE-2026-53488 is asserted to map to a specific advisory (GHSA-xhf5-7wjv-pqxp, verified); the other four CVEs are reported as a count with GHSA IDs cited by description to avoid an unverified CVE↔GHSA mapping
- Any vendor-attributed claims: none (all primary project releases and security advisories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lirn5bVsJLk6MYoWEJb5Pq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lirn5bVsJLk6MYoWEJb5Pq)_