### PR TITLE
Rawkode Academy News - June 19, 2026

### DIFF
--- a/content/news/2026-06-19-prometheus-operator-argo-cd-triton-kubeflow-openebs/index.mdx
+++ b/content/news/2026-06-19-prometheus-operator-argo-cd-triton-kubeflow-openebs/index.mdx
@@ -1,0 +1,71 @@
+---
+title: "Prometheus Operator, Argo CD, Triton, Kubeflow Trainer, and OpenEBS ship platform fixes"
+description: "Prometheus Operator promoted sharding controls while Argo CD, Triton, Kubeflow Trainer, and OpenEBS shipped operator-facing fixes."
+publishedAt: 2026-06-19
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - observability
+  - gitops
+  - ai-infrastructure
+  - storage
+---
+
+Five fresh releases landed in the last 24 hours across observability, GitOps, AI compiler tooling, ML-on-Kubernetes training, and Kubernetes storage.
+
+## Prometheus Operator v0.92.0 promotes topology sharding and shard retention to beta
+
+Prometheus Operator released v0.92.0 on June 18 and promoted the `PrometheusTopologySharding` and `PrometheusShardRetentionPolicy` feature gates to beta, enabled by default. Topology-aware sharding can keep shards scraping zone-local targets by generating relabeling rules, adding shard pod `nodeSelector`s, and setting zone external labels; shard retention can keep scaled-down shards queryable through Thanos until their retention window expires.
+
+The release also moves `Prometheus` retention options into the config file for Prometheus 3 and newer, adds `staleSeriesCompactionThreshold` to `TSDBSpec`, adds OTLP label-underscore controls, and adds a `payload` field to AlertmanagerConfig webhook receivers. Validation tightened across OAuth2 `tokenUrl`, `RemoteReadSpec.url`, Probe static target labels, OAuth2 proxy configuration, Slack `update_message`, and malformed key/value flags.
+
+For operators running large Prometheus estates, this turns two sharding behaviors from opt-in experiments into default beta controls and reduces the chance of generating invalid scrape or Alertmanager configuration.
+
+**Source:** [Prometheus Operator v0.92.0 release](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.92.0) - June 18, 2026
+
+---
+
+## Argo CD v3.4.4 and v3.3.12 fix RBAC, diff, and health regressions
+
+Argo CD published v3.4.4 and v3.3.12 on June 18 with patch fixes for supported 3.x lines. The v3.4.4 release fixes an RBAC regression for project-scoped resources in multi-namespace architecture, a server-side diff regression that errored on new objects, and `PromotionStrategy` health getting stuck in `Progressing` after no-op rehydration.
+
+Both releases add locking around `clusterinformer`, exclude live status from normalization, and fix Dex password parsing when the password contains a dollar sign. The v3.3.12 line also backports a fix to honor repo depth settings in `gitSourceHasChanges` and fetch code paths.
+
+GitOps platform teams using multi-namespace Argo CD or promotion strategies should treat this as a correctness patch rather than routine dependency churn.
+
+**Source:** [Argo CD v3.4.4 release](https://github.com/argoproj/argo-cd/releases/tag/v3.4.4) - June 18, 2026
+
+---
+
+## Triton 3.7.1 patches async-copy and LLVM InstCombine correctness regressions
+
+Triton released v3.7.1 on June 18 as a patch release on top of 3.7.0, with no new features or API changes. The first fix adds async read dependencies to `FenceAsync`, correcting a missing fence between `st.shared` and `copy_local_to_global` where an async copy could read shared memory before the store completed.
+
+The second fix pulls in an LLVM InstCombine correction for add simplification when known-zero bits are on the left-hand side rather than the right-hand side. For kernel authors and inference teams compiling custom Triton kernels, this is a compiler correctness release: the important change is avoiding wrong code, not adopting a new API.
+
+**Source:** [Triton 3.7.1 release](https://github.com/triton-lang/triton/releases/tag/v3.7.1) - June 18, 2026
+
+---
+
+## Kubeflow Trainer v2.2.1 backports TrainJob unsuspend and manifest fixes
+
+Kubeflow Trainer released v2.2.1 on June 18 for the 2.2 line. The release updates the branch to k8s 0.36, fixes generated Python API model versioning in the release process, and allows a `TrainJob` to update `spec.runtimePatches` while moving from `suspend: true` to `suspend: false` in a single API request.
+
+The release also fixes manifests to use released JobSet and LWS image versions and updates examples to use a namespaced SQuAD dataset. That matters for teams automating queued or suspended training workloads, because runtime overrides can now be changed at unsuspend time without a separate preflight API write.
+
+**Source:** [Kubeflow Trainer v2.2.1 release](https://github.com/kubeflow/trainer/releases/tag/v2.2.1) - June 18, 2026
+
+---
+
+## OpenEBS 4.5.1 packages Mayastor and LocalPV fixes
+
+OpenEBS released v4.5.1 on June 18 as a patch release over 4.5.0 and recommends upgrading because it includes a critical Replicated PV Mayastor fix. The Mayastor changes cover nexus destruction getting stuck while waiting for child closure, interrupt-mode shutdown cleanup, and snapshot clone accounting.
+
+The LocalPV side fixes quoted image values across ZFS, LVM, Hostpath, and Rawfile manifests. Rawfile LocalPV also adds backing-filesystem capacity and usage metrics under the `rawfile_pool_backing_fs_*` names, removes the older inconsistent `rawfile_pool_available_bytes` and `rawfile_pool_usage_bytes` metrics, fixes a Task Manager `KeyError` for tasks without `retry_count`, and adds a `capacityPollInterval` provisioner parameter.
+
+Storage operators should check dashboards and alerts for the Rawfile metric rename before rolling the patch into environments that scrape those metrics.
+
+**Source:** [OpenEBS v4.5.1 release](https://github.com/openebs/openebs/releases/tag/v4.5.1) - June 18, 2026
+
+---


### PR DESCRIPTION
## Summary

This digest covers five fresh operator-facing releases from the last 24 hours: Prometheus Operator promoted sharding controls to beta defaults, Argo CD patched GitOps correctness regressions, Triton fixed compiler correctness issues, Kubeflow Trainer backported TrainJob unsuspend behavior, and OpenEBS packaged Mayastor and LocalPV fixes. These made the cut because each has a primary source inside the window and a concrete operational consequence.

## Run metadata

- Run time: `2026-06-19 07:01 Europe/London`
- Coverage window: `2026-06-18 07:01:31 Europe/London` to `2026-06-19 07:01:31 Europe/London`
- Source URLs inspected: `150`
- Candidates longlisted: `17`
- Candidates shortlisted: `6`
- Segments shipped: `5`
- Time horizon: last 24 hours only

## Segments

- Prometheus Operator v0.92.0 promotes topology sharding and shard retention to beta - default beta sharding behavior changes how large Prometheus estates can reduce cross-zone scraping and preserve scaled-down shard data.
- Argo CD v3.4.4 and v3.3.12 fix RBAC, diff, and health regressions - GitOps operators get fixes for multi-namespace RBAC, server-side diff, promotion health, and cluster informer locking.
- Triton 3.7.1 patches async-copy and LLVM InstCombine correctness regressions - custom kernel users get a compiler correctness patch without API changes.
- Kubeflow Trainer v2.2.1 backports TrainJob unsuspend and manifest fixes - ML platform teams can update runtime patches while unsuspending a TrainJob and get corrected JobSet/LWS image references.
- OpenEBS 4.5.1 packages Mayastor and LocalPV fixes - storage operators get Mayastor nexus/snapshot fixes and Rawfile metric changes that may require dashboard updates.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| Prometheus Operator v0.92.0 was published on June 18, 2026. | https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.92.0 release metadata | verified |
| `PrometheusTopologySharding` and `PrometheusShardRetentionPolicy` are beta and enabled by default. | https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.92.0 release note | verified |
| Prometheus Operator v0.92.0 adds Prometheus 3 retention config-file behavior, TSDB stale-series compaction threshold, OTLP underscore controls, Alertmanager webhook payload, and validation fixes. | https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.92.0 release note | verified |
| Argo CD v3.4.4 and v3.3.12 were published on June 18, 2026. | https://github.com/argoproj/argo-cd/releases/tag/v3.4.4 and https://github.com/argoproj/argo-cd/releases/tag/v3.3.12 release metadata | verified |
| Argo CD v3.4.4 fixes multi-namespace project-scoped RBAC, new-object server-side diff, PromotionStrategy health, cluster informer locking, live-status normalization, and Dex dollar-sign password parsing. | https://github.com/argoproj/argo-cd/releases/tag/v3.4.4 changelog | verified |
| Triton v3.7.1 was published on June 18, 2026 and has no new features or API changes. | https://github.com/triton-lang/triton/releases/tag/v3.7.1 release note | verified |
| Triton v3.7.1 fixes the missing FenceAsync dependency between `st.shared` and async `copy_local_to_global`. | https://github.com/triton-lang/triton/releases/tag/v3.7.1 and https://github.com/triton-lang/triton/pull/9610 | verified |
| Kubeflow Trainer v2.2.1 was published on June 18, 2026. | https://github.com/kubeflow/trainer/releases/tag/v2.2.1 release metadata | verified |
| Kubeflow Trainer v2.2.1 allows `spec.runtimePatches` updates while unsuspending a TrainJob and fixes JobSet/LWS image references. | https://github.com/kubeflow/trainer/releases/tag/v2.2.1, https://github.com/kubeflow/trainer/pull/3489, and https://github.com/kubeflow/trainer/pull/3453 | verified |
| OpenEBS v4.5.1 was published on June 18, 2026 and recommends upgrading for a critical Replicated PV Mayastor issue. | https://github.com/openebs/openebs/releases/tag/v4.5.1 release note | verified |
| OpenEBS v4.5.1 includes Mayastor nexus destruction, interrupt-mode shutdown, and snapshot clone accounting fixes. | https://github.com/openebs/openebs/releases/tag/v4.5.1 and linked Mayastor issues 1998, 1999, 2004 | verified |
| OpenEBS Rawfile LocalPV adds `rawfile_pool_backing_fs_*` metrics and removes `rawfile_pool_available_bytes` / `rawfile_pool_usage_bytes`. | https://github.com/openebs/rawfile-localpv/releases/tag/v0.14.1 linked from OpenEBS v4.5.1 | verified |

## Items considered and dropped

- Crawl4AI v0.9.0 and related security advisories - fresh and technically serious, but adjacent app-layer crawler tooling; cut to keep the digest focused on core infrastructure.
- Linkerd edge-26.6.3 - fresh edge release, but the fresh proxy payload was dependency-only and the more substantive proxy work predated the window.
- FlashInfer nightly-v0.6.13-20260618 - fresh automated nightly with no substantive release notes.
- Armeria xDS SDS advisory - global advisory was fresh, but the project-owned advisory was published at `2026-06-18 05:33 UTC`, before the window opened.
- HAProxy CVE advisories - global advisories were fresh, but the cited fix commits were from June 16 and the canonical fix artifacts were stale.
- PyTorch v2.12.1 - published at `2026-06-18 00:41 UTC`, before this run's window and already handled by the previous digest.
- Vault and OpenBao security releases - relevant but outside this run's freshness window.
- Kubernetes, Kueue, Helm, Prometheus, OTel, Flux, and most standard CNCF release feeds - latest primary artifacts were stale for this run.

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: `17`
- Segments shipped: `5`
- Any unresolved framing concerns: none
- Any vendor-attributed claims: none
