### PR TITLE
Rawkode Academy News - June 20, 2026

### DIFF
--- a/content/news/2026-06-20-runc-1-5-prometheus-3-13-talos/index.mdx
+++ b/content/news/2026-06-20-runc-1-5-prometheus-3-13-talos/index.mdx
@@ -1,0 +1,46 @@
+---
+title: "runc 1.5.0 ships stable, Prometheus 3.13 enters RC, Talos patches etcd leak"
+description: "runc cut its first stable 1.5 release with libpathrs hardening and a new support policy, Prometheus opened a 3.13.0 release candidate with new PromQL functions, and Talos v1.12.9 fixed an etcd client resource leak."
+publishedAt: 2026-06-20
+authors:
+  - rawkode
+technologies:
+  - kubernetes
+  - prometheus
+---
+
+Three primary-source releases landed in the last 24 hours across container runtimes, metrics, and the node OS. It was a quiet window, so this is a short digest rather than a padded one.
+
+## runc 1.5.0 cuts the first stable release of the 1.5 branch
+
+The OCI reference runtime published [runc 1.5.0](https://github.com/opencontainers/runc/releases/tag/v1.5.0) on June 19, described by maintainers as the somewhat-delayed first stable release of the 1.5.z line. It rolls up the 1.5.0-rc series, including the fix for CVE-2026-41579, a low-severity issue where a malicious image with a `/dev` symlink could gain limited write access to the host filesystem.
+
+The 1.5 line continues runc's move onto `libpathrs` for safer path resolution: builds using the libpathrs tag now require v0.2.5 or later, and both `runc version` and `runc features` report libpathrs build details. The release upgrades go-criu to v8.3.0, drops binary size from roughly 16MB to 14MB, and fixes a long-standing bug where the `org.opencontainers.runc.version` annotation carried a stray newline that broke parsing in downstream tools.
+
+1.5.0 is also the first stable release under runc's revised support policy: the 1.2.z and earlier branches are end-of-life, 1.3.z receives only high-severity CVE fixes through October 2026, and 1.4.z moves to security and significant bugfixes only.
+
+**Source:** [runc 1.5.0 release](https://github.com/opencontainers/runc/releases/tag/v1.5.0) - June 19, 2026
+
+---
+
+## Prometheus 3.13.0-rc.0 adds scalar min_of/max_of and metadata search endpoints
+
+Prometheus published [v3.13.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v3.13.0-rc.0) on June 19 as a testing-only release candidate for the 3.13 line. PromQL gains experimental scalar `min_of(a, b)` and `max_of(a, b)` functions and support for smoothed/anchored rate over native histograms.
+
+The candidate adds experimental API search endpoints for metric names, label names, and label values, a `storage.tsdb.chunk_encoding.floats` flag to select float chunk encoding at runtime, and new scrape-time internal labels for per-target control over classic and native histogram conversion. Container images for the 3.13 line are now also published to the GitHub Container Registry, alongside a batch of TSDB and PromQL bugfixes, including range-query alignment and histogram handling in `resets()` and `changes()`.
+
+This is a preview rather than an upgrade target, but the new scalar functions and metadata search endpoints are worth testing for teams building query tooling on top of the Prometheus API.
+
+**Source:** [Prometheus v3.13.0-rc.0 release](https://github.com/prometheus/prometheus/releases/tag/v3.13.0-rc.0) - June 19, 2026
+
+---
+
+## Talos v1.12.9 fixes an etcd client leak and tightens OOM victim selection
+
+Sidero Labs released [Talos v1.12.9](https://github.com/siderolabs/talos/releases/tag/v1.12.9) on June 19 with 18 commits from 5 contributors. The release fixes an etcd client resource leak in the legacy Upgrade API and raises the file-descriptor limit for etcd, both of which matter for long-running control-plane nodes.
+
+It also recreates the DNS server when the host DNS runner restarts, makes OOM victim selection follow stricter QoS ordering, relaxes LUKS header and hostname validation, and reverts CoreDNS to 1.14.2 for stability. The node image ships Linux 6.18.35, containerd 2.2.5, runc 1.3.6, CoreDNS 1.14.2, and Go 1.25.11, with security updates pulled in via containerd 2.2.5 and OpenSSL 3.6.3.
+
+**Source:** [Talos v1.12.9 release](https://github.com/siderolabs/talos/releases/tag/v1.12.9) - June 19, 2026
+
+---


### PR DESCRIPTION
## Summary

A short, three-segment daily digest covering the June 19 publishing window. It was a quiet 24 hours — most major projects shipped earlier in the week — so this ships only what passed the freshness gate as fresh, primary-sourced, in-scope releases: runc's first stable 1.5 release, a Prometheus 3.13 release candidate, and a Talos node-OS patch with operationally relevant fixes. No padding.

## Run metadata

- Run time: `2026-06-20 06:00 Europe/London`
- Coverage window: `2026-06-19 05:00 UTC` to `2026-06-20 05:00 UTC`
- Source URLs inspected: `~48` (release atom feeds, project/CNCF/Kubernetes blogs, arXiv cs.DC)
- Candidates longlisted: `6` in-window artifacts
- Candidates shortlisted: `3`
- Segments shipped: `3`
- Time horizon: last 24 hours only

## Segments

- runc 1.5.0 ships stable - first stable release of the 1.5 branch (libpathrs hardening, CVE-2026-41579 fix, new support/EOL policy).
- Prometheus 3.13.0-rc.0 - preview with new scalar PromQL functions and metadata search endpoints for query tooling.
- Talos v1.12.9 - fixes an etcd client resource leak and tightens OOM victim selection on control-plane nodes.

## Fact-check log

| Claim | Source | Verified |
|---|---|---|
| runc 1.5.0 is first stable of 1.5.z; fixes CVE-2026-41579; requires libpathrs v0.2.5+; go-criu v8.3.0; ~16MB→14MB; annotation newline fix; support policy (1.2.z EOL, 1.3.z high-severity CVE only through Oct 2026, 1.4.z security+bugfix) | [runc v1.5.0 release notes](https://github.com/opencontainers/runc/releases/tag/v1.5.0) — published 2026-06-19 11:44 UTC | ✅ |
| Prometheus v3.13.0-rc.0 adds scalar `min_of`/`max_of`, smoothed/anchored rate over native histograms, metadata search endpoints, `storage.tsdb.chunk_encoding.floats`, GHCR images, TSDB/PromQL bugfixes | [Prometheus v3.13.0-rc.0 + CHANGELOG](https://github.com/prometheus/prometheus/releases/tag/v3.13.0-rc.0) — tagged 2026-06-19 12:35 UTC | ✅ |
| Talos v1.12.9: 18 commits/5 contributors; etcd client leak fix in legacy Upgrade API; etcd FD limit raise; DNS recreation; stricter OOM QoS ordering; LUKS/hostname validation relaxed; Linux 6.18.35, containerd 2.2.5, runc 1.3.6, CoreDNS 1.14.2, Go 1.25.11, OpenSSL 3.6.3 | [Talos v1.12.9 release notes](https://github.com/siderolabs/talos/releases/tag/v1.12.9) — published 2026-06-19 18:47 UTC | ✅ |

## Items considered and dropped

- arXiv: ARGUS (10,000+ GPU tracing), SAC (CXL disaggregated KV cache), Online Dynamic Batching for LLM training - strongest technical material found, but all three carry an arXiv submission date of **June 18, 2026**, outside the strict 24h window at run time. Dropped on freshness despite high relevance. Worth human review if the window were widened.
- containerd v2.3.2 / v2.2.5 et al. (June 18 23:16 UTC), Argo CD v3.4.4 (June 18 09:40), Velero v1.18.2-rc.1 (June 18 08:49), Linkerd edge-26.6.3 (June 18 17:47), BuildKit v0.31.0 (June 17), Backstage v1.52.0 (June 17) - all just outside the 24h window.
- Wasmtime `dev` and llama.cpp `bNNNN` tags (June 19) - rolling CI/dev tags, not newsworthy releases.
- CNCF/Kubernetes blog + CNCF announcements (KubeCon India: India developer report, Flipkart case study, Udemy partnership, new members, KubeCon China schedule) - event/membership/case-study items, out of scope (no technical artifact or project change).

## Reviewer notes

- Stages completed: Discovery -> Triage -> Draft -> Adversarial Review -> Fact-check -> Edit Pass -> Final Review
- Total candidates considered: ~48 URLs inspected; 6 in-window artifacts; 3 shipped
- This is a deliberately short digest. The window was genuinely quiet (Friday June 19 into a Saturday run, right after KubeCon India). Per the editorial rules, shipping 3 verified items beats padding to 6.
- Prometheus segment is a pre-release; it is framed as a preview, not an upgrade target.
- Any vendor-attributed claims: none. All three are primary OSS release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnNjatREwuaUuiTWDMrCnU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnNjatREwuaUuiTWDMrCnU)_