### PR TITLE
feat(rawkode.academy/website): refresh technical publication design

### DIFF
--- a/projects/rawkode.academy/website/.impeccable.md
+++ b/projects/rawkode.academy/website/.impeccable.md
@@ -18,12 +18,14 @@ building and instead communicate signal, momentum, and practical credibility.
 
 ### Aesthetic Direction
 
-Light-first surfaces with subtle glass treatment, crisp typography, and
-brand-led teal and green accents. The homepage should feel like a technical
-editorial front page rather than a generic SaaS landing page. Real technology
-marks, concrete content previews, and measured motion should carry more weight
-than decorative effects. Avoid rounded card grids and boxed panel-heavy
-compositions when a more fluid editorial layout can carry the content.
+A modern technical publication with warm paper surfaces, wide reading and media
+canvases, decisive typography, and restrained spruce, amber, and rust accents.
+The homepage should read like a current practitioner publication rather than a
+generic SaaS landing page. Use Instrument Serif once for the defining page
+statement, then rely on Inter Tight for section hierarchy and long-form reading.
+Real technology marks, concrete content previews, and measured motion should
+carry more weight than decorative effects. Avoid persistent application
+sidebars, rounded card grids, and boxed panel-heavy compositions.
 
 ### Design Principles
 

--- a/projects/rawkode.academy/website/CLAUDE.md
+++ b/projects/rawkode.academy/website/CLAUDE.md
@@ -15,9 +15,9 @@ bun run sync:content  # Sync GraphQL content
 
 ## Component Library & Design System
 
-### Theme: Editorial — "Engineering journal meets terminal"
+### Theme: Modern technical publication
 
-The website ships a single design system: warm paper surfaces with deep ink type, italic serif display headings, geometric sans body, and mono microcopy. Light and dark colour schemes share the same vocabulary — values invert, names do not.
+The website ships a single design system: warm paper surfaces, deep ink type, a scarce serif display voice, compact sans hierarchy, and mono metadata. Light and dark colour schemes share the same vocabulary — values invert, names do not. A compact publication masthead replaces the former persistent sidebar so reading, video, and comparison pages retain the full canvas.
 
 #### Atomic CSS engine
 

--- a/projects/rawkode.academy/website/DESIGN.md
+++ b/projects/rawkode.academy/website/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 name: Rawkode Academy Website
-description: Practitioner-led cloud-native education with an engineering journal visual system.
+description: Practitioner-led cloud-native education with a modern technical-publication visual system.
 colors:
   editorial-paper: "oklch(0.97 0.008 85)"
   editorial-paper-deep: "oklch(0.93 0.012 85)"
@@ -93,11 +93,11 @@ components:
 
 ## 1. Overview
 
-**Creative North Star: "The Engineering Field Journal"**
+**Creative North Star: "The Technical Publication for Practitioners"**
 
-Rawkode Academy uses a restrained editorial system for practical technical learning: paper-like surfaces, ink-led typography, sharp corners, ruled divisions, and a small set of earthy accents. The system should feel like a published engineering notebook with production evidence attached, not a generic developer landing page.
+Rawkode Academy uses a modern publication system for practical technical learning: wide media and reading canvases, decisive hierarchy, paper-like surfaces, sharp rules, and a small set of evidence-led accents. The system should feel like the technical publication developers keep open while they work, not a generic developer landing page or a themed documentation portal.
 
-The active codebase describes the visual identity as "engineering journal meets terminal". Preserve that by pairing Instrument Serif for selective display moments, Inter Tight for dense readable UI and prose, and JetBrains Mono for metadata, labels, and schedule-like information. The site can be content-heavy, but each page should keep hierarchy clear and avoid burying decisions in decorative cards.
+Instrument Serif is reserved for one defining display moment per page. Inter Tight carries navigation, section hierarchy, dense readable UI, and prose. JetBrains Mono is limited to metadata, labels, schedules, and technical identifiers. The site can be content-heavy, but every page must make the next useful artifact obvious without burying decisions in decorative cards.
 
 The system rejects slideware polish, broad SaaS gradients, paid-media gloss, fake simplicity, and open-ended consulting posture. Commercial pages should feel as specific and bounded as technical pages.
 
@@ -106,8 +106,9 @@ The system rejects slideware polish, broad SaaS gradients, paid-media gloss, fak
 - Paper and ink surfaces with spruce, amber, rust, and violet accents.
 - Sharp editorial radii from 2px to 8px, not soft rounded cards.
 - Hairline borders and tonal layering before shadows.
-- Dense but readable layouts with deliberate section rhythm.
+- Wide, scan-friendly layouts with deliberate section rhythm.
 - Copy that names real technical work, tradeoffs, and boundaries.
+- A compact publication masthead and full navigation drawer instead of a persistent application sidebar.
 
 ## 2. Colors
 
@@ -160,7 +161,7 @@ The palette is an editorial paper and ink system with restrained practitioner ac
 
 ### Named Rules
 
-**The Display Scarcity Rule.** Large italic serif type is a signal. Use it for decisive moments, not as a site-wide reflex.
+**The Display Scarcity Rule.** Large serif type is a signal. Use it once for the defining page statement; use sans-serif hierarchy for sections and long-form reading.
 
 **The Metadata Rule.** Mono labels must describe concrete metadata or state. Avoid using mono as generic developer costume.
 
@@ -209,7 +210,14 @@ The default elevation model is flat and structural. Light-mode surfaces rely on 
 
 ### Navigation
 
-Navigation should be predictable and compact. Use clear text labels, visible hover/focus states, and avoid oversized marketing nav treatments. Mobile navigation must preserve access to content collections, search, and organization contact paths.
+Navigation uses a compact sticky publication masthead with direct links to the primary learning formats, a search trigger, and an accessible full navigation drawer. Do not reintroduce a persistent desktop sidebar. Mobile navigation must preserve access to every collection while keeping the masthead controls within a 320px viewport.
+
+### Layout Contracts
+
+- **Prose** (`--layout-prose`): articles, policies, ADR bodies, and focused utility copy.
+- **Content** (`--layout-content`): detail pages, curricula, search, and collection results.
+- **Wide** (`--layout-wide`): video, technology matrix, landing features, and dense comparison surfaces.
+- Page families assemble `PageMasthead`, `CollectionToolbar`, `ContentCard`, and `DetailFrame` before introducing route-local layout CSS.
 
 ### Editorial Shell
 
@@ -232,5 +240,6 @@ The editorial shell is the signature layout for about and commercial surfaces: m
 - **Don't** frame partnerships as outsourced DevRel, open-ended consulting retainers, lead generation, guaranteed coverage, or editorial placement.
 - **Don't** use gradient text, glassmorphism, broad purple-blue gradients, oversized rounded cards, or decorative soft shadows.
 - **Don't** repeat tiny uppercase eyebrows above every section unless the section genuinely needs metadata.
+- **Don't** introduce a new route-local masthead, filter bar, card anatomy, or content-width value when a publication contract covers it.
 - **Don't** use mono labels when the text is not metadata, state, or a technical identifier.
 - **Don't** let muted text carry long body copy on tinted surfaces if contrast falls below WCAG AA.

--- a/projects/rawkode.academy/website/src/components/html/head.astro
+++ b/projects/rawkode.academy/website/src/components/html/head.astro
@@ -72,9 +72,14 @@ const normalizedTitle =
 	<link rel="manifest" href="/site.webmanifest" />
 	<link rel="mask-icon" href="/icon-dark.svg" color="#23282d" />
 	<meta name="msapplication-TileColor" content="#f8f5ef" />
-	{/* Theme color tracks the editorial palette: paper for light, ink-dark for dark. */}
-	<meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8f5ef" />
-	<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b23" />
+	{/* ThemeScript keeps browser chrome aligned with the applied preference,
+	    including when it overrides the operating-system scheme. */}
+	<meta
+		name="theme-color"
+		content="#f8f5ef"
+		data-light-color="#f8f5ef"
+		data-dark-color="#1b1b23"
+	/>
 	<meta
 		name="description"
 		content={Astro.props.description || SITE_DESCRIPTION}

--- a/projects/rawkode.academy/website/src/components/landing/NewsletterStrip.astro
+++ b/projects/rawkode.academy/website/src/components/landing/NewsletterStrip.astro
@@ -34,6 +34,9 @@ import MLabel from "@/components/ui/MLabel.vue";
 	.newsletter-strip {
 		display: grid;
 		grid-template-columns: 1fr auto;
+		box-sizing: border-box;
+		width: 100%;
+		min-width: 0;
 		align-items: center;
 		gap: 2rem;
 		padding: 1.25rem 2.5rem;
@@ -47,6 +50,7 @@ import MLabel from "@/components/ui/MLabel.vue";
 		display: flex;
 		flex-direction: column;
 		gap: 0.4rem;
+		min-width: 0;
 	}
 
 	.newsletter-strip__copy {
@@ -62,9 +66,12 @@ import MLabel from "@/components/ui/MLabel.vue";
 	}
 
 	.newsletter-strip__form {
-		display: flex;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
 		gap: 0.5rem;
 		align-items: center;
+		width: 100%;
+		min-width: 0;
 	}
 
 	.newsletter-strip__input {
@@ -88,6 +95,11 @@ import MLabel from "@/components/ui/MLabel.vue";
 			grid-template-columns: 1fr;
 			padding: 1.25rem 1.5rem;
 		}
-		.newsletter-strip__input { min-width: 0; flex: 1; }
+		.newsletter-strip__input { width: 100%; min-width: 0; }
+	}
+
+	@media (max-width: 440px) {
+		.newsletter-strip__form { grid-template-columns: 1fr; }
+		.newsletter-strip__form :global(button) { width: 100%; }
 	}
 </style>

--- a/projects/rawkode.academy/website/src/components/navigation/PublicationNav.astro
+++ b/projects/rawkode.academy/website/src/components/navigation/PublicationNav.astro
@@ -185,7 +185,7 @@ const isCurrent = (href: string) =>
 		position: absolute;
 		inset: 0;
 		border: 0;
-		background: color-mix(in oklab, var(--editorial-ink) 46%, transparent);
+		background: color-mix(in oklab, var(--terminal-bg) 72%, transparent);
 		cursor: pointer;
 	}
 
@@ -198,7 +198,7 @@ const isCurrent = (href: string) =>
 		overflow-y: auto;
 		background: var(--surface-base);
 		border-bottom: 1px solid var(--surface-border-strong);
-		box-shadow: 0 1rem 3rem color-mix(in oklab, var(--editorial-ink) 16%, transparent);
+		box-shadow: 0 1rem 3rem color-mix(in oklab, var(--terminal-bg) 52%, transparent);
 	}
 
 	.publication-nav__intro {
@@ -206,8 +206,8 @@ const isCurrent = (href: string) =>
 		flex-direction: column;
 		gap: 1rem;
 		padding: var(--space-page-pad-block) var(--space-page-pad-inline);
-		background: var(--editorial-ink);
-		color: var(--editorial-paper);
+		background: var(--terminal-bg);
+		color: var(--terminal-text);
 	}
 
 	.publication-nav__kicker,
@@ -239,7 +239,7 @@ const isCurrent = (href: string) =>
 		gap: 1rem;
 		margin-top: auto;
 		padding-top: 1rem;
-		border-top: 1px solid color-mix(in oklab, var(--editorial-paper) 28%, transparent);
+		border-top: 1px solid var(--terminal-border);
 		color: inherit;
 		font-weight: 600;
 		text-decoration: none;

--- a/projects/rawkode.academy/website/src/components/navigation/PublicationNav.astro
+++ b/projects/rawkode.academy/website/src/components/navigation/PublicationNav.astro
@@ -1,0 +1,314 @@
+---
+interface NavItem {
+	label: string;
+	href: string;
+	description: string;
+}
+
+interface NavGroup {
+	label: string;
+	items: NavItem[];
+}
+
+const groups: NavGroup[] = [
+	{
+		label: "Learn",
+		items: [
+			{
+				label: "Videos",
+				href: "/watch",
+				description: "Live builds, tutorials, and technical conversations.",
+			},
+			{
+				label: "Articles",
+				href: "/read",
+				description: "Guides, architecture notes, and practical explanations.",
+			},
+			{
+				label: "Courses",
+				href: "/courses",
+				description: "Structured, hands-on technical curricula.",
+			},
+			{
+				label: "Learning paths",
+				href: "/learning-paths",
+				description: "Curated routes through related lessons.",
+			},
+		],
+	},
+	{
+		label: "Explore",
+		items: [
+			{
+				label: "Technology Matrix",
+				href: "/technology/matrix",
+				description: "Compare tools by adoption stage and confidence.",
+			},
+			{
+				label: "Technologies",
+				href: "/technology",
+				description: "Browse the projects covered by the academy.",
+			},
+			{
+				label: "Shows",
+				href: "/shows",
+				description: "Recurring formats and their complete archives.",
+			},
+			{
+				label: "People",
+				href: "/people",
+				description: "Meet the maintainers and practitioners on the platform.",
+			},
+		],
+	},
+	{
+		label: "Current",
+		items: [
+			{
+				label: "News",
+				href: "/news",
+				description: "Operator-relevant changes across cloud native.",
+			},
+			{
+				label: "Search",
+				href: "/search",
+				description: "Search every format and technology in one place.",
+			},
+			{
+				label: "Partnerships",
+				href: "/organizations/partnerships",
+				description: "Technical adoption work for infrastructure teams.",
+			},
+			{
+				label: "CNIcon",
+				href: "/games/cnicon",
+				description: "Test your cloud native project knowledge.",
+			},
+		],
+	},
+];
+
+const currentPath = Astro.url.pathname;
+const isCurrent = (href: string) =>
+	href === "/" ? currentPath === href : currentPath.startsWith(href);
+---
+
+<div id="publication-nav" class="publication-nav" hidden>
+	<button
+		id="publication-nav-scrim"
+		class="publication-nav__scrim"
+		type="button"
+		aria-label="Close navigation"
+	></button>
+	<nav class="publication-nav__panel" aria-label="Academy navigation">
+		<div class="publication-nav__intro">
+			<p class="publication-nav__kicker">Rawkode Academy</p>
+			<p class="publication-nav__statement">
+				Practical cloud native education for people who learn by building.
+			</p>
+			<a class="publication-nav__featured" href="/watch">
+				<span>Start with the latest session</span>
+				<span aria-hidden="true">&#8599;</span>
+			</a>
+		</div>
+
+		<div class="publication-nav__groups">
+			{groups.map((group) => (
+				<section class="publication-nav__group" aria-labelledby={`nav-${group.label.toLowerCase()}`}>
+					<h2 id={`nav-${group.label.toLowerCase()}`}>{group.label}</h2>
+					<ul>
+						{group.items.map((item) => (
+							<li>
+								<a
+									href={item.href}
+									aria-current={isCurrent(item.href) ? "page" : undefined}
+								>
+									<strong>{item.label}</strong>
+									<span>{item.description}</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				</section>
+			))}
+		</div>
+	</nav>
+</div>
+
+<script>
+	const nav = document.getElementById("publication-nav");
+	const scrim = document.getElementById("publication-nav-scrim");
+	const triggers = [
+		document.getElementById("sidebar-toggle-btn"),
+		document.getElementById("mobile-sidebar-btn"),
+	].filter(Boolean);
+
+	let returnFocus: HTMLElement | null = null;
+
+	function setOpen(open: boolean, trigger?: HTMLElement | null) {
+		if (!nav) return;
+		nav.hidden = !open;
+		document.body.classList.toggle("publication-nav-open", open);
+		for (const item of triggers) item?.setAttribute("aria-expanded", String(open));
+
+		if (open) {
+			returnFocus = trigger ?? null;
+			(nav.querySelector("a") as HTMLElement | null)?.focus();
+		} else {
+			returnFocus?.focus();
+			returnFocus = null;
+		}
+	}
+
+	for (const trigger of triggers) {
+		trigger?.setAttribute("aria-controls", "publication-nav");
+		trigger?.setAttribute("aria-expanded", "false");
+		trigger?.addEventListener("click", () => {
+			setOpen(nav?.hidden ?? true, trigger as HTMLElement);
+		});
+	}
+
+	scrim?.addEventListener("click", () => setOpen(false));
+	window.addEventListener("keydown", (event) => {
+		if (event.key === "Escape" && nav && !nav.hidden) setOpen(false);
+	});
+</script>
+
+<style>
+	.publication-nav {
+		position: fixed;
+		inset: 64px 0 0;
+		z-index: 45;
+	}
+
+	.publication-nav__scrim {
+		position: absolute;
+		inset: 0;
+		border: 0;
+		background: color-mix(in oklab, var(--editorial-ink) 46%, transparent);
+		cursor: pointer;
+	}
+
+	.publication-nav__panel {
+		position: relative;
+		display: grid;
+		grid-template-columns: minmax(16rem, 0.62fr) minmax(0, 1.7fr);
+		width: 100%;
+		max-height: calc(100vh - 64px);
+		overflow-y: auto;
+		background: var(--surface-base);
+		border-bottom: 1px solid var(--surface-border-strong);
+		box-shadow: 0 1rem 3rem color-mix(in oklab, var(--editorial-ink) 16%, transparent);
+	}
+
+	.publication-nav__intro {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: var(--space-page-pad-block) var(--space-page-pad-inline);
+		background: var(--editorial-ink);
+		color: var(--editorial-paper);
+	}
+
+	.publication-nav__kicker,
+	.publication-nav__group h2 {
+		margin: 0;
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.68rem;
+		font-weight: 600;
+		letter-spacing: 0.14em;
+		line-height: 1;
+		text-transform: uppercase;
+	}
+
+	.publication-nav__kicker { color: var(--editorial-amber); }
+
+	.publication-nav__statement {
+		max-width: 18ch;
+		margin: 0;
+		font-family: var(--font-instrument-serif), Georgia, serif;
+		font-size: clamp(2rem, 4vw, 3.5rem);
+		font-style: normal;
+		line-height: 0.98;
+		text-wrap: balance;
+	}
+
+	.publication-nav__featured {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-top: auto;
+		padding-top: 1rem;
+		border-top: 1px solid color-mix(in oklab, var(--editorial-paper) 28%, transparent);
+		color: inherit;
+		font-weight: 600;
+		text-decoration: none;
+	}
+
+	.publication-nav__groups {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.publication-nav__group {
+		padding: var(--space-page-pad-block) clamp(1.25rem, 3vw, 2.5rem);
+		border-left: 1px solid var(--surface-border);
+	}
+
+	.publication-nav__group h2 { color: var(--text-muted); }
+
+	.publication-nav__group ul {
+		list-style: none;
+		margin: 1.25rem 0 0;
+		padding: 0;
+	}
+
+	.publication-nav__group li + li { border-top: 1px solid var(--surface-border); }
+
+	.publication-nav__group a {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		padding: 1rem 0;
+		color: var(--text-primary-content);
+		text-decoration: none;
+	}
+
+	.publication-nav__group a:hover strong,
+	.publication-nav__group a[aria-current="page"] strong {
+		color: var(--editorial-spruce);
+	}
+
+	.publication-nav__group strong {
+		font-size: 1rem;
+		line-height: 1.2;
+	}
+
+	.publication-nav__group span {
+		color: var(--text-secondary-content);
+		font-size: 0.82rem;
+		line-height: 1.35;
+	}
+
+	:global(body.publication-nav-open) { overflow: hidden; }
+
+	@media (max-width: 900px) {
+		.publication-nav__panel { grid-template-columns: 1fr; }
+		.publication-nav__intro { min-height: 13rem; }
+		.publication-nav__statement { max-width: 24ch; }
+	}
+
+	@media (max-width: 640px) {
+		.publication-nav__groups { grid-template-columns: 1fr; }
+		.publication-nav__group { border-left: 0; border-top: 1px solid var(--surface-border); }
+		.publication-nav__group a { padding: 0.8rem 0; }
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.publication-nav__panel { animation: publication-nav-in 180ms var(--ease-out); }
+		@keyframes publication-nav-in {
+			from { opacity: 0; transform: translateY(-0.75rem); }
+			to { opacity: 1; transform: translateY(0); }
+		}
+	}
+</style>

--- a/projects/rawkode.academy/website/src/components/news/NewsLead.astro
+++ b/projects/rawkode.academy/website/src/components/news/NewsLead.astro
@@ -30,7 +30,7 @@ const {
 		{time ? `${time} · ` : ""}LEAD STORY · {kicker}
 	</MLabel>
 
-	<h1 class="news-lead__title">{title}</h1>
+	<h2 class="news-lead__title">{title}</h2>
 	<p class="news-lead__description">{description}</p>
 
 	<div class="news-lead__actions">

--- a/projects/rawkode.academy/website/src/components/read/ArticleHeader.astro
+++ b/projects/rawkode.academy/website/src/components/read/ArticleHeader.astro
@@ -121,7 +121,7 @@ const eyebrowText =
 
 	.article-header__title {
 		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
+		font-style: normal;
 		font-weight: 400;
 		font-size: clamp(2.75rem, 6.5vw, 5.5rem);
 		line-height: 0.97;

--- a/projects/rawkode.academy/website/src/components/read/FeaturedArticle.astro
+++ b/projects/rawkode.academy/website/src/components/read/FeaturedArticle.astro
@@ -53,7 +53,7 @@ const {
 				Featured · Dispatch №{dispatchNum}
 			</MLabel>
 
-			<h1 class="featured-article__title">{title}</h1>
+			<h2 class="featured-article__title">{title}</h2>
 			<p class="featured-article__dek">{dek}</p>
 
 			<div class="featured-article__meta">
@@ -119,12 +119,12 @@ const {
 	}
 
 	.featured-article__title {
-		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
-		font-weight: 400;
-		font-size: clamp(2.5rem, 5.5vw, 5rem);
-		line-height: 0.92;
-		letter-spacing: -0.025em;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-style: normal;
+		font-weight: 650;
+		font-size: clamp(2rem, 4vw, 3.75rem);
+		line-height: 0.98;
+		letter-spacing: -0.04em;
 		color: var(--editorial-ink);
 		margin: 0;
 		text-wrap: balance;

--- a/projects/rawkode.academy/website/src/components/read/ReadMasthead.astro
+++ b/projects/rawkode.academy/website/src/components/read/ReadMasthead.astro
@@ -1,50 +1,5 @@
-<header class="read-masthead">
-	<h1 class="read-masthead__title">Latest Articles</h1>
-	<p class="read-masthead__dek">Essays and tutorials.</p>
-</header>
+---
+import PageMasthead from "@/components/ui/PageMasthead.astro";
+---
 
-<style>
-	.read-masthead {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding: 1.125rem 2.5rem;
-		border-bottom: 1px solid var(--editorial-hairline);
-	}
-
-	.read-masthead__title {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: clamp(1.75rem, 3vw, 2.5rem);
-		font-weight: 700;
-		line-height: 1;
-		letter-spacing: 0;
-		color: var(--editorial-ink);
-		margin: 0;
-	}
-
-	.read-masthead__dek {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.95rem;
-		line-height: 1.4;
-		color: var(--editorial-ink-soft);
-		text-align: right;
-		margin: 0;
-	}
-
-	@media (max-width: 880px) {
-		.read-masthead {
-			align-items: flex-start;
-			flex-direction: column;
-			gap: 0.25rem;
-			padding: 0.875rem 1rem;
-		}
-		.read-masthead__title {
-			font-size: 1.875rem;
-		}
-		.read-masthead__dek {
-			font-size: 0.875rem;
-			text-align: left;
-		}
-	}
-</style>
+<PageMasthead title="Latest Articles" dek="Essays and tutorials." variant="collection" />

--- a/projects/rawkode.academy/website/src/components/theme/ThemeScript.astro
+++ b/projects/rawkode.academy/website/src/components/theme/ThemeScript.astro
@@ -30,6 +30,16 @@
 
 		function applyScheme(scheme) {
 			document.documentElement.classList.toggle("dark", scheme === "dark");
+			document.documentElement.setAttribute("data-color-scheme", scheme);
+			const themeColor = document.querySelector(
+				'meta[name="theme-color"][data-light-color]',
+			);
+			if (themeColor) {
+				themeColor.content =
+					scheme === "dark"
+						? themeColor.dataset.darkColor
+						: themeColor.dataset.lightColor;
+			}
 		}
 
 		function resolve(pref) {

--- a/projects/rawkode.academy/website/src/components/ui/CollectionMasthead.astro
+++ b/projects/rawkode.academy/website/src/components/ui/CollectionMasthead.astro
@@ -1,4 +1,6 @@
 ---
+import PageMasthead from "@/components/ui/PageMasthead.astro";
+
 interface Props {
 	title: string;
 	dek?: string | undefined;
@@ -7,54 +9,4 @@ interface Props {
 const { title, dek } = Astro.props as Props;
 ---
 
-<header class="collection-masthead">
-	<h1 class="collection-masthead__title">{title}</h1>
-	{dek && <p class="collection-masthead__dek">{dek}</p>}
-</header>
-
-<style>
-	.collection-masthead {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding: 1.125rem var(--space-section-pad-x);
-		border-bottom: 1px solid var(--editorial-hairline);
-		background: var(--editorial-paper);
-		color: var(--editorial-ink);
-	}
-
-	.collection-masthead__title {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: clamp(1.75rem, 3vw, 2.5rem);
-		font-weight: 700;
-		line-height: 1;
-		letter-spacing: 0;
-		margin: 0;
-	}
-
-	.collection-masthead__dek {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.95rem;
-		line-height: 1.4;
-		color: var(--editorial-ink-soft);
-		text-align: right;
-		margin: 0;
-	}
-
-	@media (max-width: 880px) {
-		.collection-masthead {
-			align-items: flex-start;
-			flex-direction: column;
-			gap: 0.25rem;
-			padding: 0.875rem 1rem;
-		}
-		.collection-masthead__title {
-			font-size: 1.875rem;
-		}
-		.collection-masthead__dek {
-			font-size: 0.875rem;
-			text-align: left;
-		}
-	}
-</style>
+<PageMasthead title={title} dek={dek} variant="collection" />

--- a/projects/rawkode.academy/website/src/components/ui/CollectionToolbar.astro
+++ b/projects/rawkode.academy/website/src/components/ui/CollectionToolbar.astro
@@ -1,0 +1,46 @@
+---
+interface Props {
+	label?: string;
+	resultCount?: number;
+	resultLabel?: string;
+	sticky?: boolean;
+}
+
+const {
+	label = "Refine",
+	resultCount,
+	resultLabel = "results",
+	sticky = false,
+} = Astro.props as Props;
+---
+
+<section class:list={["collection-toolbar", { "collection-toolbar--sticky": sticky }]} aria-label={label}>
+	<div class="collection-toolbar__summary">
+		<span>{label}</span>
+		{typeof resultCount === "number" && <strong>{resultCount} {resultLabel}</strong>}
+	</div>
+	<div class="collection-toolbar__controls"><slot /></div>
+	{Astro.slots.has("actions") && <div class="collection-toolbar__actions"><slot name="actions" /></div>}
+</section>
+
+<style>
+	.collection-toolbar {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		gap: 1rem;
+		align-items: center;
+		padding: 0.8rem var(--space-page-pad-inline);
+		border-block: 1px solid var(--surface-border);
+		background: var(--surface-overlay);
+	}
+	.collection-toolbar--sticky { position: sticky; top: 64px; z-index: 20; }
+	.collection-toolbar__summary { display: flex; flex-direction: column; gap: 0.2rem; font-family: var(--font-jetbrains-mono), monospace; font-size: 0.64rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-muted); }
+	.collection-toolbar__summary strong { color: var(--text-primary-content); font-weight: 600; }
+	.collection-toolbar__controls { display: flex; flex-wrap: wrap; gap: 0.5rem; min-width: 0; }
+	.collection-toolbar__actions { display: flex; gap: 0.5rem; }
+	@media (max-width: 720px) {
+		.collection-toolbar { grid-template-columns: 1fr; align-items: stretch; }
+		.collection-toolbar__summary { flex-direction: row; justify-content: space-between; }
+		.collection-toolbar__actions > :global(*) { flex: 1; }
+	}
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/ContentCard.astro
+++ b/projects/rawkode.academy/website/src/components/ui/ContentCard.astro
@@ -1,0 +1,79 @@
+---
+interface MetaItem {
+	label: string;
+	value: string;
+}
+
+interface Props {
+	kind: string;
+	title: string;
+	href: string;
+	description?: string;
+	image?: string;
+	imageAlt?: string;
+	meta?: MetaItem[];
+	accent?: "spruce" | "amber" | "rust" | "violet";
+	featured?: boolean;
+}
+
+const {
+	kind,
+	title,
+	href,
+	description,
+	image,
+	imageAlt = "",
+	meta = [],
+	accent = "spruce",
+	featured = false,
+} = Astro.props as Props;
+---
+
+<article class:list={["content-card", `content-card--${accent}`, { "content-card--featured": featured }]}>
+	<a href={href} class="content-card__link">
+		{image ? (
+			<div class="content-card__media"><img src={image} alt={imageAlt} loading="lazy" /></div>
+		) : (
+			<div class="content-card__monogram" aria-hidden="true">{title.charAt(0)}</div>
+		)}
+		<div class="content-card__body">
+			<p class="content-card__kind">{kind}</p>
+			<h3>{title}</h3>
+			{description && <p class="content-card__description">{description}</p>}
+			{meta.length > 0 && (
+				<dl class="content-card__meta">
+					{meta.map((item) => <div><dt>{item.label}</dt><dd>{item.value}</dd></div>)}
+				</dl>
+			)}
+		</div>
+	</a>
+</article>
+
+<style>
+	.content-card { --card-accent: var(--editorial-spruce); border-top: 2px solid var(--card-accent); border-bottom: 1px solid var(--surface-border); }
+	.content-card--amber { --card-accent: var(--editorial-amber-text); }
+	.content-card--rust { --card-accent: var(--editorial-rust); }
+	.content-card--violet { --card-accent: var(--editorial-violet); }
+	.content-card__link { display: grid; grid-template-columns: minmax(9rem, 0.42fr) minmax(0, 1fr); color: inherit; text-decoration: none; }
+	.content-card__media,
+	.content-card__monogram { aspect-ratio: 16 / 10; overflow: hidden; background: var(--surface-card); border-right: 1px solid var(--surface-border); }
+	.content-card__media img { width: 100%; height: 100%; object-fit: cover; transition: transform var(--duration-slow) var(--ease-out); }
+	.content-card__monogram { display: grid; place-items: center; color: var(--card-accent); font-family: var(--font-instrument-serif), serif; font-size: clamp(4rem, 9vw, 8rem); }
+	.content-card__body { display: flex; flex-direction: column; gap: 0.65rem; padding: clamp(1rem, 3vw, 1.75rem); min-width: 0; }
+	.content-card__kind { margin: 0; color: var(--card-accent); font-family: var(--font-jetbrains-mono), monospace; font-size: 0.66rem; font-weight: 600; letter-spacing: 0.13em; text-transform: uppercase; }
+	.content-card h3 { margin: 0; font-size: clamp(1.25rem, 2vw, 1.8rem); font-weight: 650; line-height: 1.05; letter-spacing: -0.025em; }
+	.content-card__description { max-width: 60ch; margin: 0; color: var(--text-secondary-content); line-height: 1.5; }
+	.content-card__meta { display: flex; flex-wrap: wrap; gap: 0.75rem 1.25rem; margin: auto 0 0; padding-top: 0.75rem; }
+	.content-card__meta div { display: flex; gap: 0.35rem; font-family: var(--font-jetbrains-mono), monospace; font-size: 0.64rem; text-transform: uppercase; }
+	.content-card__meta dt { color: var(--text-muted); }
+	.content-card__meta dd { margin: 0; }
+	.content-card__link:hover h3 { color: var(--card-accent); }
+	.content-card__link:hover img { transform: scale(1.025); }
+	.content-card--featured .content-card__link { grid-template-columns: minmax(0, 1.1fr) minmax(20rem, 0.9fr); }
+	@media (max-width: 640px) {
+		.content-card__link,
+		.content-card--featured .content-card__link { grid-template-columns: 1fr; }
+		.content-card__media,
+		.content-card__monogram { border-right: 0; border-bottom: 1px solid var(--surface-border); }
+	}
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/DetailFrame.astro
+++ b/projects/rawkode.academy/website/src/components/ui/DetailFrame.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+	width?: "prose" | "content" | "wide";
+	hasRail?: boolean;
+}
+
+const { width = "content", hasRail = false } = Astro.props as Props;
+---
+
+<div class:list={["detail-frame", `detail-frame--${width}`, { "detail-frame--rail": hasRail }]}>
+	<div class="detail-frame__main"><slot /></div>
+	{hasRail && <aside class="detail-frame__rail"><slot name="rail" /></aside>}
+</div>
+
+<style>
+	.detail-frame {
+		display: grid;
+		max-width: var(--layout-content);
+		margin: 0 auto;
+		padding: var(--space-page-pad-block) var(--space-page-pad-inline);
+	}
+	.detail-frame--prose { max-width: var(--layout-prose); }
+	.detail-frame--wide { max-width: var(--layout-wide); }
+	.detail-frame--rail { grid-template-columns: minmax(0, 1fr) minmax(15rem, 20rem); gap: clamp(2rem, 5vw, 5rem); }
+	.detail-frame__main { min-width: 0; }
+	.detail-frame__rail { min-width: 0; }
+	@media (max-width: 880px) { .detail-frame--rail { grid-template-columns: 1fr; } }
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/EditorialShell.astro
+++ b/projects/rawkode.academy/website/src/components/ui/EditorialShell.astro
@@ -1,4 +1,6 @@
 ---
+import PageMasthead from "@/components/ui/PageMasthead.astro";
+
 interface Props {
 	eyebrow?: string;
 	title: string;
@@ -10,14 +12,14 @@ const { eyebrow, title, lede, compact = false } = Astro.props as Props;
 ---
 
 <div class:list={["editorial-shell", { "editorial-shell--compact": compact }]}>
-	<header class="editorial-shell__masthead">
-		{eyebrow && <p class="editorial-kicker">{eyebrow}</p>}
-		<div class="editorial-shell__masthead-grid">
-			<h1 class="editorial-shell__title">{title}</h1>
-			{lede && <p class="editorial-shell__lede">{lede}</p>}
-		</div>
-		<slot name="actions" />
-	</header>
+	<PageMasthead
+		section={eyebrow}
+		title={title}
+		dek={lede}
+		variant={compact ? "collection" : "detail"}
+	>
+		<Fragment slot="actions"><slot name="actions" /></Fragment>
+	</PageMasthead>
 	<slot />
 </div>
 

--- a/projects/rawkode.academy/website/src/components/ui/PageMasthead.astro
+++ b/projects/rawkode.academy/website/src/components/ui/PageMasthead.astro
@@ -1,0 +1,122 @@
+---
+interface Props {
+	section?: string | undefined;
+	title: string;
+	dek?: string | undefined;
+	meta?: string[] | undefined;
+	variant?: "collection" | "detail" | "feature";
+	align?: "split" | "stack";
+}
+
+const {
+	section,
+	title,
+	dek,
+	meta = [],
+	variant = "collection",
+	align = "split",
+} = Astro.props as Props;
+---
+
+<header class:list={["page-masthead", `page-masthead--${variant}`, `page-masthead--${align}`]}>
+	<div class="page-masthead__inner">
+		<div class="page-masthead__heading">
+			{section && <p class="page-masthead__section">{section}</p>}
+			<h1>{title}</h1>
+		</div>
+		{(dek || meta.length > 0 || Astro.slots.has("actions")) && (
+			<div class="page-masthead__support">
+				{dek && <p class="page-masthead__dek">{dek}</p>}
+				{meta.length > 0 && (
+					<ul class="page-masthead__meta" aria-label="Page information">
+						{meta.map((item) => <li>{item}</li>)}
+					</ul>
+				)}
+				{Astro.slots.has("actions") && <div class="page-masthead__actions"><slot name="actions" /></div>}
+			</div>
+		)}
+	</div>
+</header>
+
+<style>
+	.page-masthead {
+		border-bottom: 1px solid var(--surface-border);
+		background: var(--surface-base);
+		color: var(--text-primary-content);
+	}
+
+	.page-masthead__inner {
+		display: grid;
+		grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.65fr);
+		gap: clamp(2rem, 6vw, 7rem);
+		align-items: end;
+		max-width: var(--layout-wide);
+		margin: 0 auto;
+		padding: clamp(1.5rem, 4vw, 3.75rem) var(--space-page-pad-inline);
+	}
+
+	.page-masthead--collection .page-masthead__inner { padding-block: clamp(1.25rem, 2.5vw, 2.25rem); }
+	.page-masthead--feature .page-masthead__inner { padding-block: clamp(3rem, 8vw, 8rem); }
+	.page-masthead--stack .page-masthead__inner { grid-template-columns: 1fr; gap: 1.25rem; }
+
+	.page-masthead__heading { min-width: 0; }
+
+	.page-masthead__section {
+		margin: 0 0 0.85rem;
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.68rem;
+		font-weight: 600;
+		letter-spacing: 0.14em;
+		line-height: 1;
+		text-transform: uppercase;
+		color: var(--editorial-spruce);
+	}
+
+	.page-masthead h1 {
+		margin: 0;
+		font-family: var(--font-instrument-serif), Georgia, serif;
+		font-size: var(--type-page-title);
+		font-style: normal;
+		font-weight: 400;
+		line-height: 0.98;
+		letter-spacing: -0.035em;
+		text-wrap: balance;
+		overflow-wrap: anywhere;
+	}
+
+	.page-masthead--detail h1 { font-size: var(--type-feature); }
+	.page-masthead--feature h1 { font-size: var(--type-display); max-width: 15ch; }
+
+	.page-masthead__support { display: flex; flex-direction: column; gap: 1rem; }
+
+	.page-masthead__dek {
+		max-width: 42rem;
+		margin: 0;
+		color: var(--text-secondary-content);
+		font-size: clamp(1rem, 1.4vw, 1.25rem);
+		line-height: 1.5;
+	}
+
+	.page-masthead__meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.45rem 1rem;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+		font-size: 0.68rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.page-masthead__meta li + li::before { content: "·"; margin-right: 1rem; }
+	.page-masthead__actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+
+	@media (max-width: 760px) {
+		.page-masthead__inner { grid-template-columns: 1fr; gap: 1rem; }
+		.page-masthead--feature .page-masthead__inner { padding-block: 3rem; }
+		.page-masthead--feature h1 { font-size: clamp(3.2rem, 17vw, 5rem); }
+	}
+</style>

--- a/projects/rawkode.academy/website/src/components/ui/UtilityShell.astro
+++ b/projects/rawkode.academy/website/src/components/ui/UtilityShell.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+	kicker?: string;
+	title: string;
+	description?: string;
+	tone?: "neutral" | "success" | "danger";
+}
+
+const {
+	kicker = "Rawkode Academy",
+	title,
+	description,
+	tone = "neutral",
+} = Astro.props as Props;
+const mark = tone === "success" ? "✓" : tone === "danger" ? "!" : "→";
+---
+
+<main class:list={["utility-shell", `utility-shell--${tone}`]}>
+	<div class="utility-shell__mark" aria-hidden="true">{mark}</div>
+	<p class="utility-shell__kicker">{kicker}</p>
+	<h1>{title}</h1>
+	{description && <p class="utility-shell__description">{description}</p>}
+	{Astro.slots.has("default") && <div class="utility-shell__content"><slot /></div>}
+	{Astro.slots.has("actions") && <div class="utility-shell__actions"><slot name="actions" /></div>}
+</main>
+
+<style>
+	.utility-shell {
+		--utility-tone: var(--editorial-spruce);
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		min-height: calc(100vh - 64px);
+		max-width: var(--layout-prose);
+		margin: 0 auto;
+		padding: var(--space-page-pad-block) var(--space-page-pad-inline);
+	}
+	.utility-shell--success { --utility-tone: var(--editorial-spruce); }
+	.utility-shell--danger { --utility-tone: var(--editorial-rust); }
+	.utility-shell__mark { display: grid; place-items: center; width: 3rem; height: 3rem; margin-bottom: 2rem; border: 1px solid var(--utility-tone); color: var(--utility-tone); font-family: var(--font-jetbrains-mono), monospace; font-size: 1.25rem; }
+	.utility-shell__kicker { margin: 0 0 0.8rem; color: var(--utility-tone); font-family: var(--font-jetbrains-mono), monospace; font-size: 0.68rem; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; }
+	.utility-shell h1 { max-width: 14ch; margin: 0; font-size: var(--type-feature); }
+	.utility-shell__description { max-width: 52ch; margin: 1.25rem 0 0; color: var(--text-secondary-content); font-size: 1.15rem; line-height: 1.55; }
+	.utility-shell__content { width: 100%; margin-top: 2rem; padding-top: 2rem; border-top: 1px solid var(--surface-border); }
+	.utility-shell__actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
+	.utility-shell__actions :global(a),
+	.utility-shell__actions :global(button) { display: inline-flex; min-height: 2.75rem; align-items: center; justify-content: center; padding: 0.75rem 1rem; border: 1px solid var(--editorial-ink); border-radius: 2px; background: var(--editorial-ink); color: var(--editorial-paper); font-family: var(--font-jetbrains-mono), monospace; font-size: 0.7rem; font-weight: 600; letter-spacing: 0.12em; text-decoration: none; text-transform: uppercase; }
+</style>

--- a/projects/rawkode.academy/website/src/components/video/VideoMasthead.astro
+++ b/projects/rawkode.academy/website/src/components/video/VideoMasthead.astro
@@ -1,4 +1,6 @@
 ---
+import PageMasthead from "@/components/ui/PageMasthead.astro";
+
 interface Props {
 	leftLabel?: string | undefined;
 	title: string;
@@ -8,57 +10,8 @@ interface Props {
 	rightLabel?: string | undefined;
 }
 
-const { title, dek, titleTail } = Astro.props as Props;
+const { leftLabel, title, dek, titleTail } = Astro.props as Props;
 const description = dek ?? titleTail;
 ---
 
-<header class="video-masthead">
-	<h1 class="video-masthead__title">{title}</h1>
-	{description && <p class="video-masthead__dek">{description}</p>}
-</header>
-
-<style>
-	.video-masthead {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding: 1.125rem 2.5rem;
-		border-bottom: 1px solid var(--editorial-hairline);
-	}
-
-	.video-masthead__title {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: clamp(1.75rem, 3vw, 2.5rem);
-		font-weight: 700;
-		line-height: 1;
-		letter-spacing: 0;
-		color: var(--editorial-ink);
-		margin: 0;
-	}
-
-	.video-masthead__dek {
-		font-family: var(--font-inter-tight), sans-serif;
-		font-size: 0.95rem;
-		line-height: 1.4;
-		color: var(--editorial-ink-soft);
-		text-align: right;
-		margin: 0;
-	}
-
-	@media (max-width: 880px) {
-		.video-masthead {
-			align-items: flex-start;
-			flex-direction: column;
-			gap: 0.25rem;
-			padding: 0.875rem 1rem;
-		}
-		.video-masthead__title {
-			font-size: 1.875rem;
-		}
-		.video-masthead__dek {
-			font-size: 0.875rem;
-			text-align: left;
-		}
-	}
-</style>
+<PageMasthead section={leftLabel} title={title} dek={description} variant="collection" />

--- a/projects/rawkode.academy/website/src/layouts/app.astro
+++ b/projects/rawkode.academy/website/src/layouts/app.astro
@@ -1,7 +1,7 @@
 ---
 import UserHeader from "@/components/auth/user-header.astro";
 import Footer from "@/components/footer/Footer.astro";
-import Sidebar from "@/components/sidebar/Sidebar.astro";
+import PublicationNav from "@/components/navigation/PublicationNav.astro";
 import SkipLink from "@/components/common/SkipLink.astro";
 import { ThemeToggle } from "@/components/ui";
 ---
@@ -16,7 +16,7 @@ import { ThemeToggle } from "@/components/ui";
 				<button
 					class="ed-topbar__icon-btn focus-ring hidden md:block"
 					id="sidebar-toggle-btn"
-					aria-label="Toggle sidebar"
+					aria-label="Open navigation"
 				>
 					<svg
 						class="w-5 h-5"
@@ -36,7 +36,7 @@ import { ThemeToggle } from "@/components/ui";
 				<button
 					class="ed-topbar__icon-btn focus-ring md:hidden"
 					id="mobile-sidebar-btn"
-					aria-label="Toggle mobile menu"
+					aria-label="Open navigation"
 				>
 					<svg
 						class="w-6 h-6"
@@ -66,7 +66,14 @@ import { ThemeToggle } from "@/components/ui";
 				</a>
 			</div>
 
-			<!-- Center section - search trigger. A real link to /search so
+			<nav class="ed-topbar__primary" aria-label="Primary navigation">
+				<a href="/watch">Watch</a>
+				<a href="/read">Read</a>
+				<a href="/courses">Courses</a>
+				<a href="/technology/matrix">Matrix</a>
+			</nav>
+
+			<!-- Search trigger. A real link to /search so
 			     the path works without JavaScript; the palette script
 			     upgrades the click into the command palette. -->
 			<div class="ed-topbar__center">
@@ -114,44 +121,22 @@ import { ThemeToggle } from "@/components/ui";
 		</div>
 	</nav>
 
-	<Sidebar />
+	<PublicationNav />
 
 	<div class="flex flex-col min-h-screen">
 		<div class="flex flex-1">
-			<main id="main-content" class="w-full h-auto pt-16 md:ml-64 transition-card">
+			<main id="main-content" class="w-full h-auto pt-16">
 				<slot />
 			</main>
 		</div>
-		<div id="footer-container" class="md:ml-64 transition-card">
+		<div id="footer-container">
 			<Footer />
 		</div>
 	</div>
 
 	<style>
-		:global(:root) {
-			--ed-sidebar-collapsed-width: 3.5rem;
-			--ed-sidebar-expanded-width: 16rem;
-			--ed-sidebar-current-width: var(--ed-sidebar-expanded-width);
-		}
-
-		@media (min-width: 768px) {
-			#main-content,
-			#footer-container {
-				margin-left: var(--ed-sidebar-current-width);
-			}
-
-			#footer-container {
-				width: calc(100% - var(--ed-sidebar-current-width));
-			}
-		}
-
-		@media (max-width: 767px) {
-			#main-content,
-			#footer-container {
-				margin-left: 0;
-				width: 100%;
-			}
-		}
+		#main-content,
+		#footer-container { width: 100%; }
 
 		/* ────────────────────────────────────────────────────────────
 		   Editorial top bar — flat paper with single hairline border,
@@ -249,6 +234,33 @@ import { ThemeToggle } from "@/components/ui";
 			display: none;
 			flex: 1;
 			max-width: 34rem;
+		}
+
+		.ed-topbar__primary {
+			display: none;
+			align-items: stretch;
+			align-self: stretch;
+			border-left: 1px solid var(--editorial-hairline);
+		}
+
+		.ed-topbar__primary a {
+			display: inline-flex;
+			align-items: center;
+			padding: 0 0.9rem;
+			border-right: 1px solid var(--editorial-hairline);
+			color: var(--editorial-ink-soft);
+			font-size: 0.82rem;
+			font-weight: 600;
+			text-decoration: none;
+		}
+
+		.ed-topbar__primary a:hover {
+			background: var(--surface-card-muted);
+			color: var(--editorial-ink);
+		}
+
+		@media (min-width: 1080px) {
+			.ed-topbar__primary { display: flex; }
 		}
 
 		@media (min-width: 768px) {
@@ -351,6 +363,10 @@ import { ThemeToggle } from "@/components/ui";
 				min-height: 36px;
 				padding-inline: 0.75rem;
 				font-size: 0.6875rem;
+			}
+
+			.ed-topbar__theme-toggle {
+				display: none;
 			}
 		}
 

--- a/projects/rawkode.academy/website/src/layouts/minimal.astro
+++ b/projects/rawkode.academy/website/src/layouts/minimal.astro
@@ -21,11 +21,15 @@ const { title, description, noindex } = Astro.props;
     {noindex && <meta name="robots" content="noindex,follow" />}
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0b0f" />
+    <meta
+      name="theme-color"
+      content="#f8f5ef"
+      data-light-color="#f8f5ef"
+      data-dark-color="#1b1b23"
+    />
     <ThemeScript />
   </head>
-  <body class="h-full w-full bg-white dark:bg-black text-primary-content">
+  <body class="h-full w-full text-primary-content">
     <slot />
   </body>
 </html>

--- a/projects/rawkode.academy/website/src/lib/theme.ts
+++ b/projects/rawkode.academy/website/src/lib/theme.ts
@@ -80,6 +80,16 @@ export function getColorScheme(): ColorScheme {
 function applyColorScheme(scheme: ColorScheme): void {
 	if (typeof window === "undefined") return;
 	document.documentElement.classList.toggle("dark", scheme === "dark");
+	document.documentElement.setAttribute("data-color-scheme", scheme);
+	const themeColor = document.querySelector?.(
+		'meta[name="theme-color"][data-light-color]',
+	) as HTMLMetaElement | null;
+	if (themeColor) {
+		themeColor.content =
+			scheme === "dark"
+				? (themeColor.dataset.darkColor ?? "#1b1b23")
+				: (themeColor.dataset.lightColor ?? "#f8f5ef");
+	}
 }
 
 /**

--- a/projects/rawkode.academy/website/src/pages/confirm-subscription.astro
+++ b/projects/rawkode.academy/website/src/pages/confirm-subscription.astro
@@ -1,6 +1,7 @@
 ---
 import { env } from "cloudflare:workers";
 import Page from "@/wrappers/page.astro";
+import UtilityShell from "@/components/ui/UtilityShell.astro";
 import { createLearnerId } from "@/actions/newsletter";
 
 const user = Astro.locals.user;
@@ -25,26 +26,13 @@ await env.EMAIL_PREFERENCES.setPreference(prefixedUserId, {
 	description="You are now subscribed to the Rawkode Academy newsletter."
 	noindex
 >
-	<div class="min-h-[60vh] flex flex-col items-center justify-center px-4 text-center">
-		<div class="w-24 h-24 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-8">
-			<svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-			</svg>
-		</div>
-		
-		<h1 class="text-4xl font-bold text-primary-content mb-4">
-			Subscription Confirmed!
-		</h1>
-		
-		<p class="text-xl text-muted max-w-2xl mb-8">
-			Thanks for joining the Rawkode Academy newsletter. You'll now receive updates about our latest courses, videos, and articles.
-		</p>
-		
-		<a 
-			href="/"
-			class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-primary hover:bg-primary/90 transition-colors"
-		>
-			Back to Home
-		</a>
-	</div>
+	<UtilityShell
+		kicker="Newsletter"
+		title="Subscription confirmed"
+		description="Thanks for joining Rawkode Academy. You will now receive new courses, videos, articles, and carefully selected events."
+		tone="success"
+	>
+		<a slot="actions" href="/">Back to homepage</a>
+		<a slot="actions" href="/watch">Watch the latest</a>
+	</UtilityShell>
 </Page>

--- a/projects/rawkode.academy/website/src/pages/courses/[course]/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/courses/[course]/[...slug].astro
@@ -235,14 +235,14 @@ function formatDuration(minutes?: number) {
 						<div class="flex flex-wrap gap-3">
 							<a
 								href={`/courses/${course.id}`}
-								class="inline-flex min-h-11 items-center justify-center rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-primary transition-colors hover:border-primary/25 hover:text-primary-content dark:border-white/10 dark:text-white"
+								class="inline-flex min-h-11 items-center justify-center rounded-[2px] border border-black/10 px-4 py-2 text-sm font-semibold text-primary transition-colors hover:border-primary/25 hover:text-primary-content dark:border-white/10 dark:text-white"
 							>
 								View course
 							</a>
 							{nextModule && (
 								<a
 									href={moduleHref(nextModule)}
-									class="inline-flex min-h-11 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90"
+									class="inline-flex min-h-11 items-center justify-center rounded-[2px] bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90"
 								>
 									Next lesson
 								</a>

--- a/projects/rawkode.academy/website/src/pages/index.astro
+++ b/projects/rawkode.academy/website/src/pages/index.astro
@@ -14,8 +14,6 @@ import SectionHeader from "@/components/landing/SectionHeader.astro";
 import EditorialCardRail from "@/components/landing/EditorialCardRail.astro";
 import FeaturedFeature from "@/components/landing/FeaturedFeature.astro";
 import SecondaryGrid from "@/components/landing/SecondaryGrid.astro";
-import ValuesGrid from "@/components/landing/ValuesGrid.astro";
-import TestimonialSlider from "@/components/testimonial/slider.astro";
 import { DIMENSIONS } from "@/lib/explorer/dimensions";
 
 // ─── Edge caching ───────────────────────────────────────────────
@@ -336,39 +334,6 @@ const secondaryArticleItems = secondaryArticles.map((article) => {
 	return item;
 });
 
-const academyValues = [
-	{
-		title: "Authenticity",
-		description:
-			"We show the trade-offs, the rough edges, and the decisions we'd still make again.",
-	},
-	{
-		title: "Real Projects",
-		description:
-			"Much of the curriculum comes from problems we're solving in public, not invented demos.",
-	},
-	{
-		title: "Honest Mistakes",
-		description:
-			"Mistakes stay in the session because the recovery is usually more useful than the perfect path.",
-	},
-	{
-		title: "Hands-On",
-		description:
-			"Less talking about code, more terminal time, real code, and live builds you can follow end to end.",
-	},
-	{
-		title: "Early Evaluation",
-		description:
-			"We test new tools early, evaluate them honestly, and show where they fit.",
-	},
-	{
-		title: "Open & Closed Source",
-		description:
-			"We cover open source and vendors with the same standard: what works, what costs, and what saves time.",
-	},
-];
-
 // Stat row — all wired to real content collections.
 const totalSeconds = publishedVideos.reduce(
 	(acc, v) =>
@@ -561,23 +526,6 @@ const pageDescription =
 			</section>
 		)}
 
-		<section class="landing-section">
-			<SectionHeader
-				kicker="Teaching Approach"
-				title="How we teach"
-				body="Practical lessons based on real systems, trade-offs, and mistakes."
-			/>
-			<ValuesGrid values={academyValues} />
-		</section>
-
-		<section class="landing-section">
-			<SectionHeader
-				kicker="Testimonials"
-				title="What engineers say"
-				body="Feedback from people learning with Rawkode Academy."
-			/>
-			<TestimonialSlider type="viewer" blurb="" />
-		</section>
 	</div>
 </Page>
 

--- a/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
+++ b/projects/rawkode.academy/website/src/pages/watch/[...slug].astro
@@ -860,7 +860,7 @@ const watchStatusLabel = isUpcomingLive
 		padding: clamp(1rem, 2vw, 1.5rem) var(--space-section-pad-x)
 			clamp(1.25rem, 2.5vw, 2rem);
 		display: grid;
-		grid-template-columns: minmax(0, 1fr) minmax(18rem, 30rem);
+		grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
 		grid-template-areas: "summary player";
 		gap: clamp(1rem, 2vw, 1.5rem);
 		align-items: start;
@@ -876,7 +876,7 @@ const watchStatusLabel = isUpcomingLive
 
 	.watch-detail__title {
 		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
+		font-style: normal;
 		font-weight: 400;
 		font-size: clamp(2.25rem, 3.3vw, 3.5rem);
 		line-height: 0.96;
@@ -1018,7 +1018,7 @@ const watchStatusLabel = isUpcomingLive
 		isolation: isolate;
 		position: relative;
 		width: 100%;
-		max-width: 30rem;
+		max-width: 100%;
 		transition:
 			max-width 420ms var(--ease-standard),
 			filter var(--duration-base) var(--ease-standard);
@@ -1544,8 +1544,8 @@ const watchStatusLabel = isUpcomingLive
 		.watch-detail__hero {
 			grid-template-columns: 1fr;
 			grid-template-areas:
-				"summary"
-				"player";
+				"player"
+				"summary";
 		}
 
 		/* Single-column layout: the player is already as wide as it can get,

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -70,6 +70,18 @@
 	--space-card-pad: clamp(1.25rem, 3vw, 2.25rem);
 	--space-card-pad-lg: clamp(1.75rem, 4vw, 2.75rem);
 
+	/* Technical-publication layout contracts. Page compositions choose a
+	   measure instead of introducing another route-specific max-width. */
+	--layout-prose: 46rem;
+	--layout-content: 76rem;
+	--layout-wide: 96rem;
+	--space-page-pad-inline: clamp(1rem, 4vw, 3.5rem);
+	--space-page-pad-block: clamp(2rem, 5vw, 4.5rem);
+	--type-display: clamp(3.25rem, 8vw, 7.5rem);
+	--type-feature: clamp(2.5rem, 5vw, 5rem);
+	--type-page-title: clamp(2rem, 3.5vw, 3.5rem);
+	--type-section: clamp(1.5rem, 2.2vw, 2.25rem);
+
 	/* Semantic text-tone tokens — mirrored into UnoCSS theme so
 	   `text-primary-content` works as both a class and a CSS variable. */
 	--text-primary-content: var(--editorial-ink);
@@ -283,28 +295,25 @@ html.dark {
 }
 
 @layer base {
-	/* Editorial heading ramp — h1/h2 in serif italic at display sizes,
-	   h3/h4 in Inter Tight semibold. Negative letter-spacing pulls the
-	   display sizes tight without going into "decorative" territory.
-	   `text-wrap: balance` evens out multi-line display headings so the
-	   serif italic never strands a one-word orphan line. */
+	/* Technical-publication heading ramp. The serif is a scarce display
+	   signal; section and interface hierarchy stays compact and sans. */
 	h1 {
 		@apply text-4xl md:text-5xl text-primary-content;
 		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
+		font-style: normal;
 		font-weight: 400;
-		line-height: 1.02;
+		line-height: 0.98;
 		letter-spacing: -0.035em;
 		text-wrap: balance;
 	}
 
 	h2 {
 		@apply text-3xl md:text-4xl text-primary-content;
-		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
-		font-weight: 400;
-		line-height: 1.05;
-		letter-spacing: -0.025em;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-style: normal;
+		font-weight: 650;
+		line-height: 1.02;
+		letter-spacing: -0.03em;
 		text-wrap: balance;
 	}
 
@@ -605,8 +614,8 @@ html.dark {
 	}
 
 	/* ════════════════════════════════════════════════════════════════
-	   Editorial .prose ramp — Inter Tight body over Instrument Serif
-	   italic display headings, sentence-sized JetBrains Mono code. Hairline
+	   Publication .prose ramp — Inter Tight body and hierarchy with
+	   sentence-sized JetBrains Mono code. Hairline
 	   blockquote (single 2px ink border-left, no gradient fill).
 	   ════════════════════════════════════════════════════════════════ */
 	.prose {
@@ -622,12 +631,12 @@ html.dark {
 		-moz-osx-font-smoothing: grayscale;
 	}
 
-	/* Display headings — serif italic h1/h2, sans medium h3/h4 */
+	/* Reading headings stay sans so long technical documents scan quickly. */
 	.prose h1 {
-		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-style: normal;
 		font-size: clamp(2.25rem, 5vw, 3.5rem);
-		font-weight: 400;
+		font-weight: 650;
 		letter-spacing: -0.035em;
 		line-height: 1.02;
 		color: var(--text-primary-content);
@@ -636,10 +645,10 @@ html.dark {
 	}
 
 	.prose h2 {
-		font-family: var(--font-instrument-serif), serif;
-		font-style: italic;
+		font-family: var(--font-inter-tight), sans-serif;
+		font-style: normal;
 		font-size: clamp(1.75rem, 3.5vw, 2.5rem);
-		font-weight: 400;
+		font-weight: 650;
 		letter-spacing: -0.025em;
 		line-height: 1.08;
 		color: var(--text-primary-content);

--- a/projects/rawkode.academy/website/src/styles/global.css
+++ b/projects/rawkode.academy/website/src/styles/global.css
@@ -37,7 +37,7 @@
 	--editorial-violet: oklch(0.50 0.13 290);
 
 	/* Light-mode surface tokens */
-	color-scheme: light dark;
+	color-scheme: light;
 	--surface-base: var(--editorial-paper);
 	--surface-overlay: oklch(0.97 0.008 85 / 0.94);
 	--surface-card: var(--editorial-paper-deep);
@@ -99,6 +99,8 @@
 }
 
 html.dark {
+	color-scheme: dark;
+
 	/* Dark-mode editorial palette — ink-dark ground with paper-dark surfaces.
 	   The triplet legacy tokens stay; only the value brightens slightly for
 	   contrast on dark. */

--- a/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
+++ b/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
@@ -35,6 +35,24 @@ function* walk(dir: string): Generator<string> {
 }
 
 describe("design tokens", () => {
+	it("defines the technical-publication layout contracts", () => {
+		const globalCss = readFileSync(join(projectRoot, "src/styles/global.css"), "utf-8");
+		const appLayout = readFileSync(join(projectRoot, "src/layouts/app.astro"), "utf-8");
+
+		for (const token of [
+			"--layout-prose",
+			"--layout-content",
+			"--layout-wide",
+			"--space-page-pad-inline",
+			"--type-page-title",
+		]) {
+			expect(globalCss, `Missing publication token ${token}`).toContain(token);
+		}
+
+		expect(appLayout).toContain("PublicationNav");
+		expect(appLayout).not.toContain('components/sidebar/Sidebar.astro');
+	});
+
 	it("uses editorial tokens instead of raw gray-* utilities", () => {
 		const violations: string[] = [];
 

--- a/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
+++ b/projects/rawkode.academy/website/src/tests/design-tokens.test.ts
@@ -53,6 +53,21 @@ describe("design tokens", () => {
 		expect(appLayout).not.toContain('components/sidebar/Sidebar.astro');
 	});
 
+	it("keeps the applied color scheme authoritative", () => {
+		const globalCss = readFileSync(join(projectRoot, "src/styles/global.css"), "utf-8");
+		const pageWrapper = readFileSync(join(projectRoot, "src/wrappers/page.astro"), "utf-8");
+		const publicationNav = readFileSync(
+			join(projectRoot, "src/components/navigation/PublicationNav.astro"),
+			"utf-8",
+		);
+
+		expect(globalCss).toMatch(/:root\s*\{[\s\S]*?color-scheme:\s*light;/);
+		expect(globalCss).toMatch(/html\.dark\s*\{[\s\S]*?color-scheme:\s*dark;/);
+		expect(pageWrapper).not.toContain("color-scheme: light dark");
+		expect(publicationNav).toContain("background: var(--terminal-bg)");
+		expect(publicationNav).toContain("color: var(--terminal-text)");
+	});
+
 	it("uses editorial tokens instead of raw gray-* utilities", () => {
 		const violations: string[] = [];
 

--- a/projects/rawkode.academy/website/src/wrappers/page.astro
+++ b/projects/rawkode.academy/website/src/wrappers/page.astro
@@ -37,10 +37,6 @@ const headProps = { ...(frontmatter ?? {}), ...directProps };
 	<style is:global>
 		@reference "../styles/global.css";
 
-		:root {
-			color-scheme: light dark;
-		}
-
 		h1,
 		h2,
 		h3 {


### PR DESCRIPTION
## Summary

- replace the persistent desktop sidebar with a compact publication header and accessible full navigation drawer
- introduce shared masthead, content card, collection toolbar, detail frame, and utility shell primitives
- apply the refreshed visual hierarchy across home, collections, institutional pages, video details, course lessons, and subscription confirmation
- improve responsive behavior, dark mode, navigation focus management, and small-screen overflow handling
- document the updated design system and add regression coverage for the new publication layout tokens

## Why

Rawkode Academy had accumulated several page-specific patterns around a sidebar-first shell. This refresh gives the platform a clearer technical-publication identity, makes discovery more consistent across every major page type, and creates reusable primitives for developers adding new content surfaces.

## Impact

- faster, more predictable navigation for learners
- stronger page hierarchy and content scanning
- reusable presentation components instead of page-specific styling
- player-first mobile video details and cleaner desktop reading widths
- no route, content schema, backend, or signed-in functionality changes

## Validation

- `bunx astro check` — 0 errors; 7 existing hints
- `bunx astro build` — passed
- `bunx vitest run src/tests/design-tokens.test.ts src/tests/performance.test.ts src/tests/theme.test.ts` — 20 tests passed
- responsive visual verification at 1440px and 390px in light and dark modes across home, watch, read, courses, learning paths, technology matrix, news, about, partnerships, and video detail pages
- `bun run test` — 235/236 tests passed; the remaining existing SEO taxonomy failure is `content/news/2026-06-13-vllm-sglang-kubernetes-kueue-helm/index.mdx` referencing unknown technology `ai-infrastructure`